### PR TITLE
Fix default code block styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6,7 +6,7 @@ settings:
     - 
         id: numerals-comment
         title: In-line Comment Color
-        description: Color of the text in in-line comments. Default is `--text-faint`.
+        description: Color of the text in in-line comments. Default is `--code-comment`.
         type: variable-themed-color
         format: hex
         opacity: false
@@ -15,7 +15,7 @@ settings:
     - 
         id: numerals-heading
         title: Heading / Comment Line Color
-        description: Color of lines with only a comment. Default is `--text-faint`.
+        description: Color of lines with only a comment. Default is `--code-comment`.
         type: variable-themed-color
         format: hex
         opacity: false
@@ -63,8 +63,8 @@ settings:
 /******** Non-setting specific   **/
 
 body {
-    --numerals-comment: var(--text-faint);
-    --numerals-heading: var(--text-faint);
+    --numerals-comment: var(--code-comment);
+    --numerals-heading: var(--code-comment);
     --numerals-background: var(--code-background);
     --numerals-font: var(--font-monospace);
     --numerals-size: var(--code-size);
@@ -123,6 +123,7 @@ body {
 }
 
 .numerals-block  {
+    color: var(--code-normal);
     background-color: var(--numerals-background);
     font-family: var(--numerals-font);    
     font-size: var(--numerals-size);    
@@ -184,7 +185,7 @@ body {
 
 .numerals-answer-right .numerals-result {
     float: right;
-    color: var(--text-muted);
+    color: var(--code-normal);
 }
 
 /**********************************/
@@ -204,7 +205,7 @@ body {
 }
 
 .numerals-panes .numerals-result {
-    color: var(--text-muted);
+    color: var(--code-normal);
     background-color: var(--background-modifier-hover);
     width: 25%;
     text-align: left;
@@ -230,7 +231,7 @@ body {
 }
 
 .numerals-answer-below .numerals-line .numerals-result {
-    color: var(--text-muted);
+    color: var(--code-normal);
     padding-left: var(--size-4-4);
     padding-bottom: var(--size-2-1);
 }
@@ -250,7 +251,7 @@ body {
 
 /* Don't show text in .numerals-result that and aren't descendents of .numerals-emitter */
 .numerals-emitters-present:not(.numerals-hide-non-emitters) .numerals-result:not(.numerals-emitter .numerals-result) {
-    color: var(--text-faint);
+    color: var(--code-comment);
 }
 
 .numerals-emitter .numerals-input {
@@ -280,7 +281,7 @@ body {
 
 .numerals-answer-inline .numerals-result {
     /* float: right; */
-    color: var(--text-muted);
+    color: var(--code-normal);
     display:inline-block;
 }
 


### PR DESCRIPTION
Code blocks were defaulting to `--text-normal` foreground text color, which broke in a light-mode theme that had dark code blocks configured. The result was zero-contrast dark text on a dark background.

One such theme is Polka, which has code block theming configurable via Style Settings, and defaults to a dark code block styling in light mode. This change ensures that Numeral's styling uses --code prefix color vars everywhere for math block styling, so it fully conforms to the active code block style.

## Repro steps
1. Create a test vault
2. Install the Numerals plugin and the Polka theme
3. Create a note with the sample text below.

Observe that the Numerals block is an unreadable dark-on-dark, ala:

<img width="1136" alt="Screenshot 2023-03-11 at 9 34 24 AM" src="https://user-images.githubusercontent.com/44155/224573558-2ee8d086-d877-485a-a138-7fa5aaff0d0b.png">

Via the inspector, the dark text styling above is picking up the default `--text-normal` color from `body`. Instead, it should use `--code-normal`.  This PR makes that change an catches two other instances where `--text` vs equivalent `--code` vars were used.

Result after this change:
<img width="1142" alt="Screenshot 2023-03-12 at 2 14 23 PM" src="https://user-images.githubusercontent.com/44155/224574157-cd951bb7-ae45-42b7-8a54-aee1bad6313a.png">


Sample document used for repro:
````
# Inline code blocks

This is a color test of `inline code blocks`, code in the middle of a span of text.

# Standalone code blocks

This is a test of standalone code blocks:
```
wow {
  much code;
}
so => monospace
```

# Obsidian Numerals test

```math
lets = 40
add = 20
things = 100
up = 2
lets + add + things + up =>
```
````
