### PR TITLE
Stop bundling Dataview dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. The format 
 - Updated mathjs from `^14.5.3` to `^15.2.0` to include the April 2026 security fixes.
 - Mathjs auto-complete suggestions now include newly supported functions and constants from the upgraded mathjs version.
 - README features list now documents cross-note references.
+- Replaced the bundled Dataview package import with a runtime Dataview API lookup, reducing the production bundle size and removing bundled Dataview transitive dependencies.
 
 ### Fixed
 - Inline cross-note references now rerender when referenced note metadata changes.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
 	"author": "RyanC",
 	"license": "MIT",
 	"devDependencies": {
+		"@codemirror/language": "https://github.com/lishid/cm-language",
+		"@codemirror/state": "6.5.0",
+		"@codemirror/view": "6.38.6",
 		"@eslint/js": "^9.39.2",
 		"@eslint/json": "^0.14.0",
 		"@types/jest": "^29.5.2",
@@ -35,7 +38,6 @@
 		"jest": "^29.5.0",
 		"jest-environment-jsdom": "^29.7.0",
 		"obsidian": "^1.8.7",
-		"obsidian-dataview": "^0.5.56",
 		"ts-jest": "^29.1.0",
 		"tslib": "2.8.1",
 		"typescript": "~5.8",

--- a/src/dataview.ts
+++ b/src/dataview.ts
@@ -1,0 +1,29 @@
+import { App } from 'obsidian';
+
+export interface DataviewApi {
+	page: (path: string) => Record<string, unknown> | undefined;
+}
+
+interface AppWithDataview extends App {
+	plugins: {
+		plugins: {
+			dataview?: {
+				api?: DataviewApi;
+			};
+		};
+	};
+}
+
+interface WindowWithDataview extends Window {
+	DataviewAPI?: DataviewApi;
+}
+
+export function getDataviewApi(app?: App): DataviewApi | undefined {
+	const pluginApi = app
+		? (app as AppWithDataview).plugins?.plugins?.dataview?.api
+		: undefined;
+
+	return pluginApi ?? (typeof window !== 'undefined'
+		? (window as WindowWithDataview).DataviewAPI
+		: undefined);
+}

--- a/src/inline/inlineLivePreview.ts
+++ b/src/inline/inlineLivePreview.ts
@@ -36,7 +36,6 @@ import { EditorSelection, Range } from '@codemirror/state';
 import { syntaxTree, tokenClassNodeProp } from '@codemirror/language';
 import { App, EventRef } from 'obsidian';
 import { editorInfoField, editorLivePreviewField } from 'obsidian';
-import { getAPI } from 'obsidian-dataview';
 import {
 	NumeralsSettings,
 	NumeralsScope,
@@ -47,6 +46,7 @@ import {
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
 import { parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
+import { getDataviewApi } from '../dataview';
 
 /****************************************************
  * Formatting context helpers
@@ -599,7 +599,7 @@ export function createInlineLivePreviewExtension(
 					view.dispatch({ effects: [] });
 				};
 
-				const dataviewAPI = getAPI(); // eslint-disable-line @typescript-eslint/no-unsafe-assignment -- dataview API untyped
+				const dataviewAPI = getDataviewApi(app);
 				this.metadataEventRef = dataviewAPI
 					? app.metadataCache.on(
 						// @ts-expect-error: dataview custom event not in Obsidian types

--- a/src/inline/inlinePostProcessor.ts
+++ b/src/inline/inlinePostProcessor.ts
@@ -1,9 +1,9 @@
 import { App, MarkdownPostProcessorContext, MarkdownRenderChild } from 'obsidian';
-import { getAPI } from 'obsidian-dataview';
 import { NumeralsSettings, NumeralsScope, mathjsFormat, StringReplaceMap, InlineNumeralsMode } from '../numerals.types';
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
 import { parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
+import { getDataviewApi } from '../dataview';
 
 /**
  * Write `$`-prefixed globals to the shared scope cache.
@@ -267,7 +267,7 @@ export function createInlineNumeralsPostProcessor(
 			referencedPaths = renderInlineElements();
 		};
 
-		const dataviewAPI = getAPI(); // eslint-disable-line @typescript-eslint/no-unsafe-assignment -- dataview API untyped
+		const dataviewAPI = getDataviewApi(app);
 		if (dataviewAPI) {
 			const ref = app.metadataCache.on(
 				// @ts-expect-error: dataview custom event not in Obsidian types

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,8 +27,7 @@ import {
 	MarkdownPostProcessorContext,
 	MarkdownRenderChild,
 } from "obsidian";
-
-import { getAPI } from 'obsidian-dataview';
+import { getDataviewApi } from './dataview';
 
 import * as math from 'mathjs';
 
@@ -167,7 +166,7 @@ export default class NumeralsPlugin extends Plugin {
 			referencedPaths = blockResult.referencedPaths;
 		};
 
-		const dataviewAPI = getAPI(); // eslint-disable-line @typescript-eslint/no-unsafe-assignment -- dataview API untyped
+		const dataviewAPI = getDataviewApi(this.app);
 		if (dataviewAPI) {
 			// Register on the child component so it auto-cleans on unload
 			const ref = this.app.metadataCache.on(

--- a/src/processing/crossNoteResolver.ts
+++ b/src/processing/crossNoteResolver.ts
@@ -1,9 +1,9 @@
 import { App, TFile } from 'obsidian';
-import { getAPI } from 'obsidian-dataview';
 import * as math from 'mathjs';
 import { NumeralsSettings, StringReplaceMap } from '../numerals.types';
 import { replaceStringsInTextFromMap } from './preprocessor';
 import { getScopeFromFrontmatter, removeCanonicalizedDuplicates } from './scope';
+import { getDataviewApi } from '../dataview';
 
 /**
  * Result of resolving cross-note references in a source string.
@@ -105,11 +105,10 @@ export function getMetadataForReferencedNote(
 	const cache = app.metadataCache.getFileCache(file);
 	const frontmatter: Record<string, unknown> = { ...(cache?.frontmatter), position: undefined };
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- dataview API returns untyped data
-	const dataviewAPI = getAPI();
+	const dataviewAPI = getDataviewApi(app);
 	let dataviewMetadata: Record<string, unknown> | undefined;
 	if (dataviewAPI) {
-		const dataviewPage: Record<string, unknown> = (dataviewAPI as { page: (path: string) => Record<string, unknown> }).page(file.path);
+		const dataviewPage = dataviewAPI.page(file.path);
 		if (dataviewPage) {
 			dataviewMetadata = { ...dataviewPage, file: undefined, position: undefined };
 		}

--- a/src/processing/scope.ts
+++ b/src/processing/scope.ts
@@ -1,8 +1,8 @@
 import * as math from 'mathjs';
-import { getAPI } from 'obsidian-dataview';
 import { App, TFile } from 'obsidian';
 import { NumeralsScope, StringReplaceMap } from '../numerals.types';
 import { replaceStringsInTextFromMap } from './preprocessor';
+import { getDataviewApi } from '../dataview';
 
 /**
  * Process frontmatter and return updated scope object
@@ -230,11 +230,10 @@ export function getMetadataForFileAtPath(
 	const f_cache = f_handle ? app.metadataCache.getFileCache(f_handle) : undefined;
 	const frontmatter:{[key: string]: unknown} | undefined = {...(f_cache?.frontmatter), position: undefined};
 
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- dataview API returns untyped data
-	const dataviewAPI = getAPI();
+	const dataviewAPI = getDataviewApi(app);
 	let dataviewMetadata:{[key: string]: unknown} | undefined;
 	if (dataviewAPI) {
-		const dataviewPage: Record<string, unknown> = (dataviewAPI as { page: (path: string) => Record<string, unknown> }).page(f_path);
+		const dataviewPage = dataviewAPI.page(f_path);
 		dataviewMetadata = {...dataviewPage, file: undefined, position: undefined}
 	}
  


### PR DESCRIPTION
## Summary
- replace direct obsidian-dataview imports with a local runtime Dataview API lookup
- remove obsidian-dataview from dev dependencies and add explicit CodeMirror dev dependencies used by live preview tests/typechecking
- document the bundle/dependency cleanup in the changelog

## Why
This keeps Dataview optional at runtime without bundling Dataview and its transitive dependencies into Numerals. It also removes the high-severity Svelte audit path from the release dependency tree and keeps CodeMirror dependencies explicit instead of relying on Dataview transitives.

## Verification
- npm test -- --runInBand
- npm run lint
- npm run build
- npm run symbols:check
- Obsidian plugin reload with no captured runtime or console errors

## Notes
npm audit still reports 4 low-severity findings through jest-environment-jsdom/jsdom. npm only offers a breaking forced upgrade to jest-environment-jsdom@30.3.0 for those.