### PR TITLE
feat: add decimal places directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+- Added block-level `@decimalPlaces N` / `@decimalPlace N` directives for fixed decimal-place result formatting and result insertion.
+
 ## [1.10.2] - 2026-05-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -250,6 +250,19 @@ Configure how rendered numbers are displayed:
 - **Engineering**: exponent is a multiple of 3.
 - **Formatted**: choose a specific thousands/decimal style.
 
+Use `@decimalPlaces N` or `@decimalPlace N` inside a math block to show every result in that block with exactly `N` decimal places:
+
+````markdown
+```math
+@decimalPlaces 2
+subtotal = $19.995
+tax = subtotal * 8.25%
+total = subtotal + tax =>
+```
+````
+
+The directive is hidden from rendered output and also applies to result insertion values such as `@[total]`. Inline Numerals are unaffected.
+
 ## Installation
 
 Install **Numerals** from Obsidian's Community Plugins browser.

--- a/docs/decimal-places-directive.md
+++ b/docs/decimal-places-directive.md
@@ -1,0 +1,33 @@
+# Decimal Places Directive
+
+## Goal
+
+Add a block-level Numerals directive that formats displayed block results with a fixed number of decimal places without changing math evaluation.
+
+## Syntax
+
+- `@decimalPlaces N`
+- `@decimalPlace N`
+
+`N` must be a non-negative integer. Leading and trailing whitespace are allowed. The directive applies to the entire math block and is hidden from rendered output.
+If a block contains multiple valid decimal-place directives, the last valid directive wins.
+
+## Behavior
+
+- A valid directive removes its source line before mathjs evaluation.
+- Displayed results use the active block number format with an override of `notation: "fixed"` and `precision: N`.
+- Numeric units, including currency units such as `USD`, keep their unit suffix and use the requested decimal count for the numeric value.
+- Result insertion (`@[name::value]`) uses the same block-level decimal formatting when writing values back to the note.
+- Blocks without this directive keep the existing user-selected number format behavior.
+
+## Validation
+
+Invalid directives are ignored as ordinary input so failures stay visible and explicit. Examples include `@decimalPlaces`, `@decimalPlaces -1`, `@decimalPlaces 1.5`, and `@decimalPlaces two`.
+
+## Inline Numerals
+
+This directive is block-scoped only. Inline Numerals continue to use the configured global number format and do not read nearby block directives.
+
+## Future Currency Formatting
+
+This directive only sets fixed decimal places for the block. It does not add currency-specific default decimal behavior, currency rounding rules, or automatic two-decimal currency formatting.

--- a/src/numerals.types.ts
+++ b/src/numerals.types.ts
@@ -128,6 +128,7 @@ export type numeralsBlockInfo = {
 	insertion_lines: number[];
 	hidden_lines: number[];
 	shouldHideNonEmitterLines: boolean;
+	decimalPlaces?: number;
 }
 
 /****************************************************

--- a/src/numeralsUtilities.ts
+++ b/src/numeralsUtilities.ts
@@ -45,5 +45,7 @@ export {
 	htmlToElements,
 	mathjaxLoop,
 	getLocaleFormatter,
+	withFixedDecimalPlaces,
+	formatNumeralsResult,
 	defaultCurrencyMap,
 } from './rendering/displayUtils';

--- a/src/processing/preprocessor.ts
+++ b/src/processing/preprocessor.ts
@@ -39,6 +39,7 @@ export function preProcessBlockForNumeralsDirectives(
 	const insertion_lines: number[] = [];
 	const hidden_lines: number[] = [];
 	let shouldHideNonEmitterLines = false;
+	let decimalPlaces: number | undefined = undefined;
 
 	// Find emitter and result insertion lines before modifying source
 	for (let i = 0; i < rawRows.length; i++) {
@@ -64,6 +65,13 @@ export function preProcessBlockForNumeralsDirectives(
 		if (rawRows[i].match(/^\s*@createUnit\s*$/)) {
 			hidden_lines.push(i);
 		}
+
+		// Find decimal-place directives (starts with @decimalPlace or @decimalPlaces, ignoring whitespace)
+		const decimalPlacesMatch = rawRows[i].match(/^\s*@decimalPlaces?\s+(\d+)\s*$/i);
+		if (decimalPlacesMatch) {
+			hidden_lines.push(i);
+			decimalPlaces = Number(decimalPlacesMatch[1]);
+		}
 	} 
 
 	// remove `=>` at the end of lines, but preserve comments.
@@ -81,6 +89,9 @@ export function preProcessBlockForNumeralsDirectives(
 	// Remove @hideRows directive
 	processedSource = processedSource.replace(/^\s*@hideRows/gim, "");
 
+	// Remove valid decimal-place directives
+	processedSource = processedSource.replace(/^\s*@decimalPlaces?\s+\d+\s*$/gim, "");
+
 	// Apply any pre-processors (e.g. currency replacement, thousands separator replacement, etc.)
 	if (preProcessors && preProcessors.length > 0) {
 		processedSource = replaceStringsInTextFromMap(processedSource, preProcessors);
@@ -93,7 +104,8 @@ export function preProcessBlockForNumeralsDirectives(
 			emitter_lines,
 			insertion_lines,
 			hidden_lines,
-			shouldHideNonEmitterLines
+			shouldHideNonEmitterLines,
+			decimalPlaces
 		}
 	}
 }

--- a/src/renderers/BaseLineRenderer.ts
+++ b/src/renderers/BaseLineRenderer.ts
@@ -1,6 +1,6 @@
-import * as math from 'mathjs';
 import { LineRenderData, RenderContext } from '../numerals.types';
 import { renderComment } from '../rendering/linePreparation';
+import { formatNumeralsResult } from '../rendering/displayUtils';
 import { ILineRenderer } from './ILineRenderer';
 
 /**
@@ -90,7 +90,7 @@ export abstract class BaseLineRenderer implements ILineRenderer {
 	): void {
 		const formattedResult =
 			context.settings.resultSeparator +
-			math.format(lineData.result, context.numberFormat);
+			formatNumeralsResult(lineData.result, context.numberFormat);
 		resultElement.setText(formattedResult);
 	}
 }

--- a/src/rendering/displayUtils.ts
+++ b/src/rendering/displayUtils.ts
@@ -1,6 +1,6 @@
 import { finishRenderMath, renderMath, sanitizeHTMLToDom } from 'obsidian';
 import * as math from 'mathjs';
-import { CurrencyType } from '../numerals.types';
+import { CurrencyType, mathjsFormat } from '../numerals.types';
 
 const MAX_FIXED_FORMAT_LEADING_DECIMAL_ZEROES = 5;
 
@@ -158,6 +158,32 @@ export function getLocaleFormatter(
 		}
 		return formattedValue;
 	};
+}
+
+export function withFixedDecimalPlaces(
+	numberFormat: mathjsFormat,
+	decimalPlaces: number | undefined
+): mathjsFormat {
+	if (decimalPlaces === undefined) {
+		return numberFormat;
+	}
+
+	if (numberFormat && typeof numberFormat === 'object') {
+		return {
+			...numberFormat,
+			notation: 'fixed',
+			precision: decimalPlaces,
+		};
+	}
+
+	return {
+		notation: 'fixed',
+		precision: decimalPlaces,
+	};
+}
+
+export function formatNumeralsResult(result: unknown, numberFormat: mathjsFormat): string {
+	return math.format(result, numberFormat);
 }
 
 function countLeadingDecimalZeroes(value: number): number {

--- a/src/rendering/orchestrator.ts
+++ b/src/rendering/orchestrator.ts
@@ -1,4 +1,3 @@
-import * as math from 'mathjs';
 import { App, MarkdownPostProcessorContext } from 'obsidian';
 import { NumeralsLayout, NumeralsRenderStyle, NumeralsSettings, NumeralsError, NumeralsBlockResult, mathjsFormat, NumeralsScope, StringReplaceMap, ProcessedBlock, EvaluationResult, RenderContext } from '../numerals.types';
 import { RendererFactory } from '../renderers';
@@ -6,6 +5,7 @@ import { getScopeFromFrontmatter } from '../processing/scope';
 import { preProcessBlockForNumeralsDirectives } from '../processing/preprocessor';
 import { evaluateMathFromSourceStrings } from '../processing/evaluator';
 import { resolveCrossNoteReferences } from '../processing/crossNoteResolver';
+import { formatNumeralsResult, withFixedDecimalPlaces } from './displayUtils';
 import { prepareLineData } from './linePreparation';
 import { findEditorForPath } from './editorNavigation';
 
@@ -151,7 +151,7 @@ export function handleResultInsertions(
 
 		const curLine = lineStart + i + 1;
 		const sourceLine = editor.getLine(curLine);
-		const insertionValue = math.format(results[i], numberFormat);
+		const insertionValue = formatNumeralsResult(results[i], numberFormat);
 
 		// Replace @[variable] or @[variable::oldValue] with @[variable::newValue]
 		const modifiedSource = sourceLine.replace(
@@ -232,6 +232,7 @@ export function processAndRenderNumeralsBlockFromSource(
 
 	// Phase 2: Preprocess (using cross-note resolved source)
 	const processedBlock = preProcessBlockForNumeralsDirectives(crossNoteResult.resolvedSource, preProcessors);
+	const blockNumberFormat = withFixedDecimalPlaces(numberFormat, processedBlock.blockInfo.decimalPlaces);
 
 	// Phase 3: Apply block styles
 	applyBlockStyles({
@@ -259,7 +260,7 @@ export function processAndRenderNumeralsBlockFromSource(
 	handleResultInsertions(
 		evaluationResult.results,
 		processedBlock.blockInfo.insertion_lines,
-		numberFormat,
+		blockNumberFormat,
 		ctx,
 		app,
 		el
@@ -269,7 +270,7 @@ export function processAndRenderNumeralsBlockFromSource(
 	const renderContext: RenderContext = {
 		renderStyle: blockRenderStyle,
 		settings,
-		numberFormat,
+		numberFormat: blockNumberFormat,
 		preProcessors,
 	};
 

--- a/tests/numeralsUtilities.test.ts
+++ b/tests/numeralsUtilities.test.ts
@@ -16,7 +16,8 @@ const mockApp = {
 				getLine: jest.fn(),
 				setLine: jest.fn()
 			}
-		}))
+		})),
+		iterateAllLeaves: jest.fn(),
 	}
 } as any;
 
@@ -46,7 +47,7 @@ import {
 
 import * as math from 'mathjs';
 import { defaultCurrencyMap } from "../src/numeralsUtilities";
-import { MarkdownPostProcessorContext } from "obsidian";
+import { MarkdownPostProcessorContext, MarkdownView } from "obsidian";
 const currencyPreProcessors = defaultCurrencyMap.map(m => {
 	return {regex: RegExp('\\' + m.symbol + '([\\d\\.]+)','g'), replaceStr: '$1 ' + m.currency}
 })
@@ -256,6 +257,30 @@ b = 3
 		expect(result.processedSource).toEqual("# Simple math\n1 + 1\n2 * 2");
 		expect(result.blockInfo.emitter_lines).toEqual([]);
 		expect(result.blockInfo.insertion_lines).toEqual([]);
+	});
+
+	it("removes a valid decimal-place directive and records its precision", () => {
+		const sampleBlock = `@decimalPlaces 2
+1 / 3
+@decimalPlace 4
+2 / 3`;
+
+		const result = preProcessBlockForNumeralsDirectives(sampleBlock, undefined);
+
+		expect(result.processedSource).toEqual("\n1 / 3\n\n2 / 3");
+		expect(result.blockInfo.hidden_lines).toEqual([0, 2]);
+		expect((result.blockInfo as { decimalPlaces?: number }).decimalPlaces).toBe(4);
+	});
+
+	it("leaves invalid decimal-place directives as visible mathjs input", () => {
+		const sampleBlock = `@decimalPlaces two
+1 / 3`;
+
+		const result = preProcessBlockForNumeralsDirectives(sampleBlock, undefined);
+
+		expect(result.processedSource).toEqual("@decimalPlaces two\n1 / 3");
+		expect(result.blockInfo.hidden_lines).toEqual([]);
+		expect((result.blockInfo as { decimalPlaces?: number }).decimalPlaces).toBeUndefined();
 	});
 
 	it("Correctly processes block with @prev directive", () => {
@@ -890,6 +915,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 
     beforeEach(() => {
         el = document.createElement("div");
+		mockApp.workspace.iterateAllLeaves.mockReset();
 		Object.defineProperty(HTMLElement.prototype, 'toggleClass', {
 			value: function(className: string, value: boolean) {
 				if (value) this.classList.add(className);
@@ -941,6 +967,10 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
         numberFormat = getLocaleFormatter();
     });
 
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
 	const resultSeparator = DEFAULT_SETTINGS.resultSeparator;
 
     it("renders a simple math block correctly", () => {
@@ -952,6 +982,68 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
         expect(lines[0].textContent).toContain(`1 + 1${resultSeparator}2`);
         expect(lines[1].textContent).toContain(`2 * 2${resultSeparator}4`);
     });
+
+	it("hides @decimalPlaces and formats normal results with exactly two decimals", () => {
+		source = "@decimalPlaces 2\n1 / 3\n2";
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+
+		const lines = el.querySelectorAll(".numerals-line");
+		expect(lines.length).toBe(2);
+		expect(el.textContent).not.toContain("@decimalPlaces");
+		expect(lines[0].textContent).toContain(`1 / 3${resultSeparator}0.33`);
+		expect(lines[1].textContent).toContain(`2${resultSeparator}2.00`);
+	});
+
+	it("formats currency values with the requested decimal count inside the block", () => {
+		source = "@decimalPlaces 3\n$5.5 / 2";
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+
+		const lines = el.querySelectorAll(".numerals-line");
+		expect(lines.length).toBe(1);
+		expect(lines[0].textContent).toContain(`$5.5 / 2${resultSeparator}2.750 USD`);
+	});
+
+	it("uses block-level decimal formatting when inserting results", () => {
+		jest.useFakeTimers();
+		const mockEditor = {
+			getLine: jest.fn().mockReturnValue("@[answer] = 1 / 3"),
+			setLine: jest.fn(),
+		};
+		mockApp.workspace.iterateAllLeaves.mockImplementation((callback: (leaf: unknown) => void) => {
+			callback({
+				view: Object.assign(Object.create(MarkdownView.prototype), {
+					file: { path: "test.md" },
+					editor: mockEditor,
+				}),
+			});
+		});
+		(ctx as unknown as { getSectionInfo: jest.Mock; sourcePath: string }).sourcePath = "test.md";
+		(ctx.getSectionInfo as jest.Mock).mockReturnValue({ lineStart: 10 });
+
+		source = "@decimalPlaces 2\n@[answer] = 1 / 3";
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		jest.runAllTimers();
+
+		expect(mockEditor.setLine).toHaveBeenCalledWith(12, "@[answer::0.33] = 1 / 3");
+	});
+
+	it("surfaces invalid decimal-place directives as mathjs errors", () => {
+		source = "@decimalPlaces two\n1 / 3";
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+
+		expect(el.querySelector(".numerals-error-line")).not.toBeNull();
+		expect(el.textContent).toContain("@decimalPlaces two");
+	});
+
+	it("keeps existing formatting for blocks without the directive", () => {
+		source = "2";
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+
+		const lines = el.querySelectorAll(".numerals-line");
+		expect(lines.length).toBe(1);
+		expect(lines[0].textContent).toContain(`2${resultSeparator}2`);
+		expect(lines[0].textContent).not.toContain("2.00");
+	});
 
     it("renders a block with emitter lines correctly", () => {
         source = "1 + 1 =>\n2 * 2 =>";


### PR DESCRIPTION
## Summary
- Add block-level `@decimalPlaces N` / `@decimalPlace N` directives for fixed decimal-place result formatting.
- Hide valid directive lines before evaluation and leave invalid directives visible so mathjs surfaces the error.
- Apply the block formatter to rendered results and result insertion values, including currency units.

## Tests
- `npm test -- tests/numeralsUtilities.test.ts --runInBand`
- `npm test -- --runInBand`
- `npm run build`
- `npm run lint`