### PR TITLE
chore: switch to MIT license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Changed
+- License changed from "All Rights Reserved" to MIT.
+
 ### Fixed
 - Syntax highlighting renderer no longer displays numbers ≥100,000 in scientific notation (e.g. `226000` was shown as `2.26e+5`). (Closes #118)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,21 @@
-All Rights Reserved
+MIT License
 
-Copyright (c) 2022 Ryan C
+Copyright (c) 2022-2025 The Numerals contributors
 
-Created by Ryan C
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	},
 	"keywords": [],
 	"author": "RyanC",
-	"license": "UNLICENSED",
+	"license": "MIT",
 	"devDependencies": {
 		"@eslint/js": "^9.39.2",
 		"@eslint/json": "^0.14.0",


### PR DESCRIPTION
## Summary

Switch the project from "All Rights Reserved" to the **MIT License**.

### Changes
- **`LICENSE`**: Replaced with standard MIT license text. Copyright held by "The Numerals contributors" (2022–2025).
- **`package.json`**: `license` field changed from `UNLICENSED` to `MIT`.
- **`CHANGELOG.md`**: Added entry under `[Unreleased]`.

### Why
Open-source the project to align with the broader Obsidian plugin ecosystem (overwhelmingly MIT-licensed) and welcome community contributions.

### Notes
- All 509 dependencies are MIT-compatible (MIT, ISC, BSD, Apache-2.0). No copyleft conflicts.
- No source files contained embedded copyright headers, so no other files needed changes.