### PR TITLE
fix: format pure currency results with cents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+- Pure currency results now default to two decimal places while compound currency rates keep existing precision behavior.
+
 ## [1.10.2] - 2026-05-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 | Show-your-work equations | `` `#=: 2 * (3ft + 4ft)` `` -> `2 * (3 ft + 4 ft) = 14 ft` |
 | Full math blocks | <code>```math<br>20 mi / 4 hr to m/s<br>```</code> -> `2.235 m / s` |
 | Units and conversions | `100 km/hr in mi/hr` -> `62.137 mi / hr` |
-| Currency math | `$100/hr * 3 days` -> `7,200 USD` |
+| Currency math | `$100/hr * 3 days` -> `7,200.00 USD` |
 | Note-wide variables | `$rate = $150/hr`, then `` `#: $rate * 40hr` `` |
 | Cross-note references | `[[Client Settings]].rates.hourly * 8hr` |
-| Result insertion | `@[profit] = revenue - expenses` writes `@[profit::10 USD]` |
+| Result insertion | `@[profit] = revenue - expenses` writes `@[profit::10.00 USD]` |
 
 ## Quick Start
 
@@ -84,8 +84,8 @@ Numerals uses [mathjs](https://mathjs.org/) for calculations and adds Obsidian-f
 | --- | --- |
 | Units | `1ft + 12in` -> `2 ft` |
 | Conversions | `72 degF to degC` -> `22.222 degC` |
-| Currency | `$1,000 * 2` -> `2,000 USD` |
-| Rates | `$100/hr * 3 days` -> `7,200 USD` |
+| Currency | `$1,000 * 2` -> `2,000.00 USD` |
+| Rates | `$100/hr * 3 days` -> `7,200.00 USD` |
 | Functions | `sqrt(144)`, `sin(pi/2)`, `log(1000, 10)` |
 | Bases | `0xff + 0b100` -> `259` |
 | Fractions | `fraction(1/3) + fraction(1/4)` -> `7/12` |

--- a/docs/currency-fixed-formatting.md
+++ b/docs/currency-fixed-formatting.md
@@ -1,0 +1,62 @@
+# Currency Fixed Formatting Spec
+
+## Goal
+
+Pure currency results should display with exactly two decimal places by default, without changing how Numerals evaluates expressions. Examples:
+
+- `$120` displays as `120.00 USD`
+- `$120.1` displays as `120.10 USD`
+- `$120.3499` displays as `120.35 USD`
+
+This is result-formatting behavior only. Numerals still uses mathjs for evaluation and still creates mathjs units for configured currency codes.
+
+## Detection
+
+Currency fixed formatting applies only when the evaluated value is a mathjs `Unit` that is a pure configured currency:
+
+- The result is a mathjs Unit.
+- The Unit has exactly one unit component.
+- The component power is `1`.
+- The component unit name is one of the active currency codes Numerals created from the currency map.
+
+Currency codes must come from the active Numerals currency configuration, including `$` and `¥` remappings and custom currency mappings. The formatter must not hard-code USD-only behavior.
+
+## Compound Units
+
+Compound currency units keep existing number-format behavior. Examples:
+
+- `$100/hr`
+- `$0.042/floz`
+- `USD / m^2`
+
+These values often represent rates where useful precision is not the same as money display precision. Formatting them to two fixed decimals by default could destroy information, so the helper should leave them to the selected Numerals number format.
+
+## Shared Formatting Helper
+
+Introduce a shared helper around `math.format`, for example:
+
+```ts
+formatNumeralsResult(value, numberFormat, currencyUnitNames)
+```
+
+The helper is responsible for:
+
+- Detecting pure configured currency Units.
+- Applying two fixed decimals only to pure currency Units.
+- Delegating every other value to existing `math.format(value, numberFormat)` behavior.
+- Preserving selected locale/grouping behavior when the active formatter provides it.
+
+No mathjs internals should be monkey-patched for this formatting behavior.
+
+## Rendering Surfaces
+
+The shared helper should be used anywhere Numerals displays or writes evaluated results:
+
+- Plain and syntax-highlight block rendering through the shared base renderer.
+- Result insertion via `@[name::result]`.
+- Inline Numerals in Reading mode and Live Preview via inline evaluation.
+- TeX result rendering should use the same pure-currency numeric rounding before converting the result to TeX, while continuing to avoid locale grouping because the TeX path reparses the formatted result.
+
+## Future Decimal-Place Directive
+
+This feature is independent of any future `@decimalPlaces` directive. If that directive is added later, it should become an explicit display override. Until then, pure configured currency results default to two decimals, and non-currency or compound-unit results keep the current selected number-format behavior.

--- a/src/inline/inlineEvaluator.ts
+++ b/src/inline/inlineEvaluator.ts
@@ -3,6 +3,9 @@ import { App } from 'obsidian';
 import { NumeralsScope, NumeralsSettings, mathjsFormat, StringReplaceMap, InlineEvaluationResult } from '../numerals.types';
 import { replaceStringsInTextFromMap } from '../processing/preprocessor';
 import { resolveCrossNoteReferences } from '../processing/crossNoteResolver';
+import { defaultCurrencyMap, formatNumeralsResult } from '../rendering/displayUtils';
+
+const defaultCurrencyUnitNames = new Set(defaultCurrencyMap.map(m => m.currency).filter(Boolean));
 
 /**
  * Evaluate a single inline expression against a scope.
@@ -33,6 +36,7 @@ export function evaluateInlineExpression(
 	app?: App,
 	sourcePath?: string,
 	settings?: NumeralsSettings,
+	currencyUnitNames: ReadonlySet<string> = defaultCurrencyUnitNames,
 ): InlineEvaluationResult {
 	// Resolve cross-note references before preprocessing
 	let processed = expression;
@@ -76,9 +80,7 @@ export function evaluateInlineExpression(
 		throw new Error('Expression produced no result');
 	}
 
-	const formatted = numberFormat !== undefined
-		? math.format(result, numberFormat)
-		: math.format(result);
+	const formatted = formatNumeralsResult(result, numberFormat, currencyUnitNames);
 
 	// Extract note-global ($-prefixed) variable assignments.
 	// Compare the local scope against the original to find new or changed $-keys.

--- a/src/inline/inlineLivePreview.ts
+++ b/src/inline/inlineLivePreview.ts
@@ -47,6 +47,9 @@ import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing
 import { parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
 import { getDataviewApi } from '../dataview';
+import { defaultCurrencyMap } from '../rendering/displayUtils';
+
+const defaultCurrencyUnitNames = new Set(defaultCurrencyMap.map(m => m.currency).filter(Boolean));
 
 /****************************************************
  * Formatting context helpers
@@ -224,6 +227,7 @@ interface DecorationContext {
 	equationTrigger: string;
 	numberFormat: mathjsFormat | undefined;
 	preProcessors: StringReplaceMap[];
+	currencyUnitNames: ReadonlySet<string>;
 	getScope: () => NumeralsScope;
 	scopeCache: Map<string, NumeralsScope>;
 	filePath: string;
@@ -239,6 +243,7 @@ function createDecorationContext(
 	getSettings: () => NumeralsSettings,
 	getNumberFormat: () => mathjsFormat | undefined,
 	preProcessors: StringReplaceMap[],
+	currencyUnitNames: ReadonlySet<string>,
 	scopeCache: Map<string, NumeralsScope>,
 	app: App,
 	filePath: string,
@@ -278,6 +283,7 @@ function createDecorationContext(
 		equationTrigger,
 		numberFormat: getNumberFormat(),
 		preProcessors,
+		currencyUnitNames,
 		getScope,
 		scopeCache,
 		filePath,
@@ -336,6 +342,7 @@ function tryBuildNodeDecoration(
 			ctx.app,
 			ctx.filePath,
 			ctx.settings,
+			ctx.currencyUnitNames,
 		);
 		resultText = result.formatted;
 		prevResultRef.value = result.raw;
@@ -522,6 +529,7 @@ export function createInlineLivePreviewExtension(
 	getPreProcessors: () => StringReplaceMap[],
 	scopeCache: Map<string, NumeralsScope>,
 	app: App,
+	getCurrencyUnitNames: () => ReadonlySet<string> = () => defaultCurrencyUnitNames,
 ) {
 	return ViewPlugin.fromClass(
 		class InlineNumeralsViewPlugin {
@@ -635,6 +643,7 @@ export function createInlineLivePreviewExtension(
 					getSettings,
 					getNumberFormat,
 					getPreProcessors(),
+					getCurrencyUnitNames(),
 					scopeCache,
 					app,
 					filePath,

--- a/src/inline/inlinePostProcessor.ts
+++ b/src/inline/inlinePostProcessor.ts
@@ -4,6 +4,9 @@ import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing
 import { parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
 import { getDataviewApi } from '../dataview';
+import { defaultCurrencyMap } from '../rendering/displayUtils';
+
+const defaultCurrencyUnitNames = new Set(defaultCurrencyMap.map(m => m.currency).filter(Boolean));
 
 /**
  * Write `$`-prefixed globals to the shared scope cache.
@@ -113,7 +116,8 @@ function processInlineCodeElement(
 	prevResultRef: PrevResultRef,
 	scopeCache: Map<string, NumeralsScope>,
 	sourcePath: string,
-	app: App
+	app: App,
+	currencyUnitNames: ReadonlySet<string>
 ): InlineProcessingResult {
 	const text = codeEl.dataset.numeralsInlineSource ?? codeEl.innerText;
 
@@ -137,6 +141,7 @@ function processInlineCodeElement(
 			app,
 			sourcePath,
 			settings,
+			currencyUnitNames,
 		);
 		prevResultRef.value = result.raw;
 
@@ -183,7 +188,8 @@ export function createInlineNumeralsPostProcessor(
 	getSettings: () => NumeralsSettings,
 	getNumberFormat: () => mathjsFormat,
 	getPreProcessors: () => StringReplaceMap[],
-	scopeCache: Map<string, NumeralsScope>
+	scopeCache: Map<string, NumeralsScope>,
+	getCurrencyUnitNames: () => ReadonlySet<string> = () => defaultCurrencyUnitNames
 ): (el: HTMLElement, ctx: MarkdownPostProcessorContext) => void {
 	return (el: HTMLElement, ctx: MarkdownPostProcessorContext): void => {
 		const settings = getSettings();
@@ -223,6 +229,7 @@ export function createInlineNumeralsPostProcessor(
 			);
 
 			const numberFormat = getNumberFormat();
+			const currencyUnitNames = getCurrencyUnitNames();
 
 			// Track previous result for @prev support.
 			// Resets per section (post-processor call), so @prev only chains
@@ -241,7 +248,8 @@ export function createInlineNumeralsPostProcessor(
 					prevResultRef,
 					scopeCache,
 					ctx.sourcePath,
-					app
+					app,
+					currencyUnitNames
 				);
 				for (const path of result.referencedPaths) {
 					referencedPaths.add(path);

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,7 +123,8 @@ export default class NumeralsPlugin extends Plugin {
 			this.settings,
 			this.numberFormat,
 			this.preProcessors,
-			this.app
+			this.app,
+			this.getCurrencyUnitNames()
 		);
 
 		addGlobalsFromScopeToPageCache(ctx.sourcePath, blockResult.scope, this.scopeCache);
@@ -160,7 +161,8 @@ export default class NumeralsPlugin extends Plugin {
 				this.settings,
 				this.numberFormat,
 				this.preProcessors,
-				this.app
+				this.app,
+				this.getCurrencyUnitNames()
 			);
 
 			addGlobalsFromScopeToPageCache(ctx.sourcePath, blockResult.scope, this.scopeCache);
@@ -229,6 +231,10 @@ export default class NumeralsPlugin extends Plugin {
 		this.updatePreProcessors();
 	}
 
+	private getCurrencyUnitNames(): ReadonlySet<string> {
+		return new Set(this.currencyMap.map(m => m.currency).filter(Boolean));
+	}
+
 	private updatePreProcessors() {
 		const currencyPreProcessors = this.currencyMap.map(m => {
 			return {regex: RegExp('\\' + m.symbol + '([\\d\\.]+)','g'), replaceStr: '$1 ' + m.currency}
@@ -280,7 +286,8 @@ export default class NumeralsPlugin extends Plugin {
 				() => this.settings,
 				() => this.numberFormat,
 				() => this.preProcessors,
-				this.scopeCache
+				this.scopeCache,
+				() => this.getCurrencyUnitNames()
 			)
 		);
 
@@ -291,7 +298,8 @@ export default class NumeralsPlugin extends Plugin {
 				() => this.numberFormat,
 				() => this.preProcessors,
 				this.scopeCache,
-				this.app
+				this.app,
+				() => this.getCurrencyUnitNames()
 			)
 		);
 

--- a/src/numerals.types.ts
+++ b/src/numerals.types.ts
@@ -196,6 +196,8 @@ export interface RenderContext {
 	settings: NumeralsSettings;
 	/** Number formatting configuration for displaying results */
 	numberFormat: mathjsFormat;
+	/** Active mathjs currency unit names created by Numerals */
+	currencyUnitNames: ReadonlySet<string>;
 	/** String replacements to apply (e.g., currency symbols) */
 	preProcessors: StringReplaceMap[];
 }

--- a/src/numeralsUtilities.ts
+++ b/src/numeralsUtilities.ts
@@ -45,5 +45,7 @@ export {
 	htmlToElements,
 	mathjaxLoop,
 	getLocaleFormatter,
+	formatNumeralsResult,
+	isPureCurrencyUnit,
 	defaultCurrencyMap,
 } from './rendering/displayUtils';

--- a/src/renderers/BaseLineRenderer.ts
+++ b/src/renderers/BaseLineRenderer.ts
@@ -1,6 +1,6 @@
-import * as math from 'mathjs';
 import { LineRenderData, RenderContext } from '../numerals.types';
 import { renderComment } from '../rendering/linePreparation';
+import { formatNumeralsResult } from '../rendering/displayUtils';
 import { ILineRenderer } from './ILineRenderer';
 
 /**
@@ -90,7 +90,11 @@ export abstract class BaseLineRenderer implements ILineRenderer {
 	): void {
 		const formattedResult =
 			context.settings.resultSeparator +
-			math.format(lineData.result, context.numberFormat);
+			formatNumeralsResult(
+				lineData.result,
+				context.numberFormat,
+				context.currencyUnitNames
+			);
 		resultElement.setText(formattedResult);
 	}
 }

--- a/src/renderers/TeXRenderer.ts
+++ b/src/renderers/TeXRenderer.ts
@@ -7,6 +7,8 @@ import {
 	mathjaxLoop,
 	replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw,
 	getLocaleFormatter,
+	formatNumeralsResult,
+	isPureCurrencyUnit,
 } from '../rendering/displayUtils';
 
 /**
@@ -108,9 +110,10 @@ export class TeXRenderer extends BaseLineRenderer {
 		context: RenderContext
 	): void {
 		// Format result to string with reasonable precision, no grouping
-		let processedResult = math.format(
+		let processedResult = formatNumeralsResult(
 			lineData.result,
-			getLocaleFormatter('en-US', { useGrouping: false })
+			getLocaleFormatter('en-US', { useGrouping: false }),
+			context.currencyUnitNames
 		);
 
 		// Apply preprocessors (reverse currency transformations for parsing)
@@ -119,7 +122,9 @@ export class TeXRenderer extends BaseLineRenderer {
 		}
 
 		// Convert to TeX
-		let texResult = math.parse(processedResult).toTex();
+		let texResult = isPureCurrencyUnit(lineData.result, context.currencyUnitNames)
+			? processedResult.replace(/^(.+)\s+([A-Z]{3})$/u, '$1~\\mathrm{$2}')
+			: math.parse(processedResult).toTex();
 		texResult = texCurrencyReplacement(texResult);
 
 		// Render with MathJax

--- a/src/rendering/displayUtils.ts
+++ b/src/rendering/displayUtils.ts
@@ -1,6 +1,6 @@
 import { finishRenderMath, renderMath, sanitizeHTMLToDom } from 'obsidian';
 import * as math from 'mathjs';
-import { CurrencyType } from '../numerals.types';
+import { CurrencyType, mathjsFormat } from '../numerals.types';
 
 const MAX_FIXED_FORMAT_LEADING_DECIMAL_ZEROES = 5;
 
@@ -86,6 +86,8 @@ export const defaultCurrencyMap: CurrencyType[] = [
 	{	symbol: "₹", unicode: "x20B9",	name: "rupee", 	currency: "INR"}	
 ];
 
+const defaultCurrencyUnitNames = new Set(defaultCurrencyMap.map(m => m.currency).filter(Boolean));
+
 const currencyTexReplacements = defaultCurrencyMap.map(m => ({
 	regex: new RegExp('\\\\*\\' + m.symbol, 'g'),
 	replacement: '\\' + m.name + ' ',
@@ -158,6 +160,95 @@ export function getLocaleFormatter(
 		}
 		return formattedValue;
 	};
+}
+
+interface MathjsUnitWithComponents {
+	units: math.Unit['units'];
+	value: number;
+}
+
+export function isPureCurrencyUnit(
+	value: unknown,
+	currencyUnitNames: ReadonlySet<string> = defaultCurrencyUnitNames
+): value is MathjsUnitWithComponents {
+	if (!math.isUnit(value)) {
+		return false;
+	}
+
+	const unitValue = value as MathjsUnitWithComponents;
+	if (unitValue.units.length !== 1) {
+		return false;
+	}
+
+	const [component] = unitValue.units;
+	return component.power === 1 && currencyUnitNames.has(component.unit.name);
+}
+
+export function formatNumeralsResult(
+	value: unknown,
+	numberFormat: mathjsFormat,
+	currencyUnitNames: ReadonlySet<string> = defaultCurrencyUnitNames
+): string {
+	if (isPureCurrencyUnit(value, currencyUnitNames)) {
+		return math.format(value, getCurrencyNumberFormat(numberFormat));
+	}
+
+	return numberFormat !== undefined
+		? math.format(value, numberFormat)
+		: math.format(value);
+}
+
+function getCurrencyNumberFormat(numberFormat: mathjsFormat): mathjsFormat {
+	if (typeof numberFormat === 'function') {
+		return (value: unknown): string => {
+			if (typeof value === 'number') {
+				return formatNumberWithTwoDecimals(value, numberFormat);
+			}
+			return math.format(value);
+		};
+	}
+
+	return { notation: 'fixed', precision: 2 };
+}
+
+function formatNumberWithTwoDecimals(
+	value: number,
+	baseFormatter: (value: number) => string
+): string {
+	if (!Number.isFinite(value)) {
+		return baseFormatter(value);
+	}
+
+	const roundedValue = roundToTwoDecimalPlaces(value);
+	const formattedValue = baseFormatter(roundedValue);
+	if (/[eE][+-]?\d+$/.test(formattedValue)) {
+		return roundedValue.toFixed(2);
+	}
+
+	const decimalSeparator = getDecimalSeparator(baseFormatter);
+	const decimalIndex = formattedValue.lastIndexOf(decimalSeparator);
+	if (decimalIndex === -1) {
+		return `${formattedValue}${decimalSeparator}00`;
+	}
+
+	const fractionDigits = formattedValue.length - decimalIndex - decimalSeparator.length;
+	if (fractionDigits === 0) {
+		return `${formattedValue}00`;
+	}
+	if (fractionDigits === 1) {
+		return `${formattedValue}0`;
+	}
+	return formattedValue;
+}
+
+function roundToTwoDecimalPlaces(value: number): number {
+	return Math.round((value + Math.sign(value) * Number.EPSILON) * 100) / 100;
+}
+
+function getDecimalSeparator(formatter: (value: number) => string): string {
+	const formatted = formatter(1.1);
+	const match = formatted.match(/1(\D+)1/u);
+	return match?.[1] ?? '.';
 }
 
 function countLeadingDecimalZeroes(value: number): number {

--- a/src/rendering/orchestrator.ts
+++ b/src/rendering/orchestrator.ts
@@ -1,4 +1,3 @@
-import * as math from 'mathjs';
 import { App, MarkdownPostProcessorContext } from 'obsidian';
 import { NumeralsLayout, NumeralsRenderStyle, NumeralsSettings, NumeralsError, NumeralsBlockResult, mathjsFormat, NumeralsScope, StringReplaceMap, ProcessedBlock, EvaluationResult, RenderContext } from '../numerals.types';
 import { RendererFactory } from '../renderers';
@@ -8,6 +7,9 @@ import { evaluateMathFromSourceStrings } from '../processing/evaluator';
 import { resolveCrossNoteReferences } from '../processing/crossNoteResolver';
 import { prepareLineData } from './linePreparation';
 import { findEditorForPath } from './editorNavigation';
+import { defaultCurrencyMap, formatNumeralsResult } from './displayUtils';
+
+const defaultCurrencyUnitNames = new Set(defaultCurrencyMap.map(m => m.currency).filter(Boolean));
 
 /**
  * Renders error information into the container element.
@@ -127,7 +129,8 @@ export function handleResultInsertions(
 	numberFormat: mathjsFormat,
 	ctx: MarkdownPostProcessorContext,
 	app: App,
-	el: HTMLElement
+	el: HTMLElement,
+	currencyUnitNames: ReadonlySet<string> = defaultCurrencyUnitNames
 ): void {
 	for (const i of insertionLines) {
 		const sectionInfo = ctx.getSectionInfo(el);
@@ -151,7 +154,11 @@ export function handleResultInsertions(
 
 		const curLine = lineStart + i + 1;
 		const sourceLine = editor.getLine(curLine);
-		const insertionValue = math.format(results[i], numberFormat);
+		const insertionValue = formatNumeralsResult(
+			results[i],
+			numberFormat,
+			currencyUnitNames
+		);
 
 		// Replace @[variable] or @[variable::oldValue] with @[variable::newValue]
 		const modifiedSource = sourceLine.replace(
@@ -203,7 +210,8 @@ export function processAndRenderNumeralsBlockFromSource(
 	settings: NumeralsSettings,
 	numberFormat: mathjsFormat,
 	preProcessors: StringReplaceMap[],
-	app: App
+	app: App,
+	currencyUnitNames: ReadonlySet<string> = defaultCurrencyUnitNames
 ): NumeralsBlockResult {
 
 	// Phase 1: Determine render style
@@ -262,7 +270,8 @@ export function processAndRenderNumeralsBlockFromSource(
 		numberFormat,
 		ctx,
 		app,
-		el
+		el,
+		currencyUnitNames
 	);
 
 	// Phase 7: Render
@@ -270,6 +279,7 @@ export function processAndRenderNumeralsBlockFromSource(
 		renderStyle: blockRenderStyle,
 		settings,
 		numberFormat,
+		currencyUnitNames,
 		preProcessors,
 	};
 

--- a/tests/__snapshots__/numeralsUtilities.test.ts.snap
+++ b/tests/__snapshots__/numeralsUtilities.test.ts.snap
@@ -114,7 +114,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 10 USD
+       → 10.00 USD
     </span>
   </div>
   <div
@@ -129,7 +129,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20 USD
+       → 20.00 USD
     </span>
   </div>
   <div
@@ -144,7 +144,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 30 USD
+       → 30.00 USD
     </span>
   </div>
   <div
@@ -167,7 +167,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 60 USD
+       → 60.00 USD
     </span>
   </div>
   <div
@@ -425,7 +425,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 100,000 USD
+       → 100,000.00 USD
     </span>
   </div>
   <div
@@ -455,7 +455,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20,000 USD
+       → 20,000.00 USD
     </span>
   </div>
   <div
@@ -875,7 +875,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 1,100 USD
+       → 1,100.00 USD
     </span>
   </div>
   <div
@@ -1055,7 +1055,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 10 USD
+       → 10.00 USD
     </span>
   </div>
   <div
@@ -1070,7 +1070,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20 USD
+       → 20.00 USD
     </span>
   </div>
   <div
@@ -1085,7 +1085,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 30 USD
+       → 30.00 USD
     </span>
   </div>
   <div
@@ -1108,7 +1108,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 60 USD
+       → 60.00 USD
     </span>
   </div>
   <div
@@ -1366,7 +1366,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 100,000 USD
+       → 100,000.00 USD
     </span>
   </div>
   <div
@@ -1396,7 +1396,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20,000 USD
+       → 20,000.00 USD
     </span>
   </div>
   <div
@@ -1816,7 +1816,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 1,100 USD
+       → 1,100.00 USD
     </span>
   </div>
   <div
@@ -1996,7 +1996,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 10 USD
+       → 10.00 USD
     </span>
   </div>
   <div
@@ -2011,7 +2011,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20 USD
+       → 20.00 USD
     </span>
   </div>
   <div
@@ -2026,7 +2026,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 30 USD
+       → 30.00 USD
     </span>
   </div>
   <div
@@ -2049,7 +2049,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 60 USD
+       → 60.00 USD
     </span>
   </div>
   <div
@@ -2307,7 +2307,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 100,000 USD
+       → 100,000.00 USD
     </span>
   </div>
   <div
@@ -2337,7 +2337,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20,000 USD
+       → 20,000.00 USD
     </span>
   </div>
   <div
@@ -2757,7 +2757,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 1,100 USD
+       → 1,100.00 USD
     </span>
   </div>
   <div
@@ -2937,7 +2937,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 10 USD
+       → 10.00 USD
     </span>
   </div>
   <div
@@ -2952,7 +2952,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20 USD
+       → 20.00 USD
     </span>
   </div>
   <div
@@ -2967,7 +2967,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 30 USD
+       → 30.00 USD
     </span>
   </div>
   <div
@@ -2990,7 +2990,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 60 USD
+       → 60.00 USD
     </span>
   </div>
   <div
@@ -3248,7 +3248,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 100,000 USD
+       → 100,000.00 USD
     </span>
   </div>
   <div
@@ -3278,7 +3278,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20,000 USD
+       → 20,000.00 USD
     </span>
   </div>
   <div
@@ -3698,7 +3698,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 1,100 USD
+       → 1,100.00 USD
     </span>
   </div>
   <div
@@ -3878,7 +3878,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 10 USD
+       → 10.00 USD
     </span>
   </div>
   <div
@@ -3893,7 +3893,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20 USD
+       → 20.00 USD
     </span>
   </div>
   <div
@@ -3908,7 +3908,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 30 USD
+       → 30.00 USD
     </span>
   </div>
   <div
@@ -3931,7 +3931,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 60 USD
+       → 60.00 USD
     </span>
   </div>
   <div
@@ -4189,7 +4189,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 100,000 USD
+       → 100,000.00 USD
     </span>
   </div>
   <div
@@ -4219,7 +4219,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20,000 USD
+       → 20,000.00 USD
     </span>
   </div>
   <div
@@ -4639,7 +4639,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 1,100 USD
+       → 1,100.00 USD
     </span>
   </div>
   <div
@@ -4900,7 +4900,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 1,100 USD
+       → 1,100.00 USD
     </span>
   </div>
   <div
@@ -4915,7 +4915,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 110 USD
+       → 110.00 USD
     </span>
   </div>
 </div>

--- a/tests/inline.test.ts
+++ b/tests/inline.test.ts
@@ -291,6 +291,24 @@ describe('evaluateInlineExpression', () => {
 			expect(result.formatted).toContain('USD');
 		});
 
+		it('should format pure currency results with exactly two decimals', () => {
+			const evaluate = evaluateInlineExpression as (...args: unknown[]) => ReturnType<typeof evaluateInlineExpression>;
+
+			const result = evaluate(
+				'$120.1',
+				emptyScope,
+				defaultFormat,
+				preProcessors,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				new Set(['USD'])
+			);
+
+			expect(result.formatted).toBe('120.10 USD');
+		});
+
 		it('should evaluate "€50 + €25" with EUR currency', () => {
 			const result = evaluateInlineExpression('€50 + €25', emptyScope, defaultFormat, preProcessors);
 			expect(result.formatted).toContain('75');

--- a/tests/numeralsUtilities.test.ts
+++ b/tests/numeralsUtilities.test.ts
@@ -982,7 +982,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 
         const lines = el.querySelectorAll(".numerals-line");
         expect(lines.length).toBe(1);
-        expect(lines[0].textContent).toContain(`$100 + $1,000${resultSeparator}1,100 USD`);
+        expect(lines[0].textContent).toContain(`$100 + $1,000${resultSeparator}1,100.00 USD`);
     });
 
     it("handles errors in math expressions gracefully", () => {
@@ -1010,8 +1010,8 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
 		const lines = el.querySelectorAll(".numerals-line");
 		expect(lines.length).toBe(2);
-		expect(lines[0].textContent).toContain(`amount = 100 USD + $1,000${resultSeparator}1,100 USD`);
-		expect(lines[1].textContent).toContain(`tax = 10% * amount${resultSeparator}110 USD`);
+		expect(lines[0].textContent).toContain(`amount = 100 USD + $1,000${resultSeparator}1,100.00 USD`);
+		expect(lines[1].textContent).toContain(`tax = 10% * amount${resultSeparator}110.00 USD`);
 
 		expect(el).toMatchSnapshot();
 	});
@@ -1036,10 +1036,10 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 		expect(lines[3].textContent).toContain(`grapes = 10${resultSeparator}10`);
 		expect(lines[4].textContent).toContain(`fruit = @sum${resultSeparator}17`);
 		expect(lines[5].textContent).toContain(`# Money`);
-		expect(lines[6].textContent).toContain(`monday = $10${resultSeparator}10 USD`);
-		expect(lines[7].textContent).toContain(`tuesday = $20${resultSeparator}20 USD`);
-		expect(lines[8].textContent).toContain(`wednesday = $30${resultSeparator}30 USD`);
-		expect(lines[9].textContent).toContain(`profit = @total${resultSeparator}60 USD`);
+		expect(lines[6].textContent).toContain(`monday = $10${resultSeparator}10.00 USD`);
+		expect(lines[7].textContent).toContain(`tuesday = $20${resultSeparator}20.00 USD`);
+		expect(lines[8].textContent).toContain(`wednesday = $30${resultSeparator}30.00 USD`);
+		expect(lines[9].textContent).toContain(`profit = @total${resultSeparator}60.00 USD`);
 	});
 
     it("renders only result-annotated rows when @hideRows is used", () => {

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -110,6 +110,7 @@ describe('renderNumeralsBlock', () => {
 			renderStyle: NumeralsRenderStyle.Plain,
 			settings,
 			numberFormat: math.format,
+			currencyUnitNames: new Set(['USD']),
 			preProcessors: []
 		};
 	});

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -33,9 +33,18 @@ import {
 	DEFAULT_SETTINGS,
 } from '../src/numerals.types';
 import { getLocaleFormatter } from '../src/numeralsUtilities';
+import * as math from 'mathjs';
 
 // Mock Obsidian DOM methods
 beforeAll(() => {
+	for (const unit of ['USD', 'CAD']) {
+		try {
+			math.createUnit(unit, { aliases: [unit.toLowerCase()] });
+		} catch {
+			/* unit already exists */
+		}
+	}
+
 	Object.defineProperty(HTMLElement.prototype, 'createEl', {
 		value: jest.fn(function (this: HTMLElement, tag, options) {
 			const element = document.createElement(tag);
@@ -81,6 +90,7 @@ describe('Renderer Implementations', () => {
 			renderStyle: NumeralsRenderStyle.Plain,
 			settings: DEFAULT_SETTINGS,
 			numberFormat: getLocaleFormatter(),
+			currencyUnitNames: new Set(['USD', 'CAD']),
 			preProcessors: [],
 		};
 	});
@@ -191,6 +201,98 @@ describe('Renderer Implementations', () => {
 			const totalElement = container.querySelector('.numerals-sum');
 			expect(totalElement).not.toBeNull();
 			expect(totalElement?.textContent).toBe('@total');
+		});
+
+		it.each([
+			['120 USD', '120.00 USD'],
+			['120.1 USD', '120.10 USD'],
+			['120.3499 USD', '120.35 USD'],
+		])('formats pure USD currency result %s with exactly two decimals', (expression, expected) => {
+			const lineData: LineRenderData = {
+				index: 0,
+				rawInput: `$${expression.split(' ')[0]}`,
+				processedInput: expression,
+				result: math.evaluate(expression),
+				isEmpty: false,
+				isEmitter: false,
+				isHidden: false,
+				comment: null,
+			};
+			context = {
+				...context,
+				currencyUnitNames: new Set(['USD']),
+			} as RenderContext & { currencyUnitNames: Set<string> };
+
+			renderer.renderLine(container, lineData, context);
+
+			const result = container.querySelector('.numerals-result');
+			expect(result?.textContent).toBe(` → ${expected}`);
+		});
+
+		it('formats configured non-USD currency units from the currency map', () => {
+			const lineData: LineRenderData = {
+				index: 0,
+				rawInput: '$120.1',
+				processedInput: '120.1 CAD',
+				result: math.evaluate('120.1 CAD'),
+				isEmpty: false,
+				isEmitter: false,
+				isHidden: false,
+				comment: null,
+			};
+			context = {
+				...context,
+				currencyUnitNames: new Set(['CAD']),
+			} as RenderContext & { currencyUnitNames: Set<string> };
+
+			renderer.renderLine(container, lineData, context);
+
+			const result = container.querySelector('.numerals-result');
+			expect(result?.textContent).toBe(' → 120.10 CAD');
+		});
+
+		it('leaves compound currency rates under existing precision behavior', () => {
+			const lineData: LineRenderData = {
+				index: 0,
+				rawInput: '$0.042/floz',
+				processedInput: '0.042 USD / floz',
+				result: math.evaluate('0.042 USD / floz'),
+				isEmpty: false,
+				isEmitter: false,
+				isHidden: false,
+				comment: null,
+			};
+			context = {
+				...context,
+				currencyUnitNames: new Set(['USD']),
+			} as RenderContext & { currencyUnitNames: Set<string> };
+
+			renderer.renderLine(container, lineData, context);
+
+			const result = container.querySelector('.numerals-result');
+			expect(result?.textContent).toBe(' → 0.042 USD / floz');
+		});
+
+		it('keeps non-currency numeric results on the selected number format', () => {
+			const lineData: LineRenderData = {
+				index: 0,
+				rawInput: '120',
+				processedInput: '120',
+				result: 120,
+				isEmpty: false,
+				isEmitter: false,
+				isHidden: false,
+				comment: null,
+			};
+			context = {
+				...context,
+				currencyUnitNames: new Set(['USD']),
+			} as RenderContext & { currencyUnitNames: Set<string> };
+
+			renderer.renderLine(container, lineData, context);
+
+			const result = container.querySelector('.numerals-result');
+			expect(result?.textContent).toBe(' → 120');
 		});
 	});
 

--- a/tests/resultInsertion.test.ts
+++ b/tests/resultInsertion.test.ts
@@ -6,6 +6,7 @@
 import { handleResultInsertions } from '../src/numeralsUtilities';
 import { getLocaleFormatter } from '../src/numeralsUtilities';
 import { App, MarkdownPostProcessorContext, MarkdownView } from 'obsidian';
+import * as math from 'mathjs';
 
 // Mock Obsidian types
 type MockEditor = {
@@ -26,6 +27,12 @@ describe('handleResultInsertions', () => {
 	let numberFormat: any;
 
 	beforeEach(() => {
+		try {
+			math.createUnit('USD', { aliases: ['usd'] });
+		} catch {
+			/* unit already exists */
+		}
+
 		// Mock editor
 		mockEditor = {
 			getLine: jest.fn(),
@@ -308,6 +315,29 @@ describe('handleResultInsertions', () => {
 		const call = mockEditor.setLine.mock.calls[0];
 		expect(call[0]).toBe(1);
 		expect(call[1]).toMatch(/@\[value::\d+/);
+	});
+
+	it('should insert pure currency results with two decimal places', () => {
+		const results = [math.evaluate('120.1 USD')];
+		const insertionLines = [0];
+		const insertResults = handleResultInsertions as (...args: unknown[]) => void;
+
+		mockCtx.getSectionInfo.mockReturnValue({ lineStart: 0 });
+		mockEditor.getLine.mockReturnValue('@[total]');
+
+		insertResults(
+			results,
+			insertionLines,
+			numberFormat,
+			mockCtx as unknown as MarkdownPostProcessorContext,
+			mockApp as App,
+			mockEl,
+			new Set(['USD'])
+		);
+
+		jest.runAllTimers();
+
+		expect(mockEditor.setLine).toHaveBeenCalledWith(1, '@[total::120.10 USD]');
 	});
 
 	it('should preserve text after insertion directive', () => {

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -179,6 +179,7 @@ describe('Rendering Pipeline Types', () => {
 				renderStyle: NumeralsRenderStyle.Plain,
 				settings: DEFAULT_SETTINGS,
 				numberFormat: undefined,
+				currencyUnitNames: new Set(['USD']),
 				preProcessors: [],
 			};
 
@@ -191,6 +192,7 @@ describe('Rendering Pipeline Types', () => {
 				renderStyle: NumeralsRenderStyle.TeX,
 				settings: DEFAULT_SETTINGS,
 				numberFormat: { notation: 'fixed' },
+				currencyUnitNames: new Set(['USD']),
 				preProcessors: [],
 			};
 
@@ -208,6 +210,7 @@ describe('Rendering Pipeline Types', () => {
 				renderStyle: NumeralsRenderStyle.SyntaxHighlight,
 				settings: DEFAULT_SETTINGS,
 				numberFormat: undefined,
+				currencyUnitNames: new Set(['USD']),
 				preProcessors,
 			};
 


### PR DESCRIPTION
## Summary

- Add a scoped design note for default pure-currency fixed formatting.
- Format pure configured currency units with exactly two decimal places by default across block rendering, result insertion, inline Numerals, and TeX result rendering.
- Keep compound currency units/rates on the existing selected number-format behavior.
- Update README examples, changelog, and focused Jest coverage.

## Validation

- `npm test -- --runInBand`
- `npm run build`
- `npm run lint`

Note: this branch was created from a worktree that already had unrelated local edits. The commit/PR intentionally includes only the currency-formatting change.