### PR TITLE
New Feature: shared scope/globals and result insertion

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,13 @@
 import { NumeralsSuggestor } from "./NumeralsSuggestor";
-import { StringReplaceMap, defaultCurrencyMap, CurrencyType, renderNumeralsBlockFromSource, getLocaleFormatter, getMetadataForFileAtPath} from "./numeralsUtilities";
+import {
+	StringReplaceMap,
+	defaultCurrencyMap,
+	CurrencyType,
+	processAndRenderNumeralsBlockFromSource,
+	getLocaleFormatter,
+	getMetadataForFileAtPath,
+	NumeralsScope,
+	maybeAddScopeToPageCache } from "./numeralsUtilities";
 import equal from 'fast-deep-equal';
 import {
 	Plugin,
@@ -81,6 +89,7 @@ export default class NumeralsPlugin extends Plugin {
 	private preProcessors: StringReplaceMap[];
 	private currencyPreProcessors: StringReplaceMap[];
 	private numberFormat: mathjsFormat;
+	private scopeCache: Map<string, NumeralsScope> = new Map<string, NumeralsScope>();
 
 	async numeralsMathBlockHandler(type: NumeralsRenderStyle, source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext): Promise<void> {		
 		// TODO: Rendering is getting called twice. Once without newline at the end of the code block and once with.
@@ -88,7 +97,7 @@ export default class NumeralsPlugin extends Plugin {
 
 		let metadata = getMetadataForFileAtPath(ctx.sourcePath);
 		
-		renderNumeralsBlockFromSource(
+		const scope = processAndRenderNumeralsBlockFromSource(
 			el, 
 			source,
 			metadata,
@@ -96,7 +105,9 @@ export default class NumeralsPlugin extends Plugin {
 			this.settings,
 			this.numberFormat,
 			this.preProcessors,
-		)
+		);
+
+		maybeAddScopeToPageCache(ctx.sourcePath, scope, this.scopeCache);
 
 		const numeralsBlockChild = new MarkdownRenderChild(el);
 
@@ -109,7 +120,8 @@ export default class NumeralsPlugin extends Plugin {
 			}
 
 			el.empty();
-			renderNumeralsBlockFromSource(
+
+			const scope = processAndRenderNumeralsBlockFromSource(
 				el,
 				source,
 				metadata,
@@ -118,6 +130,8 @@ export default class NumeralsPlugin extends Plugin {
 				this.numberFormat,
 				this.preProcessors,
 			);
+
+			maybeAddScopeToPageCache(ctx.sourcePath, scope, this.scopeCache);
 		}
 
 		const dataviewAPI = getAPI();

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,6 +100,7 @@ export default class NumeralsPlugin extends Plugin {
 		const scope = processAndRenderNumeralsBlockFromSource(
 			el, 
 			source,
+			ctx,
 			metadata,
 			type,
 			this.settings,
@@ -124,6 +125,7 @@ export default class NumeralsPlugin extends Plugin {
 			const scope = processAndRenderNumeralsBlockFromSource(
 				el,
 				source,
+				ctx,
 				metadata,
 				type,
 				this.settings,

--- a/src/numeralsUtilities.ts
+++ b/src/numeralsUtilities.ts
@@ -376,12 +376,12 @@ export function processAndRenderNumeralsBlockFromSource(
 			emitter_lines.push(i);
 		}
 
-		const insertionMatch = rawRows[i].match(/@\s*\[([^\]:]+)(::)?([^\]])?\].*$/);
+		const insertionMatch = rawRows[i].match(/@\s*\[([^\]:]+)(::)?([^\]]*)\].*$/);
 		if (insertionMatch) {
 			insertion_lines.push(i)
 			insertion_variables.push(insertionMatch[1]);
 		}
-	}
+	} 
 
 	// if there are any emitter lines then add the class `numerals-emitters-present` to the block
 	if (emitter_lines.length > 0) {
@@ -393,7 +393,7 @@ export function processAndRenderNumeralsBlockFromSource(
 	processedSource = processedSource.replace(/^([^#\r\n]*)(=>[\t ]*)(\$\{.*\})?(.*)$/gm,"$1") 
 
 	// Check for result insertion directive `@[variable::result]`,and replace with only variable
-	processedSource = processedSource.replace(/@\s*\[([^\]:]+)(::)?([^\]])?\].*$/gm, "$1")
+	processedSource = processedSource.replace(/@\s*\[([^\]:]+)(::([^\]].*))?\].*$/gm, "$1")
 		
 	for (const processor of preProcessors ) {
 		processedSource = processedSource.replace(processor.regex, processor.replaceStr)
@@ -461,7 +461,7 @@ export function processAndRenderNumeralsBlockFromSource(
 				const curLine = lineStart + i + 1;
 				const sourceLine = editor?.getLine(curLine);
 				const insertionValue = math.format(results[i], numberFormat);
-				const modifiedSource = sourceLine?.replace(/(@\s*\[)([^\]:]+)(::)?([^\]])?(\].*)$/gm, `$1$2::${insertionValue}$5`)
+				const modifiedSource = sourceLine?.replace(/(@\s*\[)([^\]:]+)(::([^\]]*))?(\].*)$/gm, `$1$2::${insertionValue}$5`)
 				if (modifiedSource && modifiedSource !== sourceLine) {
 					setTimeout(() => {
 						editor?.setLine(curLine, modifiedSource)
@@ -479,7 +479,7 @@ export function processAndRenderNumeralsBlockFromSource(
 			rawRows[i] = rawRows[i].replace(/^([^#\r\n]*)(=>[\t ]*)(\$\{.*\})?(.*)$/gm,"$1$4") 
 		}
 
-		rawRows[i] = rawRows[i].replace(/@\s*\[([^\]:]+)(::)?([^\]])?\].*$/gm, "$1")
+		rawRows[i] = rawRows[i].replace(/@\s*\[([^\]:]+)(::([^\]].*))?\].*$/gm, "$1")
 
 		let inputElement: HTMLElement, resultElement: HTMLElement;
 		switch(blockRenderStyle) {

--- a/src/numeralsUtilities.ts
+++ b/src/numeralsUtilities.ts
@@ -376,7 +376,7 @@ export function processAndRenderNumeralsBlockFromSource(
 			emitter_lines.push(i);
 		}
 
-		const insertionMatch = rawRows[i].match(/@\s*\[([^\]]+)\].*$/);
+		const insertionMatch = rawRows[i].match(/@\s*\[([^\]:]+)(::)?([^\]])?\].*$/);
 		if (insertionMatch) {
 			insertion_lines.push(i)
 			insertion_variables.push(insertionMatch[1]);
@@ -393,7 +393,7 @@ export function processAndRenderNumeralsBlockFromSource(
 	processedSource = processedSource.replace(/^([^#\r\n]*)(=>[\t ]*)(\$\{.*\})?(.*)$/gm,"$1") 
 
 	// Check for result insertion directive `@[variable::result]`,and replace with only variable
-	processedSource = processedSource.replace(/@\s*\[([^\]]+)\].*$/gm, "$1")
+	processedSource = processedSource.replace(/@\s*\[([^\]:]+)(::)?([^\]])?\].*$/gm, "$1")
 		
 	for (const processor of preProcessors ) {
 		processedSource = processedSource.replace(processor.regex, processor.replaceStr)
@@ -461,9 +461,11 @@ export function processAndRenderNumeralsBlockFromSource(
 				const curLine = lineStart + i + 1;
 				const sourceLine = editor?.getLine(curLine);
 				const insertionValue = math.format(results[i], numberFormat);
-				const modifiedSource = sourceLine?.replace(/(@\s*\[)([^\]]+)(\].*)$/gm, `$1$2::${insertionValue}$3`)
-				if (modifiedSource) {
-					editor?.setLine(curLine, modifiedSource)
+				const modifiedSource = sourceLine?.replace(/(@\s*\[)([^\]:]+)(::)?([^\]])?(\].*)$/gm, `$1$2::${insertionValue}$5`)
+				if (modifiedSource && modifiedSource !== sourceLine) {
+					setTimeout(() => {
+						editor?.setLine(curLine, modifiedSource)
+					}, 0);
 				}
 
 				console.log(`Source Line: \`${sourceLine}\``);
@@ -476,6 +478,8 @@ export function processAndRenderNumeralsBlockFromSource(
 		if (settings.hideEmitterMarkupInInput) {
 			rawRows[i] = rawRows[i].replace(/^([^#\r\n]*)(=>[\t ]*)(\$\{.*\})?(.*)$/gm,"$1$4") 
 		}
+
+		rawRows[i] = rawRows[i].replace(/@\s*\[([^\]:]+)(::)?([^\]])?\].*$/gm, "$1")
 
 		let inputElement: HTMLElement, resultElement: HTMLElement;
 		switch(blockRenderStyle) {

--- a/src/numeralsUtilities.ts
+++ b/src/numeralsUtilities.ts
@@ -3,7 +3,7 @@ import * as math from 'mathjs';
 import { NumeralsLayout, NumeralsRenderStyle, NumeralsSettings } from './settings';
 import { mathjsFormat } from './main';
 import { getAPI } from 'obsidian-dataview';
-import { TFile, finishRenderMath, renderMath, sanitizeHTMLToDom, MarkdownPostProcessorContext, MarkdownSectionInformation, MarkdownView } from 'obsidian';
+import { TFile, finishRenderMath, renderMath, sanitizeHTMLToDom, MarkdownPostProcessorContext, MarkdownView } from 'obsidian';
 
 
 // TODO: Addition of variables not adding up
@@ -77,7 +77,11 @@ export function processFrontmatter(
 		if (keysOnly === false) {
 			for (const [key, rawValue] of Object.entries(frontmatter_process)) {
 				let value = rawValue;
-				// if processedValue is array-like, take the last element
+				
+				// If value is a mathjs unit, convert to string representation
+				value = math.isUnit(value) ? value.valueOf() : value;
+
+				// if processedValue is array-like, take the last element. For inline dataview fields, this generally means the most recent line will be used
 				if (Array.isArray(value)) {
 					value = value[value.length - 1];
 				}
@@ -100,6 +104,7 @@ export function processFrontmatter(
 					}
 				} else if (typeof value === "object") { // TODO this is only a problem with Dataview. Can we only use dataview for inline?
 					// ignore objects
+
 					// TODO. RIght now this means data objects just get dropped. If we could instead use the data from obsidian we could handle it
 					console.error(`Frontmatter value for key ${key} is an object and will be ignored. ` +
 						`Considering surrounding the value with quotes (eg \`${key}: "value"\`) to treat it as a string.`);
@@ -137,8 +142,6 @@ export function maybeAddScopeToPageCache(sourcePath: string, scope: NumeralsScop
 			}
 		}
 	}
-
-
 }
 
 /**
@@ -467,10 +470,6 @@ export function processAndRenderNumeralsBlockFromSource(
 						editor?.setLine(curLine, modifiedSource)
 					}, 0);
 				}
-
-				console.log(`Source Line: \`${sourceLine}\``);
-				console.log(`Replace Value: \`${modifiedSource}\``);
-				console.log(`[${insertion_variables[insertion_lines.indexOf(i)]}::${insertionValue}]`);
 			}
 		}
  


### PR DESCRIPTION
### Initial implementation of shared scope (i.e. page globals) and result insertion

**Shared Scope & Globals**
- Any variable name that starts with `$` will be accessible in other math blocks
- Important Note: Do net set the same global variable in two different math blocks.  The order of math block execution is not guaranteed, so if you set the value in two different places the value that gets used in other block is indeterminate

![image](https://github.com/gtg922r/obsidian-numerals/assets/1195174/45006f0c-c2d6-4816-8a72-fffd8c834dc7)

**Result Insertion (and dataview inline values)**
- Surrounding a variable name with `@[` variable `]` will automatically insert the calculated value of that variable. It will do so in such a way that dataview will assign it as an inline value
```
``'math
apples = $2 
pears = $8
total = apples + pears
@[total::10 USD]
``'
```

