### PR TITLE
Add fractions example to README (See #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@
 - Natural Constants
 	- `e`, `i`, `pi`, `speedOfLight`, `gravitationConstant`, `vacuumImpedance`, `avogadro`
 	- And many more (see [mathjs: Constants](https://mathjs.org/docs/reference/constants.html) and [mathjs: Units](https://mathjs.org/docs/datatypes/units.html) for more)
-	
+- Fractions:	
+	- `fraction(1/3) + fraction(1/4)` → `7/12`
+
 *Numerals* utilizes the [mathjs](https://mathjs.org/) library for all calculations. *Numerals* implements a preprocessor to allow more human-friendly syntax, such as currency symbols and thousands separators. For all available functions and capabilities (which includes matrices, vectors, symbolic algebra and calculus, etc), see the [mathjs documentation](https://mathjs.org/docs/index.html)
 
 


### PR DESCRIPTION
I read #2 (adding fraction support) and thought that mentioning existing support in the README might advertise it to users, and reduce the chance of it being requested again...

Awesome plugin, by the way. I'm really looking forward to trying it out.