### PR TITLE
[codex] Support click-through edits of rendered blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 - Release workflow no longer uses deprecated `set-output` commands or archived release upload actions. (Closes #124)
+- Rendered Numerals math blocks can now be clicked or tapped in Live Preview to focus the corresponding source line for editing. (Closes #50, #59)
 - Inline cross-note references now rerender when referenced note metadata changes.
 - Cross-note references now evaluate dependent metadata values using the referenced note's Numerals scope.
 - Tiny non-zero numbers in system and locale-formatted results no longer render as `0` or `-0`; values with more than five leading decimal zeroes now use scientific notation to avoid overly wide output. (Closes #121)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { NumeralsSuggestor } from "./NumeralsSuggestor";
 import { defaultCurrencyMap, getLocaleFormatter } from "./rendering/displayUtils";
 import { processAndRenderNumeralsBlockFromSource } from "./rendering/orchestrator";
+import { handleNumeralsBlockClick } from "./rendering/editorNavigation";
 import { getMetadataForFileAtPath, addGlobalsFromScopeToPageCache } from "./processing/scope";
 import { createInlineNumeralsPostProcessor, createInlineLivePreviewExtension } from "./inline";
 import {
@@ -179,6 +180,10 @@ export default class NumeralsPlugin extends Plugin {
 			const ref = this.app.metadataCache.on("changed", numeralsBlockCallback);
 			numeralsBlockChild.registerEvent(ref);
 		}
+
+		numeralsBlockChild.registerDomEvent(el, "click", (event: MouseEvent) => {
+			handleNumeralsBlockClick(event, ctx, el, this.app);
+		});
 
 		ctx.addChild(numeralsBlockChild);
 	}

--- a/src/numeralsUtilities.ts
+++ b/src/numeralsUtilities.ts
@@ -30,6 +30,7 @@ export {
 	numeralsLayoutClasses,
 	numeralsRenderStyleClasses,
 } from './rendering/orchestrator';
+export { findEditorForPath } from './rendering/editorNavigation';
 export { prepareLineData, extractComment, cleanRawInput, renderComment } from './rendering/linePreparation';
 export {
 	texCurrencyReplacement,

--- a/src/numeralsUtilities.ts
+++ b/src/numeralsUtilities.ts
@@ -12,6 +12,7 @@
  *   - rendering/orchestrator: processAndRenderNumeralsBlockFromSource, renderNumeralsBlock, renderError, handleResultInsertions, applyBlockStyles
  *   - rendering/linePreparation: prepareLineData, extractComment, cleanRawInput, renderComment
  *   - rendering/displayUtils: texCurrencyReplacement, unescapeSubscripts, mathjaxLoop, htmlToElements, getLocaleFormatter, defaultCurrencyMap
+ *   - rendering/editorNavigation: findEditorForPath, handleNumeralsBlockClick
  */
 
 // Processing
@@ -30,7 +31,12 @@ export {
 	numeralsLayoutClasses,
 	numeralsRenderStyleClasses,
 } from './rendering/orchestrator';
-export { findEditorForPath } from './rendering/editorNavigation';
+export {
+	findEditorForPath,
+	getTextOffsetFromPoint,
+	handleNumeralsBlockClick,
+	sourceChForRenderedOffset,
+} from './rendering/editorNavigation';
 export { prepareLineData, extractComment, cleanRawInput, renderComment } from './rendering/linePreparation';
 export {
 	texCurrencyReplacement,

--- a/src/rendering/editorNavigation.ts
+++ b/src/rendering/editorNavigation.ts
@@ -1,4 +1,9 @@
-import { App, Editor, MarkdownView, WorkspaceLeaf } from 'obsidian';
+import { App, Editor, MarkdownPostProcessorContext, MarkdownView, WorkspaceLeaf } from 'obsidian';
+
+type CaretPositionDocument = Document & {
+	caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
+	caretRangeFromPoint?: (x: number, y: number) => Range | null;
+};
 
 /**
  * Find the editor for a specific file path by searching all workspace leaves.
@@ -13,4 +18,91 @@ export function findEditorForPath(app: App, sourcePath: string): Editor | undefi
 		}
 	});
 	return found;
+}
+
+function getCaretRangeFromPoint(doc: Document, clientX: number, clientY: number): Range | null {
+	const caretDoc = doc as CaretPositionDocument;
+	const position = caretDoc.caretPositionFromPoint?.(clientX, clientY);
+	if (position) {
+		const range = doc.createRange();
+		range.setStart(position.offsetNode, position.offset);
+		range.collapse(true);
+		return range;
+	}
+	return caretDoc.caretRangeFromPoint?.(clientX, clientY) ?? null;
+}
+
+export function getTextOffsetFromPoint(element: HTMLElement, clientX: number, clientY: number): number | null {
+	const range = getCaretRangeFromPoint(element.ownerDocument, clientX, clientY);
+	if (!range || !element.contains(range.startContainer)) {
+		return null;
+	}
+
+	const measure = element.ownerDocument.createRange();
+	measure.selectNodeContents(element);
+	measure.setEnd(range.startContainer, range.startOffset);
+	const offset = measure.toString().length;
+	measure.detach();
+	return offset;
+}
+
+export function sourceChForRenderedOffset(
+	sourceLine: string,
+	renderedInputText: string,
+	renderedOffset: number
+): number {
+	const nonNegativeRenderedOffset = Math.max(0, renderedOffset);
+	const exactStart = renderedInputText.length > 0 ? sourceLine.indexOf(renderedInputText) : -1;
+	if (exactStart >= 0) {
+		const clampedRenderedOffset = Math.min(nonNegativeRenderedOffset, renderedInputText.length);
+		return Math.min(exactStart + clampedRenderedOffset, sourceLine.length);
+	}
+	return Math.min(nonNegativeRenderedOffset, sourceLine.length);
+}
+
+export function handleNumeralsBlockClick(
+	event: MouseEvent,
+	ctx: MarkdownPostProcessorContext,
+	el: HTMLElement,
+	app: App
+): void {
+	const target = event.target;
+	if (!(target instanceof HTMLElement)) {
+		return;
+	}
+
+	const lineElement = target.closest<HTMLElement>('.numerals-line');
+	if (!lineElement || !el.contains(lineElement)) {
+		return;
+	}
+
+	const sourceLineIndex = Number.parseInt(lineElement.dataset.sourceLine ?? '', 10);
+	if (!Number.isInteger(sourceLineIndex)) {
+		return;
+	}
+
+	const sectionInfo = ctx.getSectionInfo(el);
+	if (sectionInfo?.lineStart === undefined) {
+		return;
+	}
+
+	const editor = findEditorForPath(app, ctx.sourcePath);
+	if (!editor) {
+		return;
+	}
+
+	const editorLine = sectionInfo.lineStart + 1 + sourceLineIndex;
+	const sourceLine = editor.getLine(editorLine);
+	let ch = sourceLine.length;
+
+	const inputElement = target.closest<HTMLElement>('.numerals-input');
+	if (inputElement && lineElement.contains(inputElement)) {
+		const renderedOffset = getTextOffsetFromPoint(inputElement, event.clientX, event.clientY);
+		if (renderedOffset !== null) {
+			ch = sourceChForRenderedOffset(sourceLine, inputElement.textContent ?? '', renderedOffset);
+		}
+	}
+
+	editor.setCursor({ line: editorLine, ch });
+	editor.focus();
 }

--- a/src/rendering/editorNavigation.ts
+++ b/src/rendering/editorNavigation.ts
@@ -2,8 +2,9 @@ import { App, Editor, MarkdownPostProcessorContext, MarkdownView, WorkspaceLeaf 
 
 type CaretPositionDocument = Document & {
 	caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
-	caretRangeFromPoint?: (x: number, y: number) => Range | null;
 };
+
+type CaretRangeFromPoint = (x: number, y: number) => Range | null;
 
 /**
  * Find the editor for a specific file path by searching all workspace leaves.
@@ -29,7 +30,12 @@ function getCaretRangeFromPoint(doc: Document, clientX: number, clientY: number)
 		range.collapse(true);
 		return range;
 	}
-	return caretDoc.caretRangeFromPoint?.(clientX, clientY) ?? null;
+
+	const legacyRangeFromPoint = (doc as unknown as Record<string, unknown>)['caretRangeFromPoint'];
+	if (typeof legacyRangeFromPoint === 'function') {
+		return (legacyRangeFromPoint as CaretRangeFromPoint).call(doc, clientX, clientY);
+	}
+	return null;
 }
 
 export function getTextOffsetFromPoint(element: HTMLElement, clientX: number, clientY: number): number | null {

--- a/src/rendering/editorNavigation.ts
+++ b/src/rendering/editorNavigation.ts
@@ -1,0 +1,16 @@
+import { App, Editor, MarkdownView, WorkspaceLeaf } from 'obsidian';
+
+/**
+ * Find the editor for a specific file path by searching all workspace leaves.
+ * More reliable than getActiveViewOfType, which can return the wrong editor in split panes.
+ */
+export function findEditorForPath(app: App, sourcePath: string): Editor | undefined {
+	let found: Editor | undefined;
+	app.workspace.iterateAllLeaves((leaf: WorkspaceLeaf) => {
+		if (found) return;
+		if (leaf.view instanceof MarkdownView && leaf.view.file?.path === sourcePath) {
+			found = leaf.view.editor;
+		}
+	});
+	return found;
+}

--- a/src/rendering/editorNavigation.ts
+++ b/src/rendering/editorNavigation.ts
@@ -63,7 +63,54 @@ export function sourceChForRenderedOffset(
 		const clampedRenderedOffset = Math.min(nonNegativeRenderedOffset, renderedInputText.length);
 		return Math.min(exactStart + clampedRenderedOffset, sourceLine.length);
 	}
+
+	const alignedSourceCh = sourceChFromRenderedSubsequence(
+		sourceLine,
+		renderedInputText,
+		nonNegativeRenderedOffset
+	);
+	if (alignedSourceCh !== null) {
+		return alignedSourceCh;
+	}
+
 	return Math.min(nonNegativeRenderedOffset, sourceLine.length);
+}
+
+function sourceChFromRenderedSubsequence(
+	sourceLine: string,
+	renderedInputText: string,
+	renderedOffset: number
+): number | null {
+	if (renderedInputText.length === 0) {
+		return null;
+	}
+
+	const renderedChToSourceCh: Array<number | undefined> = [];
+	let renderedIndex = 0;
+
+	for (let sourceIndex = 0; sourceIndex < sourceLine.length; sourceIndex++) {
+		if (sourceLine[sourceIndex] !== renderedInputText[renderedIndex]) {
+			continue;
+		}
+
+		renderedChToSourceCh[renderedIndex] ??= sourceIndex;
+		renderedIndex++;
+		renderedChToSourceCh[renderedIndex] = sourceIndex + 1;
+
+		if (renderedIndex === renderedInputText.length) {
+			break;
+		}
+	}
+
+	if (renderedIndex !== renderedInputText.length) {
+		return null;
+	}
+
+	if (renderedOffset > renderedInputText.length) {
+		return sourceLine.length;
+	}
+
+	return renderedChToSourceCh[renderedOffset] ?? null;
 }
 
 export function handleNumeralsBlockClick(

--- a/src/rendering/orchestrator.ts
+++ b/src/rendering/orchestrator.ts
@@ -83,6 +83,7 @@ export function renderNumeralsBlock(
 		}
 
 		const lineContainer = container.createEl("div", {cls: "numerals-line"});
+		lineContainer.dataset.sourceLine = String(lineData.index);
 		if (lineData.isEmitter) {
 			lineContainer.toggleClass("numerals-emitter", true);
 		}

--- a/src/rendering/orchestrator.ts
+++ b/src/rendering/orchestrator.ts
@@ -1,5 +1,5 @@
 import * as math from 'mathjs';
-import { App, Editor, MarkdownPostProcessorContext, MarkdownView, WorkspaceLeaf } from 'obsidian';
+import { App, MarkdownPostProcessorContext } from 'obsidian';
 import { NumeralsLayout, NumeralsRenderStyle, NumeralsSettings, NumeralsError, NumeralsBlockResult, mathjsFormat, NumeralsScope, StringReplaceMap, ProcessedBlock, EvaluationResult, RenderContext } from '../numerals.types';
 import { RendererFactory } from '../renderers';
 import { getScopeFromFrontmatter } from '../processing/scope';
@@ -7,21 +7,7 @@ import { preProcessBlockForNumeralsDirectives } from '../processing/preprocessor
 import { evaluateMathFromSourceStrings } from '../processing/evaluator';
 import { resolveCrossNoteReferences } from '../processing/crossNoteResolver';
 import { prepareLineData } from './linePreparation';
-
-/**
- * Find the editor for a specific file path by searching all workspace leaves.
- * More reliable than getActiveViewOfType which can return the wrong editor in split panes.
- */
-function findEditorForPath(app: App, sourcePath: string): Editor | undefined {
-	let found: Editor | undefined;
-	app.workspace.iterateAllLeaves((leaf: WorkspaceLeaf) => {
-		if (found) return;
-		if (leaf.view instanceof MarkdownView && leaf.view.file?.path === sourcePath) {
-			found = leaf.view.editor;
-		}
-	});
-	return found;
-}
+import { findEditorForPath } from './editorNavigation';
 
 /**
  * Renders error information into the container element.

--- a/styles.css
+++ b/styles.css
@@ -130,6 +130,10 @@ body {
     padding: var(--size-4-4);    
 } 
 
+.numerals-block .numerals-line {
+    cursor: text;
+}
+
 .numerals-block .MathJax {
     text-align: left !important;
     margin-top: .5em !important;

--- a/tests/__snapshots__/numeralsUtilities.test.ts.snap
+++ b/tests/__snapshots__/numeralsUtilities.test.ts.snap
@@ -6,6 +6,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
 >
   <div
     class="numerals-line"
+    data-source-line="0"
   >
     <span
       class="numerals-input numerals-empty"
@@ -20,6 +21,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="1"
   >
     <span
       class="numerals-input"
@@ -34,6 +36,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="2"
   >
     <span
       class="numerals-input"
@@ -48,6 +51,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="3"
   >
     <span
       class="numerals-input"
@@ -62,6 +66,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="4"
   >
     <span
       class="numerals-input"
@@ -84,6 +89,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="5"
   >
     <span
       class="numerals-input numerals-empty"
@@ -98,6 +104,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="6"
   >
     <span
       class="numerals-input"
@@ -112,6 +119,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="7"
   >
     <span
       class="numerals-input"
@@ -126,6 +134,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="8"
   >
     <span
       class="numerals-input"
@@ -140,6 +149,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="9"
   >
     <span
       class="numerals-input"
@@ -162,6 +172,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="10"
   >
     <span
       class="numerals-input numerals-empty"
@@ -176,6 +187,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="11"
   >
     <span
       class="numerals-input numerals-empty"
@@ -190,6 +202,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="12"
   >
     <span
       class="numerals-input"
@@ -204,6 +217,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="13"
   >
     <span
       class="numerals-input"
@@ -218,6 +232,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="14"
   >
     <span
       class="numerals-input"
@@ -232,6 +247,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="15"
   >
     <span
       class="numerals-input"
@@ -254,6 +270,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="16"
   >
     <span
       class="numerals-input numerals-empty"
@@ -268,6 +285,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="17"
   >
     <span
       class="numerals-input numerals-empty"
@@ -282,6 +300,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="18"
   >
     <span
       class="numerals-input"
@@ -296,6 +315,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="19"
   >
     <span
       class="numerals-input"
@@ -310,6 +330,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="20"
   >
     <span
       class="numerals-input"
@@ -324,6 +345,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="21"
   >
     <span
       class="numerals-input"
@@ -343,6 +365,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="22"
   >
     <span
       class="numerals-input numerals-empty"
@@ -357,6 +380,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="23"
   >
     <span
       class="numerals-input"
@@ -376,6 +400,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="24"
   >
     <span
       class="numerals-input numerals-empty"
@@ -390,6 +415,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="25"
   >
     <span
       class="numerals-input"
@@ -404,6 +430,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="26"
   >
     <span
       class="numerals-input"
@@ -418,6 +445,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="27"
   >
     <span
       class="numerals-input"
@@ -432,6 +460,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="28"
   >
     <span
       class="numerals-input numerals-empty"
@@ -446,6 +475,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="29"
   >
     <span
       class="numerals-input"
@@ -460,6 +490,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="30"
   >
     <span
       class="numerals-input"
@@ -474,6 +505,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="31"
   >
     <span
       class="numerals-input"
@@ -488,6 +520,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="32"
   >
     <span
       class="numerals-input numerals-empty"
@@ -502,6 +535,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="33"
   >
     <span
       class="numerals-input"
@@ -516,6 +550,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="34"
   >
     <span
       class="numerals-input"
@@ -530,6 +565,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="35"
   >
     <span
       class="numerals-input numerals-empty"
@@ -544,6 +580,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="36"
   >
     <span
       class="numerals-input numerals-empty"
@@ -558,6 +595,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="37"
   >
     <span
       class="numerals-input numerals-empty"
@@ -572,6 +610,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="38"
   >
     <span
       class="numerals-input"
@@ -586,6 +625,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="39"
   >
     <span
       class="numerals-input"
@@ -600,6 +640,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="40"
   >
     <span
       class="numerals-input numerals-empty"
@@ -614,6 +655,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="41"
   >
     <span
       class="numerals-input"
@@ -628,6 +670,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="42"
   >
     <span
       class="numerals-input"
@@ -642,6 +685,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="43"
   >
     <span
       class="numerals-input numerals-empty"
@@ -656,6 +700,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="44"
   >
     <span
       class="numerals-input"
@@ -670,6 +715,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="45"
   >
     <span
       class="numerals-input"
@@ -684,6 +730,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="46"
   >
     <span
       class="numerals-input numerals-empty"
@@ -698,6 +745,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="47"
   >
     <span
       class="numerals-input"
@@ -712,6 +760,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="48"
   >
     <span
       class="numerals-input"
@@ -726,6 +775,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="49"
   >
     <span
       class="numerals-input numerals-empty"
@@ -740,6 +790,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="50"
   >
     <span
       class="numerals-input numerals-empty"
@@ -754,6 +805,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="51"
   >
     <span
       class="numerals-input"
@@ -768,6 +820,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="52"
   >
     <span
       class="numerals-input"
@@ -782,6 +835,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="53"
   >
     <span
       class="numerals-input"
@@ -796,6 +850,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="54"
   >
     <span
       class="numerals-input"
@@ -810,6 +865,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="55"
   >
     <span
       class="numerals-input"
@@ -824,6 +880,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="56"
   >
     <span
       class="numerals-input"
@@ -838,6 +895,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="57"
   >
     <span
       class="numerals-input"
@@ -852,6 +910,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="58"
   >
     <span
       class="numerals-input"
@@ -866,6 +925,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="59"
   >
     <span
       class="numerals-input numerals-empty"
@@ -887,6 +947,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
 >
   <div
     class="numerals-line"
+    data-source-line="0"
   >
     <span
       class="numerals-input numerals-empty"
@@ -901,6 +962,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="1"
   >
     <span
       class="numerals-input"
@@ -915,6 +977,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="2"
   >
     <span
       class="numerals-input"
@@ -929,6 +992,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="3"
   >
     <span
       class="numerals-input"
@@ -943,6 +1007,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="4"
   >
     <span
       class="numerals-input"
@@ -965,6 +1030,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="5"
   >
     <span
       class="numerals-input numerals-empty"
@@ -979,6 +1045,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="6"
   >
     <span
       class="numerals-input"
@@ -993,6 +1060,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="7"
   >
     <span
       class="numerals-input"
@@ -1007,6 +1075,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="8"
   >
     <span
       class="numerals-input"
@@ -1021,6 +1090,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="9"
   >
     <span
       class="numerals-input"
@@ -1043,6 +1113,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="10"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1057,6 +1128,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="11"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1071,6 +1143,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="12"
   >
     <span
       class="numerals-input"
@@ -1085,6 +1158,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="13"
   >
     <span
       class="numerals-input"
@@ -1099,6 +1173,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="14"
   >
     <span
       class="numerals-input"
@@ -1113,6 +1188,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="15"
   >
     <span
       class="numerals-input"
@@ -1135,6 +1211,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="16"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1149,6 +1226,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="17"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1163,6 +1241,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="18"
   >
     <span
       class="numerals-input"
@@ -1177,6 +1256,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="19"
   >
     <span
       class="numerals-input"
@@ -1191,6 +1271,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="20"
   >
     <span
       class="numerals-input"
@@ -1205,6 +1286,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="21"
   >
     <span
       class="numerals-input"
@@ -1224,6 +1306,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="22"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1238,6 +1321,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="23"
   >
     <span
       class="numerals-input"
@@ -1257,6 +1341,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="24"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1271,6 +1356,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="25"
   >
     <span
       class="numerals-input"
@@ -1285,6 +1371,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="26"
   >
     <span
       class="numerals-input"
@@ -1299,6 +1386,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="27"
   >
     <span
       class="numerals-input"
@@ -1313,6 +1401,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="28"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1327,6 +1416,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="29"
   >
     <span
       class="numerals-input"
@@ -1341,6 +1431,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="30"
   >
     <span
       class="numerals-input"
@@ -1355,6 +1446,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="31"
   >
     <span
       class="numerals-input"
@@ -1369,6 +1461,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="32"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1383,6 +1476,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="33"
   >
     <span
       class="numerals-input"
@@ -1397,6 +1491,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="34"
   >
     <span
       class="numerals-input"
@@ -1411,6 +1506,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="35"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1425,6 +1521,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="36"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1439,6 +1536,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="37"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1453,6 +1551,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="38"
   >
     <span
       class="numerals-input"
@@ -1467,6 +1566,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="39"
   >
     <span
       class="numerals-input"
@@ -1481,6 +1581,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="40"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1495,6 +1596,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="41"
   >
     <span
       class="numerals-input"
@@ -1509,6 +1611,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="42"
   >
     <span
       class="numerals-input"
@@ -1523,6 +1626,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="43"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1537,6 +1641,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="44"
   >
     <span
       class="numerals-input"
@@ -1551,6 +1656,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="45"
   >
     <span
       class="numerals-input"
@@ -1565,6 +1671,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="46"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1579,6 +1686,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="47"
   >
     <span
       class="numerals-input"
@@ -1593,6 +1701,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="48"
   >
     <span
       class="numerals-input"
@@ -1607,6 +1716,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="49"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1621,6 +1731,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="50"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1635,6 +1746,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="51"
   >
     <span
       class="numerals-input"
@@ -1649,6 +1761,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="52"
   >
     <span
       class="numerals-input"
@@ -1663,6 +1776,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="53"
   >
     <span
       class="numerals-input"
@@ -1677,6 +1791,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="54"
   >
     <span
       class="numerals-input"
@@ -1691,6 +1806,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="55"
   >
     <span
       class="numerals-input"
@@ -1705,6 +1821,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="56"
   >
     <span
       class="numerals-input"
@@ -1719,6 +1836,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="57"
   >
     <span
       class="numerals-input"
@@ -1733,6 +1851,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="58"
   >
     <span
       class="numerals-input"
@@ -1747,6 +1866,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="59"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1768,6 +1888,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
 >
   <div
     class="numerals-line"
+    data-source-line="0"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1782,6 +1903,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="1"
   >
     <span
       class="numerals-input"
@@ -1796,6 +1918,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="2"
   >
     <span
       class="numerals-input"
@@ -1810,6 +1933,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="3"
   >
     <span
       class="numerals-input"
@@ -1824,6 +1948,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="4"
   >
     <span
       class="numerals-input"
@@ -1846,6 +1971,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="5"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1860,6 +1986,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="6"
   >
     <span
       class="numerals-input"
@@ -1874,6 +2001,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="7"
   >
     <span
       class="numerals-input"
@@ -1888,6 +2016,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="8"
   >
     <span
       class="numerals-input"
@@ -1902,6 +2031,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="9"
   >
     <span
       class="numerals-input"
@@ -1924,6 +2054,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="10"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1938,6 +2069,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="11"
   >
     <span
       class="numerals-input numerals-empty"
@@ -1952,6 +2084,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="12"
   >
     <span
       class="numerals-input"
@@ -1966,6 +2099,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="13"
   >
     <span
       class="numerals-input"
@@ -1980,6 +2114,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="14"
   >
     <span
       class="numerals-input"
@@ -1994,6 +2129,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="15"
   >
     <span
       class="numerals-input"
@@ -2016,6 +2152,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="16"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2030,6 +2167,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="17"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2044,6 +2182,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="18"
   >
     <span
       class="numerals-input"
@@ -2058,6 +2197,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="19"
   >
     <span
       class="numerals-input"
@@ -2072,6 +2212,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="20"
   >
     <span
       class="numerals-input"
@@ -2086,6 +2227,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="21"
   >
     <span
       class="numerals-input"
@@ -2105,6 +2247,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="22"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2119,6 +2262,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="23"
   >
     <span
       class="numerals-input"
@@ -2138,6 +2282,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="24"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2152,6 +2297,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="25"
   >
     <span
       class="numerals-input"
@@ -2166,6 +2312,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="26"
   >
     <span
       class="numerals-input"
@@ -2180,6 +2327,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="27"
   >
     <span
       class="numerals-input"
@@ -2194,6 +2342,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="28"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2208,6 +2357,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="29"
   >
     <span
       class="numerals-input"
@@ -2222,6 +2372,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="30"
   >
     <span
       class="numerals-input"
@@ -2236,6 +2387,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="31"
   >
     <span
       class="numerals-input"
@@ -2250,6 +2402,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="32"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2264,6 +2417,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="33"
   >
     <span
       class="numerals-input"
@@ -2278,6 +2432,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="34"
   >
     <span
       class="numerals-input"
@@ -2292,6 +2447,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="35"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2306,6 +2462,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="36"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2320,6 +2477,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="37"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2334,6 +2492,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="38"
   >
     <span
       class="numerals-input"
@@ -2348,6 +2507,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="39"
   >
     <span
       class="numerals-input"
@@ -2362,6 +2522,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="40"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2376,6 +2537,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="41"
   >
     <span
       class="numerals-input"
@@ -2390,6 +2552,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="42"
   >
     <span
       class="numerals-input"
@@ -2404,6 +2567,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="43"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2418,6 +2582,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="44"
   >
     <span
       class="numerals-input"
@@ -2432,6 +2597,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="45"
   >
     <span
       class="numerals-input"
@@ -2446,6 +2612,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="46"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2460,6 +2627,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="47"
   >
     <span
       class="numerals-input"
@@ -2474,6 +2642,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="48"
   >
     <span
       class="numerals-input"
@@ -2488,6 +2657,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="49"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2502,6 +2672,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="50"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2516,6 +2687,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="51"
   >
     <span
       class="numerals-input"
@@ -2530,6 +2702,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="52"
   >
     <span
       class="numerals-input"
@@ -2544,6 +2717,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="53"
   >
     <span
       class="numerals-input"
@@ -2558,6 +2732,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="54"
   >
     <span
       class="numerals-input"
@@ -2572,6 +2747,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="55"
   >
     <span
       class="numerals-input"
@@ -2586,6 +2762,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="56"
   >
     <span
       class="numerals-input"
@@ -2600,6 +2777,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="57"
   >
     <span
       class="numerals-input"
@@ -2614,6 +2792,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="58"
   >
     <span
       class="numerals-input"
@@ -2628,6 +2807,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="59"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2649,6 +2829,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
 >
   <div
     class="numerals-line"
+    data-source-line="0"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2663,6 +2844,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="1"
   >
     <span
       class="numerals-input"
@@ -2677,6 +2859,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="2"
   >
     <span
       class="numerals-input"
@@ -2691,6 +2874,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="3"
   >
     <span
       class="numerals-input"
@@ -2705,6 +2889,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="4"
   >
     <span
       class="numerals-input"
@@ -2727,6 +2912,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="5"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2741,6 +2927,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="6"
   >
     <span
       class="numerals-input"
@@ -2755,6 +2942,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="7"
   >
     <span
       class="numerals-input"
@@ -2769,6 +2957,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="8"
   >
     <span
       class="numerals-input"
@@ -2783,6 +2972,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="9"
   >
     <span
       class="numerals-input"
@@ -2805,6 +2995,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="10"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2819,6 +3010,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="11"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2833,6 +3025,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="12"
   >
     <span
       class="numerals-input"
@@ -2847,6 +3040,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="13"
   >
     <span
       class="numerals-input"
@@ -2861,6 +3055,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="14"
   >
     <span
       class="numerals-input"
@@ -2875,6 +3070,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="15"
   >
     <span
       class="numerals-input"
@@ -2897,6 +3093,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="16"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2911,6 +3108,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="17"
   >
     <span
       class="numerals-input numerals-empty"
@@ -2925,6 +3123,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="18"
   >
     <span
       class="numerals-input"
@@ -2939,6 +3138,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="19"
   >
     <span
       class="numerals-input"
@@ -2953,6 +3153,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="20"
   >
     <span
       class="numerals-input"
@@ -2967,6 +3168,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="21"
   >
     <span
       class="numerals-input"
@@ -2986,6 +3188,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="22"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3000,6 +3203,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="23"
   >
     <span
       class="numerals-input"
@@ -3019,6 +3223,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="24"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3033,6 +3238,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="25"
   >
     <span
       class="numerals-input"
@@ -3047,6 +3253,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="26"
   >
     <span
       class="numerals-input"
@@ -3061,6 +3268,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="27"
   >
     <span
       class="numerals-input"
@@ -3075,6 +3283,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="28"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3089,6 +3298,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="29"
   >
     <span
       class="numerals-input"
@@ -3103,6 +3313,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="30"
   >
     <span
       class="numerals-input"
@@ -3117,6 +3328,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="31"
   >
     <span
       class="numerals-input"
@@ -3131,6 +3343,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="32"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3145,6 +3358,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="33"
   >
     <span
       class="numerals-input"
@@ -3159,6 +3373,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="34"
   >
     <span
       class="numerals-input"
@@ -3173,6 +3388,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="35"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3187,6 +3403,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="36"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3201,6 +3418,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="37"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3215,6 +3433,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="38"
   >
     <span
       class="numerals-input"
@@ -3229,6 +3448,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="39"
   >
     <span
       class="numerals-input"
@@ -3243,6 +3463,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="40"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3257,6 +3478,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="41"
   >
     <span
       class="numerals-input"
@@ -3271,6 +3493,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="42"
   >
     <span
       class="numerals-input"
@@ -3285,6 +3508,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="43"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3299,6 +3523,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="44"
   >
     <span
       class="numerals-input"
@@ -3313,6 +3538,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="45"
   >
     <span
       class="numerals-input"
@@ -3327,6 +3553,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="46"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3341,6 +3568,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="47"
   >
     <span
       class="numerals-input"
@@ -3355,6 +3583,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="48"
   >
     <span
       class="numerals-input"
@@ -3369,6 +3598,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="49"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3383,6 +3613,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="50"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3397,6 +3628,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="51"
   >
     <span
       class="numerals-input"
@@ -3411,6 +3643,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="52"
   >
     <span
       class="numerals-input"
@@ -3425,6 +3658,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="53"
   >
     <span
       class="numerals-input"
@@ -3439,6 +3673,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="54"
   >
     <span
       class="numerals-input"
@@ -3453,6 +3688,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="55"
   >
     <span
       class="numerals-input"
@@ -3467,6 +3703,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="56"
   >
     <span
       class="numerals-input"
@@ -3481,6 +3718,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="57"
   >
     <span
       class="numerals-input"
@@ -3495,6 +3733,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="58"
   >
     <span
       class="numerals-input"
@@ -3509,6 +3748,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="59"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3530,6 +3770,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
 >
   <div
     class="numerals-line"
+    data-source-line="0"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3544,6 +3785,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="1"
   >
     <span
       class="numerals-input"
@@ -3558,6 +3800,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="2"
   >
     <span
       class="numerals-input"
@@ -3572,6 +3815,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="3"
   >
     <span
       class="numerals-input"
@@ -3586,6 +3830,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="4"
   >
     <span
       class="numerals-input"
@@ -3608,6 +3853,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="5"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3622,6 +3868,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="6"
   >
     <span
       class="numerals-input"
@@ -3636,6 +3883,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="7"
   >
     <span
       class="numerals-input"
@@ -3650,6 +3898,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="8"
   >
     <span
       class="numerals-input"
@@ -3664,6 +3913,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="9"
   >
     <span
       class="numerals-input"
@@ -3686,6 +3936,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="10"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3700,6 +3951,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="11"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3714,6 +3966,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="12"
   >
     <span
       class="numerals-input"
@@ -3728,6 +3981,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="13"
   >
     <span
       class="numerals-input"
@@ -3742,6 +3996,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="14"
   >
     <span
       class="numerals-input"
@@ -3756,6 +4011,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="15"
   >
     <span
       class="numerals-input"
@@ -3778,6 +4034,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="16"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3792,6 +4049,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="17"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3806,6 +4064,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="18"
   >
     <span
       class="numerals-input"
@@ -3820,6 +4079,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="19"
   >
     <span
       class="numerals-input"
@@ -3834,6 +4094,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="20"
   >
     <span
       class="numerals-input"
@@ -3848,6 +4109,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="21"
   >
     <span
       class="numerals-input"
@@ -3867,6 +4129,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="22"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3881,6 +4144,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="23"
   >
     <span
       class="numerals-input"
@@ -3900,6 +4164,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="24"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3914,6 +4179,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="25"
   >
     <span
       class="numerals-input"
@@ -3928,6 +4194,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="26"
   >
     <span
       class="numerals-input"
@@ -3942,6 +4209,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="27"
   >
     <span
       class="numerals-input"
@@ -3956,6 +4224,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="28"
   >
     <span
       class="numerals-input numerals-empty"
@@ -3970,6 +4239,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="29"
   >
     <span
       class="numerals-input"
@@ -3984,6 +4254,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="30"
   >
     <span
       class="numerals-input"
@@ -3998,6 +4269,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="31"
   >
     <span
       class="numerals-input"
@@ -4012,6 +4284,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="32"
   >
     <span
       class="numerals-input numerals-empty"
@@ -4026,6 +4299,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="33"
   >
     <span
       class="numerals-input"
@@ -4040,6 +4314,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="34"
   >
     <span
       class="numerals-input"
@@ -4054,6 +4329,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="35"
   >
     <span
       class="numerals-input numerals-empty"
@@ -4068,6 +4344,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="36"
   >
     <span
       class="numerals-input numerals-empty"
@@ -4082,6 +4359,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="37"
   >
     <span
       class="numerals-input numerals-empty"
@@ -4096,6 +4374,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="38"
   >
     <span
       class="numerals-input"
@@ -4110,6 +4389,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="39"
   >
     <span
       class="numerals-input"
@@ -4124,6 +4404,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="40"
   >
     <span
       class="numerals-input numerals-empty"
@@ -4138,6 +4419,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="41"
   >
     <span
       class="numerals-input"
@@ -4152,6 +4434,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="42"
   >
     <span
       class="numerals-input"
@@ -4166,6 +4449,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="43"
   >
     <span
       class="numerals-input numerals-empty"
@@ -4180,6 +4464,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="44"
   >
     <span
       class="numerals-input"
@@ -4194,6 +4479,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="45"
   >
     <span
       class="numerals-input"
@@ -4208,6 +4494,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="46"
   >
     <span
       class="numerals-input numerals-empty"
@@ -4222,6 +4509,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="47"
   >
     <span
       class="numerals-input"
@@ -4236,6 +4524,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="48"
   >
     <span
       class="numerals-input"
@@ -4250,6 +4539,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="49"
   >
     <span
       class="numerals-input numerals-empty"
@@ -4264,6 +4554,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="50"
   >
     <span
       class="numerals-input numerals-empty"
@@ -4278,6 +4569,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="51"
   >
     <span
       class="numerals-input"
@@ -4292,6 +4584,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="52"
   >
     <span
       class="numerals-input"
@@ -4306,6 +4599,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="53"
   >
     <span
       class="numerals-input"
@@ -4320,6 +4614,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="54"
   >
     <span
       class="numerals-input"
@@ -4334,6 +4629,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="55"
   >
     <span
       class="numerals-input"
@@ -4348,6 +4644,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="56"
   >
     <span
       class="numerals-input"
@@ -4362,6 +4659,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="57"
   >
     <span
       class="numerals-input"
@@ -4376,6 +4674,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="58"
   >
     <span
       class="numerals-input"
@@ -4390,6 +4689,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="59"
   >
     <span
       class="numerals-input numerals-empty"
@@ -4411,6 +4711,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
 >
   <div
     class="numerals-line"
+    data-source-line="0"
   >
     <span
       class="numerals-input numerals-empty"
@@ -4425,6 +4726,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="1"
   >
     <span
       class="numerals-input"
@@ -4439,6 +4741,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="2"
   >
     <span
       class="numerals-input"
@@ -4453,6 +4756,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="3"
   >
     <span
       class="numerals-input"
@@ -4467,6 +4771,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="4"
   >
     <span
       class="numerals-input"
@@ -4488,6 +4793,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
 >
   <div
     class="numerals-line"
+    data-source-line="0"
   >
     <span
       class="numerals-input numerals-empty"
@@ -4502,6 +4808,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="1"
   >
     <span
       class="numerals-input"
@@ -4516,6 +4823,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="2"
   >
     <span
       class="numerals-input"
@@ -4530,6 +4838,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="3"
   >
     <span
       class="numerals-input"
@@ -4544,6 +4853,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="4"
   >
     <span
       class="numerals-input"
@@ -4558,6 +4868,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line"
+    data-source-line="5"
   >
     <span
       class="numerals-input"
@@ -4579,6 +4890,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
 >
   <div
     class="numerals-line"
+    data-source-line="0"
   >
     <span
       class="numerals-input"
@@ -4593,6 +4905,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
   </div>
   <div
     class="numerals-line numerals-emitter"
+    data-source-line="1"
   >
     <span
       class="numerals-input"

--- a/tests/clickThroughEditing.test.ts
+++ b/tests/clickThroughEditing.test.ts
@@ -89,6 +89,15 @@ describe('click-through editor navigation', () => {
 		expect(sourceChForRenderedOffset('@[profit::100] = sales - costs', 'profit = sales - costs', 100)).toBe(30);
 	});
 
+	it('should map cleaned insertion directive text back to editable source positions', () => {
+		const sourceLine = '@[profit::100] = sales - costs';
+		const renderedInputText = 'profit = sales - costs';
+
+		expect(sourceChForRenderedOffset(sourceLine, renderedInputText, 0)).toBe(2);
+		expect(sourceChForRenderedOffset(sourceLine, renderedInputText, 6)).toBe(8);
+		expect(sourceChForRenderedOffset(sourceLine, renderedInputText, 9)).toBe(17);
+	});
+
 	it('should read a text offset from a DOM caret position', () => {
 		const input = document.createElement('span');
 		input.textContent = 'apples + oranges';

--- a/tests/clickThroughEditing.test.ts
+++ b/tests/clickThroughEditing.test.ts
@@ -1,5 +1,10 @@
-import { App, MarkdownView } from 'obsidian';
-import { findEditorForPath } from '../src/rendering/editorNavigation';
+import { App, MarkdownPostProcessorContext, MarkdownView } from 'obsidian';
+import {
+	findEditorForPath,
+	getTextOffsetFromPoint,
+	handleNumeralsBlockClick,
+	sourceChForRenderedOffset,
+} from '../src/rendering/editorNavigation';
 
 type MockEditor = {
 	getLine: jest.Mock;
@@ -14,6 +19,25 @@ function createMarkdownLeaf(path: string, editor: MockEditor) {
 			editor,
 		}),
 	};
+}
+
+function createMockElement(tag: string = 'div'): HTMLElement {
+	const el = document.createElement(tag);
+	(el as any).createEl = function(
+		this: HTMLElement,
+		tagName: string,
+		options?: { text?: string; cls?: string | string[] }
+	) {
+		const child = createMockElement(tagName);
+		if (options?.text) child.textContent = options.text;
+		if (options?.cls) {
+			const classes = Array.isArray(options.cls) ? options.cls : [options.cls];
+			classes.forEach((className) => child.classList.add(className));
+		}
+		this.appendChild(child);
+		return child;
+	};
+	return el;
 }
 
 describe('click-through editor navigation', () => {
@@ -55,5 +79,129 @@ describe('click-through editor navigation', () => {
 		} as unknown as App;
 
 		expect(findEditorForPath(app, 'source.md')).toBeUndefined();
+	});
+
+	it('should map rendered offsets to exact source positions when rendered text exists in source', () => {
+		expect(sourceChForRenderedOffset('total = apples + oranges =>', 'total = apples + oranges ', 8)).toBe(8);
+	});
+
+	it('should clamp rendered offsets when source mapping is approximate', () => {
+		expect(sourceChForRenderedOffset('@[profit::100] = sales - costs', 'profit = sales - costs', 100)).toBe(30);
+	});
+
+	it('should read a text offset from a DOM caret position', () => {
+		const input = document.createElement('span');
+		input.textContent = 'apples + oranges';
+		document.body.appendChild(input);
+		const textNode = input.firstChild as Text;
+		Object.defineProperty(document, 'caretPositionFromPoint', {
+			configurable: true,
+			value: jest.fn(() => ({ offsetNode: textNode, offset: 6 })),
+		});
+
+		expect(getTextOffsetFromPoint(input, 10, 20)).toBe(6);
+
+		Reflect.deleteProperty(document, 'caretPositionFromPoint');
+		input.remove();
+	});
+
+	it('should focus the source editor at the clicked input character', () => {
+		const editor: MockEditor = {
+			getLine: jest.fn(() => 'apples + oranges'),
+			setCursor: jest.fn(),
+			focus: jest.fn(),
+		};
+		const app = {
+			workspace: {
+				iterateAllLeaves: jest.fn((callback: (leaf: unknown) => void) => {
+					callback(createMarkdownLeaf('source.md', editor));
+				}),
+			},
+		} as unknown as App;
+		const ctx = {
+			sourcePath: 'source.md',
+			getSectionInfo: jest.fn(() => ({ lineStart: 10 })),
+		} as unknown as MarkdownPostProcessorContext;
+		const block = createMockElement('div');
+		const line = block.createEl('div', { cls: 'numerals-line' });
+		line.dataset.sourceLine = '2';
+		const input = line.createEl('span', { cls: 'numerals-input', text: 'apples + oranges' });
+		line.createEl('span', { cls: 'numerals-result', text: ' -> 15' });
+		const textNode = input.firstChild as Text;
+		Object.defineProperty(document, 'caretPositionFromPoint', {
+			configurable: true,
+			value: jest.fn(() => ({ offsetNode: textNode, offset: 6 })),
+		});
+
+		const event = new MouseEvent('click', { clientX: 10, clientY: 20, bubbles: true });
+		Object.defineProperty(event, 'target', { value: input });
+
+		handleNumeralsBlockClick(event, ctx, block, app);
+
+		expect(editor.setCursor).toHaveBeenCalledWith({ line: 13, ch: 6 });
+		expect(editor.focus).toHaveBeenCalled();
+
+		Reflect.deleteProperty(document, 'caretPositionFromPoint');
+	});
+
+	it('should place the cursor at end of source line when clicking the result area', () => {
+		const editor: MockEditor = {
+			getLine: jest.fn(() => 'apples + oranges'),
+			setCursor: jest.fn(),
+			focus: jest.fn(),
+		};
+		const app = {
+			workspace: {
+				iterateAllLeaves: jest.fn((callback: (leaf: unknown) => void) => {
+					callback(createMarkdownLeaf('source.md', editor));
+				}),
+			},
+		} as unknown as App;
+		const ctx = {
+			sourcePath: 'source.md',
+			getSectionInfo: jest.fn(() => ({ lineStart: 10 })),
+		} as unknown as MarkdownPostProcessorContext;
+		const block = createMockElement('div');
+		const line = block.createEl('div', { cls: 'numerals-line' });
+		line.dataset.sourceLine = '2';
+		line.createEl('span', { cls: 'numerals-input', text: 'apples + oranges' });
+		const result = line.createEl('span', { cls: 'numerals-result', text: ' -> 15' });
+
+		const event = new MouseEvent('click', { clientX: 10, clientY: 20, bubbles: true });
+		Object.defineProperty(event, 'target', { value: result });
+
+		handleNumeralsBlockClick(event, ctx, block, app);
+
+		expect(editor.setCursor).toHaveBeenCalledWith({ line: 13, ch: 16 });
+		expect(editor.focus).toHaveBeenCalled();
+	});
+
+	it('should no-op when the clicked line has no source line index', () => {
+		const editor: MockEditor = {
+			getLine: jest.fn(() => 'apples + oranges'),
+			setCursor: jest.fn(),
+			focus: jest.fn(),
+		};
+		const app = {
+			workspace: {
+				iterateAllLeaves: jest.fn((callback: (leaf: unknown) => void) => {
+					callback(createMarkdownLeaf('source.md', editor));
+				}),
+			},
+		} as unknown as App;
+		const ctx = {
+			sourcePath: 'source.md',
+			getSectionInfo: jest.fn(() => ({ lineStart: 10 })),
+		} as unknown as MarkdownPostProcessorContext;
+		const block = createMockElement('div');
+		const line = block.createEl('div', { cls: 'numerals-line' });
+		const input = line.createEl('span', { cls: 'numerals-input', text: 'apples + oranges' });
+		const event = new MouseEvent('click', { clientX: 10, clientY: 20, bubbles: true });
+		Object.defineProperty(event, 'target', { value: input });
+
+		handleNumeralsBlockClick(event, ctx, block, app);
+
+		expect(editor.setCursor).not.toHaveBeenCalled();
+		expect(editor.focus).not.toHaveBeenCalled();
 	});
 });

--- a/tests/clickThroughEditing.test.ts
+++ b/tests/clickThroughEditing.test.ts
@@ -1,0 +1,59 @@
+import { App, MarkdownView } from 'obsidian';
+import { findEditorForPath } from '../src/rendering/editorNavigation';
+
+type MockEditor = {
+	getLine: jest.Mock;
+	setCursor: jest.Mock;
+	focus: jest.Mock;
+};
+
+function createMarkdownLeaf(path: string, editor: MockEditor) {
+	return {
+		view: Object.assign(Object.create(MarkdownView.prototype), {
+			file: { path },
+			editor,
+		}),
+	};
+}
+
+describe('click-through editor navigation', () => {
+	it('should find the editor for the requested source path', () => {
+		const wrongEditor: MockEditor = {
+			getLine: jest.fn(),
+			setCursor: jest.fn(),
+			focus: jest.fn(),
+		};
+		const rightEditor: MockEditor = {
+			getLine: jest.fn(),
+			setCursor: jest.fn(),
+			focus: jest.fn(),
+		};
+		const app = {
+			workspace: {
+				iterateAllLeaves: jest.fn((callback: (leaf: unknown) => void) => {
+					callback(createMarkdownLeaf('other.md', wrongEditor));
+					callback(createMarkdownLeaf('source.md', rightEditor));
+				}),
+			},
+		} as unknown as App;
+
+		expect(findEditorForPath(app, 'source.md')).toBe(rightEditor);
+	});
+
+	it('should return undefined when no matching editor is open', () => {
+		const editor: MockEditor = {
+			getLine: jest.fn(),
+			setCursor: jest.fn(),
+			focus: jest.fn(),
+		};
+		const app = {
+			workspace: {
+				iterateAllLeaves: jest.fn((callback: (leaf: unknown) => void) => {
+					callback(createMarkdownLeaf('other.md', editor));
+				}),
+			},
+		} as unknown as App;
+
+		expect(findEditorForPath(app, 'source.md')).toBeUndefined();
+	});
+});

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -128,6 +128,22 @@ describe('renderNumeralsBlock', () => {
 		expect(lines.length).toBe(3);
 	});
 
+	it('should attach source line indices to rendered lines', () => {
+		const evaluationResult: EvaluationResult = {
+			results: [2, 4, 6],
+			inputs: ['1 + 1', '2 + 2', '3 + 3'],
+			errorMsg: null,
+			errorInput: ''
+		};
+
+		renderNumeralsBlock(container, evaluationResult, processedBlock, context);
+
+		const lines = container.querySelectorAll<HTMLElement>('.numerals-line');
+		expect(lines[0].dataset.sourceLine).toBe('0');
+		expect(lines[1].dataset.sourceLine).toBe('1');
+		expect(lines[2].dataset.sourceLine).toBe('2');
+	});
+
 	it('should skip hidden lines', () => {
 		processedBlock.blockInfo.hidden_lines = [1];
 		const evaluationResult: EvaluationResult = {
@@ -141,6 +157,23 @@ describe('renderNumeralsBlock', () => {
 
 		const lines = container.querySelectorAll('.numerals-line');
 		expect(lines.length).toBe(2);
+	});
+
+	it('should keep source line indices when hidden lines are skipped', () => {
+		processedBlock.blockInfo.hidden_lines = [1];
+		const evaluationResult: EvaluationResult = {
+			results: [2, 4, 6],
+			inputs: ['1 + 1', '2 + 2', '3 + 3'],
+			errorMsg: null,
+			errorInput: ''
+		};
+
+		renderNumeralsBlock(container, evaluationResult, processedBlock, context);
+
+		const lines = container.querySelectorAll<HTMLElement>('.numerals-line');
+		expect(lines.length).toBe(2);
+		expect(lines[0].dataset.sourceLine).toBe('0');
+		expect(lines[1].dataset.sourceLine).toBe('2');
 	});
 
 	it('should add emitter class to emitter lines', () => {


### PR DESCRIPTION
## Summary
- Adds source-line metadata to rendered Numerals rows so visible rows map back to original math block source lines, including when rows are hidden.
- Adds click-through navigation for rendered Numerals blocks that focuses the matching source editor and places the cursor on the clicked source line/column where possible.
- Registers the click handler through `MarkdownRenderChild`, adds editability cursor styling, and documents the fix for #50 and #59.
- Improves character mapping when rendered input text omits source-only syntax such as result insertion markup.

## Validation
- `npm test` (13 suites, 357 tests)
- `npm run build`
- `npm run lint`