### PR TITLE
Fix decimal precision for small numbers

### DIFF
--- a/tests/numeralsUtilities.test.ts
+++ b/tests/numeralsUtilities.test.ts
@@ -152,6 +152,22 @@ describe("numeralsUtilities: applyBlockStyles()", () => {
 	});
 });
 
+describe("numeralsUtilities: getLocaleFormatter small number precision", () => {
+    it("formats very small positive numbers without rounding to 0", () => {
+        const fmt = getLocaleFormatter('en-US');
+        const formatted = fmt(1.055e-5);
+        expect(formatted).not.toBe('0');
+        expect(formatted).toContain('1055');
+    });
+
+    it("formats very small negative numbers without rounding to -0", () => {
+        const fmt = getLocaleFormatter('en-US');
+        const formatted = fmt(-3.593e-9);
+        expect(formatted).not.toBe('-0');
+        expect(formatted).toContain('3593');
+    });
+});
+
 describe("numeralsUtilities: preProcessBlockForNumeralsDirectives", () => {
 	it("Correctly processes block with emitters and insertion directives", () => {
 		const sampleBlock = `# comment 1


### PR DESCRIPTION
Improve number formatting to prevent very small non-zero values from displaying as 0.

The `Intl.NumberFormat` defaults, used when "System Formatted" was selected, would round numbers with magnitudes below `1e-3` to 0 or -0, leading to a display bug where accurate calculations appeared incorrect. This change detects such small values and applies a higher precision format (up to 12 fractional digits) to ensure their true value is shown.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1b45ad9-84f5-4dbd-ad89-ceec1ce12f21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1b45ad9-84f5-4dbd-ad89-ceec1ce12f21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

