### PR TITLE
[codex] Preserve tiny non-zero formatted results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 - License changed from "All Rights Reserved" to MIT.
 
 ### Fixed
+- Tiny non-zero numbers in system and locale-formatted results no longer render as `0` or `-0`; values with more than five leading decimal zeroes now use scientific notation to avoid overly wide output. (Closes #121)
 - Syntax highlighting renderer no longer displays numbers ≥100,000 in scientific notation (e.g. `226000` was shown as `2.26e+5`). (Closes #118)
 
 ### Added

--- a/src/main.ts
+++ b/src/main.ts
@@ -332,7 +332,7 @@ export default class NumeralsPlugin extends Plugin {
 			}
 		}
 
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, loadData) as NumeralsSettings;
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, loadData);
 	}
 
 	async saveSettings() {

--- a/src/rendering/displayUtils.ts
+++ b/src/rendering/displayUtils.ts
@@ -1,5 +1,8 @@
 import { finishRenderMath, renderMath, sanitizeHTMLToDom } from 'obsidian';
+import * as math from 'mathjs';
 import { CurrencyType } from '../numerals.types';
+
+const MAX_FIXED_FORMAT_LEADING_DECIMAL_ZEROES = 5;
 
 /**
  * Regular expression for matching variables with subscript notation 
@@ -137,11 +140,30 @@ export function getLocaleFormatter(
 	locale: Intl.LocalesArgument | undefined = undefined,
 	options: Intl.NumberFormatOptions | undefined = undefined
 ): (value: number) => string {
-	if (locale === undefined) {
-		return (value: number): string => value.toLocaleString();
-	} else if (options === undefined) {
-		return (value: number): string => value.toLocaleString(locale);
-	} else {
-		return (value: number): string => value.toLocaleString(locale, options);
+	const defaultFormatter = new Intl.NumberFormat(locale, options);
+	const preciseFormatter = new Intl.NumberFormat(locale, {
+		...options,
+		maximumSignificantDigits: Math.max(options?.maximumSignificantDigits ?? 0, 15),
+	});
+	const zero = defaultFormatter.format(0);
+	const negativeZero = defaultFormatter.format(-0);
+
+	return (value: number): string => {
+		const formattedValue = defaultFormatter.format(value);
+		if (Number.isFinite(value) && value !== 0 && (formattedValue === zero || formattedValue === negativeZero)) {
+			if (countLeadingDecimalZeroes(value) > MAX_FIXED_FORMAT_LEADING_DECIMAL_ZEROES) {
+				return math.format(value, { notation: 'exponential' });
+			}
+			return preciseFormatter.format(value);
+		}
+		return formattedValue;
+	};
+}
+
+function countLeadingDecimalZeroes(value: number): number {
+	const absValue = Math.abs(value);
+	if (absValue >= 1 || absValue === 0) {
+		return 0;
 	}
+	return Math.max(0, -Math.floor(Math.log10(absValue)) - 1);
 }

--- a/tests/numeralsUtilities.test.ts
+++ b/tests/numeralsUtilities.test.ts
@@ -153,6 +153,45 @@ describe("numeralsUtilities: applyBlockStyles()", () => {
 	});
 });
 
+describe("numeralsUtilities: getLocaleFormatter()", () => {
+	it("uses scientific notation when preserving very tiny non-zero numbers", () => {
+		const format = getLocaleFormatter("en-US");
+
+		expect(format(1e-10)).toBe("1e-10");
+		expect(format(-3.593e-9)).toBe("-3.593e-9");
+	});
+
+	it("uses locale fixed-decimal formatting when preserving readable tiny non-zero numbers", () => {
+		const format = getLocaleFormatter("de-DE");
+
+		expect(format(0.00001)).toBe("0,00001");
+		expect(format(0.000001)).toBe("0,000001");
+	});
+
+	it("switches from fixed decimal to scientific notation after five leading decimal zeroes", () => {
+		const format = getLocaleFormatter("en-US");
+
+		expect(format(0.000001)).toBe("0.000001");
+		expect(format(0.0000001)).toBe("1e-7");
+	});
+
+	it("preserves normal locale rounding when formatted output is already non-zero", () => {
+		const format = getLocaleFormatter("en-US");
+
+		expect(format(0.0009)).toBe("0.001");
+		expect(format(1234.5678)).toBe("1,234.568");
+	});
+
+	it("does not apply tiny-number fallback to zero or non-finite values", () => {
+		const format = getLocaleFormatter("en-US");
+
+		expect(format(0)).toBe("0");
+		expect(format(-0)).toBe("-0");
+		expect(format(Number.POSITIVE_INFINITY)).toBe("∞");
+		expect(format(Number.NaN)).toBe("NaN");
+	});
+});
+
 describe("numeralsUtilities: preProcessBlockForNumeralsDirectives", () => {
 	it("Correctly processes block with emitters and insertion directives", () => {
 		const sampleBlock = `# comment 1


### PR DESCRIPTION
## Summary

Fixes #121 and #42 by preserving finite non-zero results when the default system/locale formatter would otherwise round them all the way down to `0` or `-0`.

The formatter still follows the existing system/locale formatting path for normal values. It only falls back when the formatted output has lost every non-zero digit. When that fallback is needed, readable small values stay in fixed decimal form, while values that would require more than five leading decimal zeroes switch to scientific notation to avoid very wide rendered results.

## Why this approach

- Keeps the change scoped to the shared locale formatter used by plain and syntax-highlight result rendering.
- Preserves existing Intl rounding, grouping, non-finite value handling, and actual zero/negative-zero behavior unless the formatter collapses a finite non-zero result to zero.
- Avoids a broad formatting rewrite or renderer-specific special cases.
- Uses scientific notation only for the fallback cases where fixed decimal output would be visually noisy.

## Behavior

| Case | Before | After |
| --- | --- | --- |
| `1e-10` | `0` | `1e-10` |
| `-3.593e-9` | `-0` | `-3.593e-9` |
| `0.000001` | `0` | `0.000001` |
| `0.0000001` | `0` | `1e-7` |
| `0` | `0` | `0` |
| `-0` | `-0` | `-0` |
| `0.0009` | `0.001` | `0.001` |
| `1234.5678` | `1,234.568` | `1,234.568` |
| `Infinity` | `∞` | `∞` |
| `NaN` | `NaN` | `NaN` |

## Obsidian verification screenshots

Captured with Obsidian's app CLI from the live Numerals vault, with the sidebar collapsed and unrelated tabs closed.

**Before:** 
<img width="611" height="799" alt="numerals-pr-139-clean-before-master" src="https://github.com/user-attachments/assets/5c6d1c48-d64e-4f7a-8a21-90fdb769b1ef" />

tiny non-zero values render as `0`/`-0` in plain, TeX, and syntax-highlight renderers.

**After this PR:**
<img width="611" height="799" alt="numerals-pr-139-clean-after-pr" src="https://github.com/user-attachments/assets/7ad35be4-b86d-4cb7-b44b-e9dc8bfe912a" />

tiny non-zero values render as non-zero results; readable tiny decimals stay fixed, and the smaller threshold case uses scientific notation.


## Validation

- `npm test -- --runInBand` - 295 tests passing, 8 snapshots passing
- `npm run lint`
- `npm run build`
- Obsidian CLI DOM check before/after the artifact swap
- Obsidian CLI runtime checks: no captured errors and no console errors after loading the PR artifact

Closes #121
Closes #42