### PR TITLE
feat: add inline TeX rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+- TeX-style rendering option for Inline Numerals results in Live Preview and Reading mode. (Closes #161)
+
 ## [1.10.2] - 2026-05-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Inline Numerals expressions are ordinary inline code with a trigger prefix:
 
 Inline calculations work in Live Preview and Reading mode. They support the same math engine, number formatting, units, currency symbols, variables, frontmatter, and Dataview values as math blocks.
 
+Use the `Inline rendering style` setting to render inline results as plain text or TeX-style MathJax. Plain text remains the default; TeX style renders both the expression and answer in equation mode.
+
 ### Math Blocks
 
 Numerals math blocks are ideal for longer calculations:

--- a/src/inline/inlineEvaluator.ts
+++ b/src/inline/inlineEvaluator.ts
@@ -89,5 +89,5 @@ export function evaluateInlineExpression(
 		}
 	}
 
-	return { formatted, raw: result, globals, referencedPaths };
+	return { formatted, raw: result, processedExpression: processed, globals, referencedPaths };
 }

--- a/src/inline/inlineLivePreview.ts
+++ b/src/inline/inlineLivePreview.ts
@@ -42,11 +42,17 @@ import {
 	mathjsFormat,
 	StringReplaceMap,
 	InlineNumeralsMode,
+	NumeralsRenderStyle,
 } from '../numerals.types';
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
 import { parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
 import { getDataviewApi } from '../dataview';
+import {
+	preProcessorsEqual,
+	renderInlineInputContent,
+	renderInlineValueContent,
+} from './inlineRenderer';
 
 /****************************************************
  * Formatting context helpers
@@ -136,6 +142,10 @@ export class InlineNumeralsWidget extends WidgetType {
 		private readonly separator: string,
 		private readonly isError: boolean,
 		private readonly formattingClasses: string[] = [],
+		private readonly renderStyle: NumeralsRenderStyle = NumeralsRenderStyle.Plain,
+		private readonly rawResult: unknown = resultText,
+		private readonly processedExpression: string = rawExpression,
+		private readonly preProcessors: StringReplaceMap[] = [],
 	) {
 		super();
 	}
@@ -151,6 +161,10 @@ export class InlineNumeralsWidget extends WidgetType {
 			this.rawExpression === other.rawExpression &&
 			this.separator === other.separator &&
 			this.isError === other.isError &&
+			this.renderStyle === other.renderStyle &&
+			this.rawResult === other.rawResult &&
+			this.processedExpression === other.processedExpression &&
+			preProcessorsEqual(this.preProcessors, other.preProcessors) &&
 			this.formattingClasses.length === other.formattingClasses.length &&
 			this.formattingClasses.every((c, i) => c === other.formattingClasses[i])
 		);
@@ -177,7 +191,12 @@ export class InlineNumeralsWidget extends WidgetType {
 
 			const inputEl = ownerDocument.createElement('span');
 			inputEl.className = 'numerals-inline-input';
-			inputEl.textContent = this.rawExpression;
+			renderInlineInputContent(
+				inputEl,
+				this.rawExpression,
+				this.processedExpression,
+				this.renderStyle
+			);
 
 			const sepEl = ownerDocument.createElement('span');
 			sepEl.className = 'numerals-inline-separator';
@@ -185,7 +204,13 @@ export class InlineNumeralsWidget extends WidgetType {
 
 			const valueEl = ownerDocument.createElement('span');
 			valueEl.className = 'numerals-inline-value';
-			valueEl.textContent = this.resultText;
+			renderInlineValueContent(
+				valueEl,
+				this.resultText,
+				this.rawResult,
+				this.renderStyle,
+				this.preProcessors
+			);
 
 			span.appendChild(inputEl);
 			span.appendChild(sepEl);
@@ -196,7 +221,13 @@ export class InlineNumeralsWidget extends WidgetType {
 
 			const valueEl = ownerDocument.createElement('span');
 			valueEl.className = 'numerals-inline-value';
-			valueEl.textContent = this.resultText;
+			renderInlineValueContent(
+				valueEl,
+				this.resultText,
+				this.rawResult,
+				this.renderStyle,
+				this.preProcessors
+			);
 
 			span.appendChild(valueEl);
 		}
@@ -324,6 +355,8 @@ function tryBuildNodeDecoration(
 
 	// Evaluate
 	let resultText: string;
+	let rawResult: unknown = '';
+	let processedExpression = parsed.expression;
 	let isError = false;
 	try {
 		const scope = ctx.getScope();
@@ -338,6 +371,8 @@ function tryBuildNodeDecoration(
 			ctx.settings,
 		);
 		resultText = result.formatted;
+		rawResult = result.raw;
+		processedExpression = result.processedExpression;
 		prevResultRef.value = result.raw;
 		for (const path of result.referencedPaths) {
 			ctx.referencedPaths.add(path);
@@ -363,6 +398,8 @@ function tryBuildNodeDecoration(
 		}
 	} catch {
 		resultText = '';
+		rawResult = '';
+		processedExpression = parsed.expression;
 		isError = true;
 		prevResultRef.value = undefined;
 	}
@@ -376,6 +413,10 @@ function tryBuildNodeDecoration(
 		ctx.settings.inlineEquationSeparator,
 		isError,
 		formattingClasses,
+		ctx.settings.inlineRenderStyle,
+		rawResult,
+		processedExpression,
+		ctx.preProcessors,
 	);
 
 	return Decoration.replace({ widget }).range(spanFrom, spanTo);

--- a/src/inline/inlinePostProcessor.ts
+++ b/src/inline/inlinePostProcessor.ts
@@ -1,9 +1,10 @@
 import { App, MarkdownPostProcessorContext, MarkdownRenderChild } from 'obsidian';
-import { NumeralsSettings, NumeralsScope, mathjsFormat, StringReplaceMap, InlineNumeralsMode } from '../numerals.types';
+import { NumeralsSettings, NumeralsScope, mathjsFormat, StringReplaceMap, InlineNumeralsMode, InlineEvaluationResult } from '../numerals.types';
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
 import { parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
 import { getDataviewApi } from '../dataview';
+import { renderInlineInputContent, renderInlineValueContent } from './inlineRenderer';
 
 /**
  * Write `$`-prefixed globals to the shared scope cache.
@@ -41,20 +42,41 @@ function renderInlineResult(
 	codeEl: HTMLElement,
 	expression: string,
 	mode: InlineNumeralsMode,
-	result: string,
-	settings: NumeralsSettings
+	result: InlineEvaluationResult,
+	settings: NumeralsSettings,
+	preProcessors: StringReplaceMap[]
 ): void {
 	codeEl.empty();
 	codeEl.addClass('numerals-inline');
 
 	if (mode === InlineNumeralsMode.Equation) {
 		codeEl.addClass('numerals-inline-equation');
-		codeEl.createEl('span', { cls: 'numerals-inline-input', text: expression });
+		const inputEl = codeEl.createEl('span', { cls: 'numerals-inline-input' });
+		renderInlineInputContent(
+			inputEl,
+			expression,
+			result.processedExpression,
+			settings.inlineRenderStyle
+		);
 		codeEl.createEl('span', { cls: 'numerals-inline-separator', text: settings.inlineEquationSeparator });
-		codeEl.createEl('span', { cls: 'numerals-inline-value', text: result });
+		const valueEl = codeEl.createEl('span', { cls: 'numerals-inline-value' });
+		renderInlineValueContent(
+			valueEl,
+			result.formatted,
+			result.raw,
+			settings.inlineRenderStyle,
+			preProcessors
+		);
 	} else {
 		codeEl.addClass('numerals-inline-result');
-		codeEl.createEl('span', { cls: 'numerals-inline-value', text: result });
+		const valueEl = codeEl.createEl('span', { cls: 'numerals-inline-value' });
+		renderInlineValueContent(
+			valueEl,
+			result.formatted,
+			result.raw,
+			settings.inlineRenderStyle,
+			preProcessors
+		);
 	}
 }
 
@@ -150,7 +172,7 @@ function processInlineCodeElement(
 			addGlobalsToScopeCache(scopeCache, sourcePath, result.globals);
 		}
 
-		renderInlineResult(codeEl, parsed.expression, parsed.mode, result.formatted, settings);
+		renderInlineResult(codeEl, parsed.expression, parsed.mode, result, settings, preProcessors);
 		return { referencedPaths: result.referencedPaths };
 	} catch {
 		prevResultRef.value = undefined;

--- a/src/inline/inlineRenderer.ts
+++ b/src/inline/inlineRenderer.ts
@@ -1,0 +1,71 @@
+import { NumeralsRenderStyle, StringReplaceMap } from '../numerals.types';
+import { mathjaxLoop } from '../rendering/displayUtils';
+import { expressionToTeX, resultToTeX } from '../rendering/texRendering';
+
+function createSpan(parent: HTMLElement, className: string): HTMLElement {
+	const span = parent.ownerDocument.createElement('span');
+	span.className = className;
+	parent.appendChild(span);
+	return span;
+}
+
+function renderTexOrText(
+	container: HTMLElement,
+	text: string,
+	renderStyle: NumeralsRenderStyle,
+	toTex: () => string
+): void {
+	if (renderStyle !== NumeralsRenderStyle.TeX) {
+		container.textContent = text;
+		return;
+	}
+
+	try {
+		const texElement = createSpan(container, 'numerals-tex');
+		void mathjaxLoop(texElement, toTex());
+	} catch {
+		container.textContent = text;
+	}
+}
+
+export function renderInlineInputContent(
+	container: HTMLElement,
+	rawExpression: string,
+	processedExpression: string,
+	renderStyle: NumeralsRenderStyle
+): void {
+	renderTexOrText(
+		container,
+		rawExpression,
+		renderStyle,
+		() => expressionToTeX(processedExpression, rawExpression)
+	);
+}
+
+export function renderInlineValueContent(
+	container: HTMLElement,
+	formattedResult: string,
+	rawResult: unknown,
+	renderStyle: NumeralsRenderStyle,
+	preProcessors: StringReplaceMap[]
+): void {
+	renderTexOrText(
+		container,
+		formattedResult,
+		renderStyle,
+		() => resultToTeX(rawResult, preProcessors)
+	);
+}
+
+export function preProcessorsEqual(
+	a: StringReplaceMap[],
+	b: StringReplaceMap[]
+): boolean {
+	return (
+		a.length === b.length &&
+		a.every((processor, index) => (
+			processor.regex.toString() === b[index].regex.toString() &&
+			processor.replaceStr === b[index].replaceStr
+		))
+	);
+}

--- a/src/numerals.types.ts
+++ b/src/numerals.types.ts
@@ -65,6 +65,7 @@ export interface NumeralsSettings {
 	enableGreekAutoComplete: boolean;
 	// Inline Numerals settings
 	enableInlineNumerals: boolean;
+	inlineRenderStyle: NumeralsRenderStyle;
 	inlineResultTrigger: string;
 	inlineEquationTrigger: string;
 	inlineEquationSeparator: string;
@@ -91,6 +92,7 @@ export const DEFAULT_SETTINGS: NumeralsSettings = {
 	enableGreekAutoComplete: 			true,
 	// Inline Numerals settings
 	enableInlineNumerals:				true,
+	inlineRenderStyle:					NumeralsRenderStyle.Plain,
 	inlineResultTrigger:				"#:",
 	inlineEquationTrigger:				"#=:",
 	inlineEquationSeparator:				" = ",
@@ -235,6 +237,8 @@ export interface InlineEvaluationResult {
 	formatted: string;
 	/** The raw mathjs result value (for chaining via @prev) */
 	raw: unknown;
+	/** Expression after cross-note resolution, preprocessing, and inline directives */
+	processedExpression: string;
 	/** Note-global ($-prefixed) variables that were assigned during evaluation */
 	globals: Map<string, unknown>;
 	/** File paths referenced via [[note]].property syntax */

--- a/src/renderers/TeXRenderer.ts
+++ b/src/renderers/TeXRenderer.ts
@@ -1,13 +1,7 @@
-import * as math from 'mathjs';
 import { LineRenderData, RenderContext } from '../numerals.types';
 import { BaseLineRenderer } from './BaseLineRenderer';
-import {
-	texCurrencyReplacement,
-	unescapeSubscripts,
-	mathjaxLoop,
-	replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw,
-	getLocaleFormatter,
-} from '../rendering/displayUtils';
+import { mathjaxLoop } from '../rendering/displayUtils';
+import { expressionToTeX, resultToTeX } from '../rendering/texRendering';
 
 /**
  * TeX renderer for Numerals blocks.
@@ -70,17 +64,10 @@ export class TeXRenderer extends BaseLineRenderer {
 	 * @private
 	 */
 	private renderInputTeX(inputElement: HTMLElement, lineData: LineRenderData): void {
-		// Convert input to TeX
-		const preprocessedTex = math.parse(lineData.processedInput).toTex();
-
-		// Apply transformations
-		let inputTex = replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw(
-			preprocessedTex,
-			lineData.rawInput + (lineData.comment || ''),
-			'@Sum()'
+		const inputTex = expressionToTeX(
+			lineData.processedInput,
+			lineData.rawInput + (lineData.comment || '')
 		);
-		inputTex = unescapeSubscripts(inputTex);
-		inputTex = texCurrencyReplacement(inputTex);
 
 		// Render with MathJax
 		const inputTexElement = inputElement.createEl('span', { cls: 'numerals-tex' });
@@ -107,20 +94,7 @@ export class TeXRenderer extends BaseLineRenderer {
 		lineData: LineRenderData,
 		context: RenderContext
 	): void {
-		// Format result to string with reasonable precision, no grouping
-		let processedResult = math.format(
-			lineData.result,
-			getLocaleFormatter('en-US', { useGrouping: false })
-		);
-
-		// Apply preprocessors (reverse currency transformations for parsing)
-		for (const processor of context.preProcessors) {
-			processedResult = processedResult.replace(processor.regex, processor.replaceStr);
-		}
-
-		// Convert to TeX
-		let texResult = math.parse(processedResult).toTex();
-		texResult = texCurrencyReplacement(texResult);
+		const texResult = resultToTeX(lineData.result, context.preProcessors);
 
 		// Render with MathJax
 		const resultTexElement = resultElement.createEl('span', { cls: 'numerals-tex' });

--- a/src/rendering/texRendering.ts
+++ b/src/rendering/texRendering.ts
@@ -1,0 +1,46 @@
+import * as math from 'mathjs';
+import { StringReplaceMap } from '../numerals.types';
+import {
+	texCurrencyReplacement,
+	unescapeSubscripts,
+	replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw,
+	getLocaleFormatter,
+} from './displayUtils';
+
+/**
+ * Convert a mathjs-ready expression into TeX, preserving Numerals display
+ * conventions such as escaped subscripts, currency symbols, and @sum labels.
+ */
+export function expressionToTeX(
+	processedExpression: string,
+	rawExpression = processedExpression
+): string {
+	const preprocessedTex = math.parse(processedExpression).toTex();
+	let tex = replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw(
+		preprocessedTex,
+		rawExpression,
+		'@Sum()'
+	);
+	tex = unescapeSubscripts(tex);
+	return texCurrencyReplacement(tex);
+}
+
+/**
+ * Convert an evaluated mathjs result into TeX using the same no-grouping,
+ * period-decimal formatting that block TeX rendering uses.
+ */
+export function resultToTeX(
+	result: unknown,
+	preProcessors: StringReplaceMap[]
+): string {
+	let processedResult = math.format(
+		result,
+		getLocaleFormatter('en-US', { useGrouping: false })
+	);
+
+	for (const processor of preProcessors) {
+		processedResult = processedResult.replace(processor.regex, processor.replaceStr);
+	}
+
+	return texCurrencyReplacement(math.parse(processedResult).toTex());
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -444,6 +444,21 @@ export class NumeralsSettingTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl)
+			.setName('Inline rendering style')
+			.setDesc('Choose how inline calculation results are rendered')
+			.addDropdown(dropDown => {
+				dropDown.addOption(NumeralsRenderStyle.Plain, 'Plain text');
+				dropDown.addOption(NumeralsRenderStyle.TeX, 'TeX style'); // eslint-disable-line obsidianmd/ui/sentence-case
+				dropDown.setValue(this.plugin.settings.inlineRenderStyle);
+				dropDown.onChange(async (value) => {
+					const renderStyleStr = value as keyof typeof NumeralsRenderStyle;
+					this.plugin.settings.inlineRenderStyle =
+						NumeralsRenderStyle[renderStyleStr] ?? NumeralsRenderStyle.Plain;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
 			.setName('Result-only trigger')
 			.setDesc(htmlToElements(
 				`Prefix for inline code that shows only the result.<br>`

--- a/tests/inline.test.ts
+++ b/tests/inline.test.ts
@@ -376,6 +376,11 @@ describe('evaluateInlineExpression', () => {
 			expect(result.formatted).toContain('USD');
 		});
 
+		it('should return the processed expression used for mathjs evaluation', () => {
+			const result = evaluateInlineExpression('$1,000 * 2', emptyScope, defaultFormat, preProcessors);
+			expect(result.processedExpression).toBe('1000 USD * 2');
+		});
+
 		it('should handle multiple thousands separators: "$1,000,000"', () => {
 			const result = evaluateInlineExpression('$1,000,000 + $0', emptyScope, defaultFormat, preProcessors);
 			// mathjs uses exponential notation for large numbers by default

--- a/tests/inlineLivePreview.test.ts
+++ b/tests/inlineLivePreview.test.ts
@@ -9,6 +9,12 @@
 jest.mock('obsidian', () => ({
 	editorInfoField: {},
 	editorLivePreviewField: {},
+	renderMath: jest.fn((tex: string) => {
+		const span = document.createElement('span');
+		span.textContent = `TeX:${tex}`;
+		return span;
+	}),
+	finishRenderMath: jest.fn().mockResolvedValue(undefined),
 }), { virtual: true });
 
 jest.mock('obsidian-dataview', () => ({
@@ -20,7 +26,7 @@ import {
 	getFormattingClasses,
 	selectionOverlapsRange,
 } from '../src/inline/inlineLivePreview';
-import { InlineNumeralsMode } from '../src/numerals.types';
+import { InlineNumeralsMode, NumeralsRenderStyle } from '../src/numerals.types';
 import { EditorSelection } from '@codemirror/state';
 
 beforeAll(() => {
@@ -131,6 +137,18 @@ describe('InlineNumeralsWidget', () => {
 			expect(el.querySelector('.numerals-inline-separator')).toBeNull();
 		});
 
+		it('should render result-only TeX mode with MathJax inside the value span', async () => {
+			const widget = new InlineNumeralsWidget(
+				'36', InlineNumeralsMode.ResultOnly, '3ft in inches', ' = ', false,
+				[], NumeralsRenderStyle.TeX, 36, '3 ft in inches', []
+			);
+			const el = widget.toDOM();
+			await Promise.resolve();
+
+			expect(el.classList.contains('numerals-inline-result')).toBe(true);
+			expect(el.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:36');
+		});
+
 		it('should render equation mode with input, separator, and value spans', () => {
 			const widget = new InlineNumeralsWidget(
 				'5 ft', InlineNumeralsMode.Equation, '3ft + 2ft', ' = ', false
@@ -141,6 +159,19 @@ describe('InlineNumeralsWidget', () => {
 			expect(el.querySelector('.numerals-inline-input')?.textContent).toBe('3ft + 2ft');
 			expect(el.querySelector('.numerals-inline-separator')?.textContent).toBe(' = ');
 			expect(el.querySelector('.numerals-inline-value')?.textContent).toBe('5 ft');
+		});
+
+		it('should render equation TeX mode with MathJax input and value spans', async () => {
+			const widget = new InlineNumeralsWidget(
+				'12', InlineNumeralsMode.Equation, 'sqrt(144)', ' = ', false,
+				[], NumeralsRenderStyle.TeX, 12, 'sqrt(144)', []
+			);
+			const el = widget.toDOM();
+			await Promise.resolve();
+
+			expect(el.querySelector('.numerals-inline-input .numerals-tex')?.textContent).toBe('TeX:\\sqrt{144}');
+			expect(el.querySelector('.numerals-inline-separator')?.textContent).toBe(' = ');
+			expect(el.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:12');
 		});
 
 		it('should create widget nodes from the editor ownerDocument', () => {
@@ -249,6 +280,19 @@ describe('InlineNumeralsWidget', () => {
 			const a = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong', 'cm-em']);
 			const b = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong', 'cm-em']);
 			expect(a.eq(b)).toBe(true);
+		});
+
+		it('should return false when render style differs', () => {
+			const plain = new InlineNumeralsWidget(
+				'5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false,
+				[], NumeralsRenderStyle.Plain, 5, '3+2', []
+			);
+			const tex = new InlineNumeralsWidget(
+				'5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false,
+				[], NumeralsRenderStyle.TeX, 5, '3+2', []
+			);
+
+			expect(plain.eq(tex)).toBe(false);
 		});
 	});
 });

--- a/tests/inlinePostProcessor.test.ts
+++ b/tests/inlinePostProcessor.test.ts
@@ -11,6 +11,12 @@ jest.mock("obsidian", () => ({
 	MarkdownRenderChild: class {
 		registerEvent = jest.fn((ref) => mockRegisteredEvents.push(ref));
 	},
+	renderMath: jest.fn((tex: string) => {
+		const span = document.createElement('span');
+		span.textContent = `TeX:${tex}`;
+		return span;
+	}),
+	finishRenderMath: jest.fn().mockResolvedValue(undefined),
 }), { virtual: true });
 jest.mock(
 	"obsidian-dataview",
@@ -22,6 +28,7 @@ import * as math from 'mathjs';
 import { defaultCurrencyMap } from '../src/rendering/displayUtils';
 import {
 	NumeralsSettings,
+	NumeralsRenderStyle,
 	NumeralsScope,
 	DEFAULT_SETTINGS,
 	StringReplaceMap,
@@ -146,6 +153,54 @@ describe('inline numerals integration', () => {
 			const output = simulateInlinePipeline('#=: sqrt(144)');
 			expect(output).not.toBeNull();
 			expect(output!.result).toBe('12');
+		});
+	});
+
+	describe('TeX rendering mode', () => {
+		function createTexPostProcessor() {
+			const app = {
+				vault: {
+					getAbstractFileByPath: jest.fn(() => null),
+				},
+				metadataCache: {
+					getFileCache: jest.fn(),
+				},
+			};
+			return createInlineNumeralsPostProcessor(
+				app as any,
+				() => ({ ...DEFAULT_SETTINGS, inlineRenderStyle: NumeralsRenderStyle.TeX }),
+				() => undefined,
+				() => [],
+				new Map(),
+			);
+		}
+
+		it('renders result-only inline values with MathJax in Reading mode', async () => {
+			const container = document.createElement('p');
+			const code = document.createElement('code');
+			code.innerText = '#: 3ft in inches';
+			container.appendChild(code);
+
+			createTexPostProcessor()(container, { sourcePath: 'source.md', addChild: jest.fn() } as any);
+			await Promise.resolve();
+
+			const texValue = code.querySelector('.numerals-inline-value .numerals-tex');
+			expect(texValue).not.toBeNull();
+			expect(texValue?.textContent).toBe('TeX:36~\\mathrm{inches}');
+		});
+
+		it('renders equation input and result with MathJax in Reading mode', async () => {
+			const container = document.createElement('p');
+			const code = document.createElement('code');
+			code.innerText = '#=: sqrt(144)';
+			container.appendChild(code);
+
+			createTexPostProcessor()(container, { sourcePath: 'source.md', addChild: jest.fn() } as any);
+			await Promise.resolve();
+
+			expect(code.querySelector('.numerals-inline-input .numerals-tex')?.textContent).toBe('TeX:\\sqrt{144}');
+			expect(code.querySelector('.numerals-inline-separator')?.textContent).toBe(' = ');
+			expect(code.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:12');
 		});
 	});
 

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -26,12 +26,14 @@ import {
 	SyntaxHighlightRenderer,
 	RendererFactory,
 } from '../src/renderers';
+import * as math from 'mathjs';
 import {
 	LineRenderData,
 	RenderContext,
 	NumeralsRenderStyle,
 	DEFAULT_SETTINGS,
 } from '../src/numerals.types';
+import { expressionToTeX, resultToTeX } from '../src/rendering/texRendering';
 import { getLocaleFormatter } from '../src/numeralsUtilities';
 
 // Mock Obsidian DOM methods
@@ -315,7 +317,12 @@ describe('Renderer Implementations', () => {
 			renderer = new TeXRenderer();
 		});
 
-		it('should render normal line', () => {
+		it('should convert expressions and results using shared TeX helpers', () => {
+			expect(expressionToTeX('sqrt(144)')).toBe('\\sqrt{144}');
+			expect(resultToTeX(math.evaluate('3 ft to inches'), [])).toBe('36~\\mathrm{inches}');
+		});
+
+		it('should render normal line', async () => {
 			const lineData: LineRenderData = {
 				index: 0,
 				rawInput: '2 + 2',
@@ -328,6 +335,7 @@ describe('Renderer Implementations', () => {
 			};
 
 			renderer.renderLine(container, lineData, context);
+			await Promise.resolve();
 
 			const input = container.querySelector('.numerals-input');
 			const result = container.querySelector('.numerals-result');
@@ -338,6 +346,8 @@ describe('Renderer Implementations', () => {
 			// Should have TeX spans
 			const texSpans = container.querySelectorAll('.numerals-tex');
 			expect(texSpans.length).toBe(2); // input and result
+			expect(input?.textContent).toContain('TeX:2+2');
+			expect(result?.textContent).toContain('TeX:4');
 		});
 
 		it('should render empty line', () => {


### PR DESCRIPTION
## Feature spec

Closes #161.

Add an inline-specific render style setting for Inline Numerals:

- `Plain text`: preserves the current inline rendering behavior and remains the default for existing users.
- `TeX style`: renders result-only inline calculations with MathJax, and renders both the expression and answer with MathJax in equation mode.

Non-goals for this PR:

- No inline syntax highlighting mode, since syntax highlighting is a block-input renderer and has no clear inline result equivalent.
- No per-expression inline style markers; the existing `#:` and `#=:` trigger syntax stays unchanged.
- No changes to inline evaluation semantics, note-global variables, `@prev`, cross-note references, or auto-complete.

## Architecture

The implementation keeps the existing inline pipeline boundaries intact: parsing stays in `inlineParser`, evaluation stays in `inlineEvaluator`, and display decisions live in the rendering layer.

Shared TeX conversion helpers now live in `src/rendering/texRendering.ts`, so block `math-tex` rendering and inline TeX rendering use the same mathjs-to-MathJax conventions for expressions, results, currency symbols, subscripts, and no-grouping TeX number formatting.

Inline Reading mode and Live Preview both route through `src/inline/inlineRenderer.ts`, which renders plain text by default and switches to MathJax only when `settings.inlineRenderStyle` is `TeX`.

## Changes

- Added `inlineRenderStyle` to plugin settings with a `Plain` default.
- Added an `Inline rendering style` dropdown in the Inline Numerals settings section.
- Added shared TeX expression/result conversion helpers and refactored `TeXRenderer` to use them.
- Added inline renderer helpers for consistent Reading mode and Live Preview DOM output.
- Extended inline evaluation results with the processed expression used by mathjs, so equation TeX rendering does not duplicate preprocessing logic.
- Documented the new setting in the README and CHANGELOG.

## Verification

- `npm test` - 399 tests passed
- `npm run lint` - passed
- `npm run build` - passed