### PR TITLE
Add a @hideRows command 

### DIFF
--- a/src/NumeralsSuggestor.ts
+++ b/src/NumeralsSuggestor.ts
@@ -48,6 +48,12 @@ const greekSymbols = [
     { trigger: 'Omega', symbol: 'Ω' },
 ];
 
+const numeralsDirectives = [
+	"@hideRows",
+	"@Sum",
+	"@Total",
+]
+
 export class NumeralsSuggestor extends EditorSuggest<string> {
 	plugin: NumeralsPlugin;
 	
@@ -91,7 +97,7 @@ export class NumeralsSuggestor extends EditorSuggest<string> {
 
 		// Get last word in current line
 		const currentLineToCursor = editor.getLine(cursor.line).slice(0, cursor.ch);
-		const currentLineLastWordStart = currentLineToCursor.search(/[:@]?[$\w\u0370-\u03FF]+$/);
+		const currentLineLastWordStart = currentLineToCursor.search(/[:]?[$@\w\u0370-\u03FF]+$/);
 		// if there is no word, return null
 		if (currentLineLastWordStart === -1) {
 			return null;
@@ -134,8 +140,6 @@ export class NumeralsSuggestor extends EditorSuggest<string> {
 				localSymbols = [...new Set([...localSymbols, ...frontmatterSymbolsArray])];
 			}
 
-			// localSymbols = localSymbols.concat("m|@Sum", "m|@Total");
-
 			this.localSuggestionCache = localSymbols;
 			this.lastSuggestionListUpdate = performance.now();
 		} else {
@@ -157,7 +161,11 @@ export class NumeralsSuggestor extends EditorSuggest<string> {
 			suggestions = local_suggestions;
 		}
 
-		suggestions = suggestions.concat(["@Sum", "@Total"].filter((value) => value.slice(0,-1).toLowerCase().startsWith(query_lower, 0)).map((value) => 'm|' + value));
+		suggestions = suggestions.concat(
+			numeralsDirectives
+				.filter((value) => value.slice(0,-1).toLowerCase().startsWith(query_lower, 0))
+				.map((value) => 'm|' + value)
+			);
 
 		// TODO MOVE THESE UP INTO THE CACHED portion. also trigger isn't the right name
 		if (this.plugin.settings.enableGreekAutoComplete) {

--- a/src/numerals.types.ts
+++ b/src/numerals.types.ts
@@ -78,3 +78,10 @@ export interface CurrencyType {
 export type mathjsFormat = number | math.FormatOptions | ((item: any) => string) | undefined;
 
 export class NumeralsScope extends Map<string, unknown>{}
+
+export type numeralsBlockInfo = {
+	emitter_lines: number[];
+	insertion_lines: number[];
+	hidden_lines: number[];
+	shouldHideNonEmitterLines: boolean;
+}

--- a/tests/numeralsUtilities.test.ts
+++ b/tests/numeralsUtilities.test.ts
@@ -162,8 +162,8 @@ apples = 2
 		expect(result.processedSource).toEqual(
 			"# comment 1\n3 = 2\n2 + 3\n$result"
 		);
-		expect(result.emitter_lines).toEqual([2]);
-		expect(result.insertion_lines).toEqual([3]);
+		expect(result.blockInfo.emitter_lines).toEqual([2]);
+		expect(result.blockInfo.insertion_lines).toEqual([3]);
 	});
 
 	it("Correctly processes block with insertion directives inline", () => {
@@ -185,8 +185,8 @@ b = 3
 			"@[result::5] = a + b",
 		]);
 		expect(result.processedSource).toEqual("# comment 1\na = 2\nb = 3\nresult = a + b");
-		expect(result.emitter_lines).toEqual([]);
-		expect(result.insertion_lines).toEqual([3]);
+		expect(result.blockInfo.emitter_lines).toEqual([]);
+		expect(result.blockInfo.insertion_lines).toEqual([3]);
 	});	
 
 	it("Processes block without emitters or insertion directives", () => {
@@ -202,8 +202,8 @@ b = 3
 
 		expect(result.rawRows).toEqual(["# Simple math", "1 + 1", "2 * 2"]);
 		expect(result.processedSource).toEqual("# Simple math\n1 + 1\n2 * 2");
-		expect(result.emitter_lines).toEqual([]);
-		expect(result.insertion_lines).toEqual([]);
+		expect(result.blockInfo.emitter_lines).toEqual([]);
+		expect(result.blockInfo.insertion_lines).toEqual([]);
 	});
 
 	it("Handles multiple emitters and insertion directives", () => {
@@ -229,8 +229,8 @@ b = 3
 		expect(result.processedSource).toEqual(
 			"# Multiple directives\n5 + 5\n10 - 2\n$firstResult\n$secondResult"
 		);
-		expect(result.emitter_lines).toEqual([1, 2]);
-		expect(result.insertion_lines).toEqual([3, 4]);
+		expect(result.blockInfo.emitter_lines).toEqual([1, 2]);
+		expect(result.blockInfo.insertion_lines).toEqual([3, 4]);
 	});
 
 	it("Correctly applies preProcessors to the source", () => {
@@ -255,8 +255,8 @@ apples + oranges
 		expect(result.processedSource).toEqual(
 			"# Preprocessor test\n3 + 5\n$totalFruits"
 		);
-		expect(result.emitter_lines).toEqual([]);
-		expect(result.insertion_lines).toEqual([2]);
+		expect(result.blockInfo.emitter_lines).toEqual([]);
+		expect(result.blockInfo.insertion_lines).toEqual([2]);
 	});
 });
 


### PR DESCRIPTION
- Hides any line that does not have `=>` result annotation (closes #31)
- Adds `@hideRows` to autosuggestion list
- numerals directives (command that start with `@`) will now offer autocomplete suggestions after typing `@`