### PR TITLE
feat: add inline TeX syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+- Inline TeX rendering syntax: use `` `#$: expression` `` for TeX-rendered inline results and `` `#=$: expression` `` for TeX-rendered inline equations. (Closes #161)
+
 ## [1.10.2] - 2026-05-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 | --- | --- |
 | Inline calculations | `` `#: 3ft * 4ft` `` -> `12 ft^2` |
 | Show-your-work equations | `` `#=: 2 * (3ft + 4ft)` `` -> `2 * (3 ft + 4 ft) = 14 ft` |
+| Inline TeX calculations | `` `#$: sqrt(144)` `` -> TeX-rendered `12` |
 | Full math blocks | <code>```math<br>20 mi / 4 hr to m/s<br>```</code> -> `2.235 m / s` |
 | Units and conversions | `100 km/hr in mi/hr` -> `62.137 mi / hr` |
 | Currency math | `$100/hr * 3 days` -> `7,200 USD` |
@@ -55,8 +56,10 @@ Inline Numerals expressions are ordinary inline code with a trigger prefix:
 | --- | --- | --- |
 | `` `#: 3ft * 4ft` `` | `12 ft^2` | Showing just the answer |
 | `` `#=: 3ft * 4ft` `` | `3 ft * 4 ft = 12 ft^2` | Showing the expression and answer |
+| `` `#$: sqrt(144)` `` | TeX-rendered `12` | Typeset inline results |
+| `` `#=$: sqrt(144)` `` | TeX-rendered `sqrt(144) = 12` | Typeset inline equations |
 
-Inline calculations work in Live Preview and Reading mode. They support the same math engine, number formatting, units, currency symbols, variables, frontmatter, and Dataview values as math blocks.
+Inline calculations work in Live Preview and Reading mode. They support the same math engine, number formatting, units, currency symbols, variables, frontmatter, and Dataview values as math blocks. Use `#$:` or `#=$:` on individual expressions when you want TeX-style rendering without changing the default inline triggers.
 
 ### Math Blocks
 

--- a/src/inline/inlineEvaluator.ts
+++ b/src/inline/inlineEvaluator.ts
@@ -21,7 +21,7 @@ import { resolveCrossNoteReferences } from '../processing/crossNoteResolver';
  * @param app - The Obsidian App instance (optional; required for cross-note references)
  * @param sourcePath - Path of the current file (optional; required for cross-note references)
  * @param settings - Numerals settings (optional; required for cross-note references)
- * @returns Object with `formatted` (display string) and `raw` (mathjs value for chaining)
+ * @returns Object with display, raw, and processed expression values
  * @throws If mathjs cannot evaluate the expression, or @prev is used without a previous result
  */
 export function evaluateInlineExpression(
@@ -89,5 +89,5 @@ export function evaluateInlineExpression(
 		}
 	}
 
-	return { formatted, raw: result, globals, referencedPaths };
+	return { formatted, raw: result, processedExpression: processed, globals, referencedPaths };
 }

--- a/src/inline/inlineLivePreview.ts
+++ b/src/inline/inlineLivePreview.ts
@@ -42,11 +42,13 @@ import {
 	mathjsFormat,
 	StringReplaceMap,
 	InlineNumeralsMode,
+	NumeralsRenderStyle,
 } from '../numerals.types';
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
 import { parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
 import { getDataviewApi } from '../dataview';
+import { preProcessorsEqual, renderInlineResultContent } from './inlineRenderer';
 
 /****************************************************
  * Formatting context helpers
@@ -136,6 +138,10 @@ export class InlineNumeralsWidget extends WidgetType {
 		private readonly separator: string,
 		private readonly isError: boolean,
 		private readonly formattingClasses: string[] = [],
+		private readonly renderStyle: NumeralsRenderStyle = NumeralsRenderStyle.Plain,
+		private readonly rawResult: unknown = resultText,
+		private readonly processedExpression: string = rawExpression,
+		private readonly preProcessors: StringReplaceMap[] = [],
 	) {
 		super();
 	}
@@ -145,12 +151,20 @@ export class InlineNumeralsWidget extends WidgetType {
 	 * All fields must match for the widget to be considered unchanged.
 	 */
 	eq(other: InlineNumeralsWidget): boolean {
+		const texInputsMatch = this.renderStyle !== NumeralsRenderStyle.TeX || (
+			Object.is(this.rawResult, other.rawResult) &&
+			this.processedExpression === other.processedExpression &&
+			preProcessorsEqual(this.preProcessors, other.preProcessors)
+		);
+
 		return (
 			this.resultText === other.resultText &&
 			this.mode === other.mode &&
 			this.rawExpression === other.rawExpression &&
 			this.separator === other.separator &&
 			this.isError === other.isError &&
+			this.renderStyle === other.renderStyle &&
+			texInputsMatch &&
 			this.formattingClasses.length === other.formattingClasses.length &&
 			this.formattingClasses.every((c, i) => c === other.formattingClasses[i])
 		);
@@ -172,34 +186,17 @@ export class InlineNumeralsWidget extends WidgetType {
 			return span;
 		}
 
-		if (this.mode === InlineNumeralsMode.Equation) {
-			span.classList.add('numerals-inline-equation');
-
-			const inputEl = ownerDocument.createElement('span');
-			inputEl.className = 'numerals-inline-input';
-			inputEl.textContent = this.rawExpression;
-
-			const sepEl = ownerDocument.createElement('span');
-			sepEl.className = 'numerals-inline-separator';
-			sepEl.textContent = this.separator;
-
-			const valueEl = ownerDocument.createElement('span');
-			valueEl.className = 'numerals-inline-value';
-			valueEl.textContent = this.resultText;
-
-			span.appendChild(inputEl);
-			span.appendChild(sepEl);
-			span.appendChild(valueEl);
-		} else {
-			// ResultOnly
-			span.classList.add('numerals-inline-result');
-
-			const valueEl = ownerDocument.createElement('span');
-			valueEl.className = 'numerals-inline-value';
-			valueEl.textContent = this.resultText;
-
-			span.appendChild(valueEl);
-		}
+		renderInlineResultContent(
+			span,
+			this.mode,
+			this.renderStyle,
+			this.rawExpression,
+			this.processedExpression,
+			this.resultText,
+			this.rawResult,
+			this.separator,
+			this.preProcessors,
+		);
 
 		return span;
 	}
@@ -249,7 +246,6 @@ function createDecorationContext(
 
 	const resultTrigger = settings.inlineResultTrigger;
 	const equationTrigger = settings.inlineEquationTrigger;
-	if (!resultTrigger && !equationTrigger) return null;
 
 	// Lazy scope resolution — only built on first matching expression
 	let scope: NumeralsScope | null = null;
@@ -324,6 +320,8 @@ function tryBuildNodeDecoration(
 
 	// Evaluate
 	let resultText: string;
+	let rawResult: unknown = '';
+	let processedExpression = parsed.expression;
 	let isError = false;
 	try {
 		const scope = ctx.getScope();
@@ -338,6 +336,8 @@ function tryBuildNodeDecoration(
 			ctx.settings,
 		);
 		resultText = result.formatted;
+		rawResult = result.raw;
+		processedExpression = result.processedExpression;
 		prevResultRef.value = result.raw;
 		for (const path of result.referencedPaths) {
 			ctx.referencedPaths.add(path);
@@ -376,6 +376,10 @@ function tryBuildNodeDecoration(
 		ctx.settings.inlineEquationSeparator,
 		isError,
 		formattingClasses,
+		parsed.renderStyle,
+		rawResult,
+		processedExpression,
+		ctx.preProcessors,
 	);
 
 	return Decoration.replace({ widget }).range(spanFrom, spanTo);

--- a/src/inline/inlineParser.ts
+++ b/src/inline/inlineParser.ts
@@ -1,39 +1,82 @@
-import { InlineNumeralsMode, InlineNumeralsExpression } from '../numerals.types';
+import { InlineNumeralsMode, InlineNumeralsExpression, NumeralsRenderStyle } from '../numerals.types';
+
+export const INLINE_TEX_RESULT_TRIGGER = '#$:';
+export const INLINE_TEX_EQUATION_TRIGGER = '#=$:';
+
+export interface InlineTriggerCandidate {
+	trigger: string;
+	mode: InlineNumeralsMode;
+	renderStyle: NumeralsRenderStyle;
+}
+
+/**
+ * Build the complete list of inline trigger candidates.
+ *
+ * User-configurable plain triggers are kept alongside fixed TeX triggers.
+ * TeX triggers are not settings because they are per-expression style markers.
+ */
+export function getInlineTriggerCandidates(
+	resultTrigger: string,
+	equationTrigger: string,
+): InlineTriggerCandidate[] {
+	const candidates: InlineTriggerCandidate[] = [];
+
+	function addCandidate(
+		trigger: string,
+		mode: InlineNumeralsMode,
+		renderStyle: NumeralsRenderStyle,
+	): void {
+		if (!trigger) return;
+		if (candidates.some(candidate => candidate.trigger === trigger)) return;
+		candidates.push({ trigger, mode, renderStyle });
+	}
+
+	addCandidate(INLINE_TEX_RESULT_TRIGGER, InlineNumeralsMode.ResultOnly, NumeralsRenderStyle.TeX);
+	addCandidate(INLINE_TEX_EQUATION_TRIGGER, InlineNumeralsMode.Equation, NumeralsRenderStyle.TeX);
+	addCandidate(resultTrigger, InlineNumeralsMode.ResultOnly, NumeralsRenderStyle.Plain);
+	addCandidate(equationTrigger, InlineNumeralsMode.Equation, NumeralsRenderStyle.Plain);
+
+	return candidates.sort((a, b) => b.trigger.length - a.trigger.length);
+}
+
+export function hasInlineTrigger(
+	text: string,
+	resultTrigger: string,
+	equationTrigger: string,
+): boolean {
+	return getInlineTriggerCandidates(resultTrigger, equationTrigger).some(({ trigger }) =>
+		text.startsWith(trigger)
+	);
+}
 
 /**
  * Attempt to parse an inline code string as a Numerals expression.
  *
- * Checks whether the text starts with a recognized trigger prefix.
- * The longer trigger is checked first to handle the case where
- * one trigger is a prefix of the other (e.g. "=:" vs "==:").
+ * Checks whether the text starts with a recognized trigger prefix. This includes
+ * user-configured plain triggers plus fixed TeX triggers (`#$:` and `#=$:`).
+ * The longer trigger is checked first to handle prefix conflicts.
  *
  * Empty triggers are silently ignored to prevent matching all code spans.
  *
  * @param text - The raw inline code text
- * @param resultTrigger - Trigger prefix for result-only mode (e.g. "=:")
- * @param equationTrigger - Trigger prefix for equation mode (e.g. "==:")
- * @returns Parsed expression with mode, or null if no trigger matched
+ * @param resultTrigger - Trigger prefix for result-only mode (e.g. "#:")
+ * @param equationTrigger - Trigger prefix for equation mode (e.g. "#=:")
+ * @returns Parsed expression with mode and render style, or null if no trigger matched
  */
 export function parseInlineExpression(
 	text: string,
 	resultTrigger: string,
 	equationTrigger: string
 ): InlineNumeralsExpression | null {
-	// Build candidate list, filtering out empty triggers
-	const candidates: [string, InlineNumeralsMode][] = [];
-	if (resultTrigger) candidates.push([resultTrigger, InlineNumeralsMode.ResultOnly]);
-	if (equationTrigger) candidates.push([equationTrigger, InlineNumeralsMode.Equation]);
+	const candidates = getInlineTriggerCandidates(resultTrigger, equationTrigger);
 
-	// Sort longest-first to avoid prefix conflicts ("==:" before "=:")
-	candidates.sort((a, b) => b[0].length - a[0].length);
-
-	for (const [trigger, mode] of candidates) {
+	for (const { trigger, mode, renderStyle } of candidates) {
 		if (text.startsWith(trigger)) {
 			const expression = text.slice(trigger.length).trim();
 			if (expression.length === 0) {
 				return null;
 			}
-			return { mode, expression };
+			return { mode, renderStyle, expression };
 		}
 	}
 

--- a/src/inline/inlinePostProcessor.ts
+++ b/src/inline/inlinePostProcessor.ts
@@ -1,9 +1,10 @@
 import { App, MarkdownPostProcessorContext, MarkdownRenderChild } from 'obsidian';
-import { NumeralsSettings, NumeralsScope, mathjsFormat, StringReplaceMap, InlineNumeralsMode } from '../numerals.types';
+import { NumeralsSettings, NumeralsScope, mathjsFormat, StringReplaceMap } from '../numerals.types';
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
-import { parseInlineExpression } from './inlineParser';
+import { hasInlineTrigger, parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
 import { getDataviewApi } from '../dataview';
+import { renderInlineResultContent } from './inlineRenderer';
 
 /**
  * Write `$`-prefixed globals to the shared scope cache.
@@ -22,39 +23,6 @@ function addGlobalsToScopeCache(
 	}
 	for (const [key, value] of globals) {
 		pageScope.set(key, value);
-	}
-}
-
-/**
- * Render an Inline Numerals result into a container element.
- *
- * Replaces the content of the given element with the evaluated result.
- * In Equation mode, shows "input = result". In ResultOnly mode, shows just the result.
- *
- * @param codeEl - The <code> element to render into
- * @param expression - The raw expression text (trigger already stripped)
- * @param mode - Whether to show result-only or equation style
- * @param result - The formatted result string
- * @param settings - Plugin settings (for separator string)
- */
-function renderInlineResult(
-	codeEl: HTMLElement,
-	expression: string,
-	mode: InlineNumeralsMode,
-	result: string,
-	settings: NumeralsSettings
-): void {
-	codeEl.empty();
-	codeEl.addClass('numerals-inline');
-
-	if (mode === InlineNumeralsMode.Equation) {
-		codeEl.addClass('numerals-inline-equation');
-		codeEl.createEl('span', { cls: 'numerals-inline-input', text: expression });
-		codeEl.createEl('span', { cls: 'numerals-inline-separator', text: settings.inlineEquationSeparator });
-		codeEl.createEl('span', { cls: 'numerals-inline-value', text: result });
-	} else {
-		codeEl.addClass('numerals-inline-result');
-		codeEl.createEl('span', { cls: 'numerals-inline-value', text: result });
 	}
 }
 
@@ -150,7 +118,18 @@ function processInlineCodeElement(
 			addGlobalsToScopeCache(scopeCache, sourcePath, result.globals);
 		}
 
-		renderInlineResult(codeEl, parsed.expression, parsed.mode, result.formatted, settings);
+		codeEl.empty();
+		renderInlineResultContent(
+			codeEl,
+			parsed.mode,
+			parsed.renderStyle,
+			parsed.expression,
+			result.processedExpression,
+			result.formatted,
+			result.raw,
+			settings.inlineEquationSeparator,
+			preProcessors,
+		);
 		return { referencedPaths: result.referencedPaths };
 	} catch {
 		prevResultRef.value = undefined;
@@ -189,20 +168,15 @@ export function createInlineNumeralsPostProcessor(
 		const settings = getSettings();
 		if (!settings.enableInlineNumerals) return;
 
-		const resultTrigger = settings.inlineResultTrigger;
-		const equationTrigger = settings.inlineEquationTrigger;
-
-		// Guard against empty triggers (would match every <code> element)
-		if (!resultTrigger && !equationTrigger) return;
-
 		const codeElements = el.querySelectorAll<HTMLElement>('code');
 		if (codeElements.length === 0) return;
 
 		// Quick-reject: check if any code element starts with a trigger
 		// before building scope (which is the expensive part)
+		const resultTrigger = settings.inlineResultTrigger;
+		const equationTrigger = settings.inlineEquationTrigger;
 		const hasMatch = Array.from(codeElements).some(code =>
-			code.innerText.startsWith(resultTrigger) ||
-			code.innerText.startsWith(equationTrigger)
+			hasInlineTrigger(code.innerText, resultTrigger, equationTrigger)
 		);
 		if (!hasMatch) return;
 

--- a/src/inline/inlineRenderer.ts
+++ b/src/inline/inlineRenderer.ts
@@ -1,0 +1,105 @@
+import { InlineNumeralsMode, NumeralsRenderStyle, StringReplaceMap } from '../numerals.types';
+import { mathjaxLoop } from '../rendering/displayUtils';
+import { expressionToTeX, resultToTeX } from '../rendering/texRendering';
+
+function createSpan(parent: HTMLElement, className: string): HTMLElement {
+	const span = parent.ownerDocument.createElement('span');
+	span.className = className;
+	parent.appendChild(span);
+	return span;
+}
+
+function renderTexOrText(
+	container: HTMLElement,
+	text: string,
+	renderStyle: NumeralsRenderStyle,
+	toTex: () => string,
+): void {
+	if (renderStyle !== NumeralsRenderStyle.TeX) {
+		container.textContent = text;
+		return;
+	}
+
+	try {
+		const tex = toTex();
+		const texElement = createSpan(container, 'numerals-tex');
+		void mathjaxLoop(texElement, tex).catch(() => {
+			texElement.textContent = text;
+		});
+	} catch {
+		container.textContent = text;
+	}
+}
+
+export function renderInlineInputContent(
+	container: HTMLElement,
+	rawExpression: string,
+	processedExpression: string,
+	renderStyle: NumeralsRenderStyle,
+): void {
+	renderTexOrText(
+		container,
+		rawExpression,
+		renderStyle,
+		() => expressionToTeX(processedExpression, rawExpression),
+	);
+}
+
+export function renderInlineValueContent(
+	container: HTMLElement,
+	formattedResult: string,
+	rawResult: unknown,
+	renderStyle: NumeralsRenderStyle,
+	preProcessors: StringReplaceMap[],
+): void {
+	renderTexOrText(
+		container,
+		formattedResult,
+		renderStyle,
+		() => resultToTeX(rawResult, preProcessors),
+	);
+}
+
+export function renderInlineResultContent(
+	container: HTMLElement,
+	mode: InlineNumeralsMode,
+	renderStyle: NumeralsRenderStyle,
+	rawExpression: string,
+	processedExpression: string,
+	formattedResult: string,
+	rawResult: unknown,
+	separator: string,
+	preProcessors: StringReplaceMap[],
+): void {
+	container.classList.add('numerals-inline');
+	if (renderStyle === NumeralsRenderStyle.TeX) {
+		container.classList.add('numerals-inline-tex');
+	}
+
+	if (mode === InlineNumeralsMode.Equation) {
+		container.classList.add('numerals-inline-equation');
+		const inputEl = createSpan(container, 'numerals-inline-input');
+		renderInlineInputContent(inputEl, rawExpression, processedExpression, renderStyle);
+		createSpan(container, 'numerals-inline-separator').textContent = separator;
+		const valueEl = createSpan(container, 'numerals-inline-value');
+		renderInlineValueContent(valueEl, formattedResult, rawResult, renderStyle, preProcessors);
+		return;
+	}
+
+	container.classList.add('numerals-inline-result');
+	const valueEl = createSpan(container, 'numerals-inline-value');
+	renderInlineValueContent(valueEl, formattedResult, rawResult, renderStyle, preProcessors);
+}
+
+export function preProcessorsEqual(
+	a: StringReplaceMap[],
+	b: StringReplaceMap[],
+): boolean {
+	return (
+		a.length === b.length &&
+		a.every((processor, index) => (
+			processor.regex.toString() === b[index].regex.toString() &&
+			processor.replaceStr === b[index].replaceStr
+		))
+	);
+}

--- a/src/inlineSuggestorUtils.ts
+++ b/src/inlineSuggestorUtils.ts
@@ -1,3 +1,5 @@
+import { getInlineTriggerCandidates } from './inline/inlineParser';
+
 /**
  * Utilities for the Numerals inline code suggestor.
  *
@@ -61,12 +63,8 @@ export function findInlineNumeralsContext(
 ): InlineNumeralsContext | null {
 	const segments = findInlineCodeSegments(line);
 
-	// Build trigger candidates, filtering out empty triggers.
-	// Sort longest-first to handle prefix conflicts (e.g. '#=:' before '#:').
-	const triggers: string[] = [];
-	if (resultTrigger) triggers.push(resultTrigger);
-	if (equationTrigger) triggers.push(equationTrigger);
-	triggers.sort((a, b) => b.length - a.length);
+	const triggers = getInlineTriggerCandidates(resultTrigger, equationTrigger)
+		.map(candidate => candidate.trigger);
 
 	if (triggers.length === 0) return null;
 

--- a/src/numerals.types.ts
+++ b/src/numerals.types.ts
@@ -225,6 +225,8 @@ export enum InlineNumeralsMode {
 export interface InlineNumeralsExpression {
 	/** The rendering mode determined by which trigger was matched */
 	mode: InlineNumeralsMode;
+	/** The visual style to use for the rendered inline expression */
+	renderStyle: NumeralsRenderStyle;
 	/** The raw expression text after the trigger prefix */
 	expression: string;
 }
@@ -235,6 +237,8 @@ export interface InlineEvaluationResult {
 	formatted: string;
 	/** The raw mathjs result value (for chaining via @prev) */
 	raw: unknown;
+	/** The preprocessed expression that was evaluated by mathjs */
+	processedExpression: string;
 	/** Note-global ($-prefixed) variables that were assigned during evaluation */
 	globals: Map<string, unknown>;
 	/** File paths referenced via [[note]].property syntax */

--- a/src/renderers/TeXRenderer.ts
+++ b/src/renderers/TeXRenderer.ts
@@ -1,13 +1,7 @@
-import * as math from 'mathjs';
 import { LineRenderData, RenderContext } from '../numerals.types';
 import { BaseLineRenderer } from './BaseLineRenderer';
-import {
-	texCurrencyReplacement,
-	unescapeSubscripts,
-	mathjaxLoop,
-	replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw,
-	getLocaleFormatter,
-} from '../rendering/displayUtils';
+import { mathjaxLoop } from '../rendering/displayUtils';
+import { expressionToTeX, resultToTeX } from '../rendering/texRendering';
 
 /**
  * TeX renderer for Numerals blocks.
@@ -70,17 +64,10 @@ export class TeXRenderer extends BaseLineRenderer {
 	 * @private
 	 */
 	private renderInputTeX(inputElement: HTMLElement, lineData: LineRenderData): void {
-		// Convert input to TeX
-		const preprocessedTex = math.parse(lineData.processedInput).toTex();
-
-		// Apply transformations
-		let inputTex = replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw(
-			preprocessedTex,
+		const inputTex = expressionToTeX(
+			lineData.processedInput,
 			lineData.rawInput + (lineData.comment || ''),
-			'@Sum()'
 		);
-		inputTex = unescapeSubscripts(inputTex);
-		inputTex = texCurrencyReplacement(inputTex);
 
 		// Render with MathJax
 		const inputTexElement = inputElement.createEl('span', { cls: 'numerals-tex' });
@@ -107,20 +94,7 @@ export class TeXRenderer extends BaseLineRenderer {
 		lineData: LineRenderData,
 		context: RenderContext
 	): void {
-		// Format result to string with reasonable precision, no grouping
-		let processedResult = math.format(
-			lineData.result,
-			getLocaleFormatter('en-US', { useGrouping: false })
-		);
-
-		// Apply preprocessors (reverse currency transformations for parsing)
-		for (const processor of context.preProcessors) {
-			processedResult = processedResult.replace(processor.regex, processor.replaceStr);
-		}
-
-		// Convert to TeX
-		let texResult = math.parse(processedResult).toTex();
-		texResult = texCurrencyReplacement(texResult);
+		const texResult = resultToTeX(lineData.result, context.preProcessors);
 
 		// Render with MathJax
 		const resultTexElement = resultElement.createEl('span', { cls: 'numerals-tex' });

--- a/src/rendering/texRendering.ts
+++ b/src/rendering/texRendering.ts
@@ -1,0 +1,50 @@
+import * as math from 'mathjs';
+import { StringReplaceMap } from '../numerals.types';
+import {
+	texCurrencyReplacement,
+	unescapeSubscripts,
+	replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw,
+	getLocaleFormatter,
+} from './displayUtils';
+
+function restoreInlineMagicVariables(tex: string, rawExpression: string): string {
+	if (!/@prev/i.test(rawExpression)) return tex;
+	return tex.replace(/(\\_\\_prev|__prev)\b/g, '@prev');
+}
+
+/**
+ * Convert a mathjs-ready expression into TeX using Numerals display conventions.
+ */
+export function expressionToTeX(
+	processedExpression: string,
+	rawExpression = processedExpression,
+): string {
+	const preprocessedTex = math.parse(processedExpression).toTex();
+	let tex = replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw(
+		preprocessedTex,
+		rawExpression,
+		'@Sum()',
+	);
+	tex = restoreInlineMagicVariables(tex, rawExpression);
+	tex = unescapeSubscripts(tex);
+	return texCurrencyReplacement(tex);
+}
+
+/**
+ * Convert an evaluated mathjs result into TeX using block TeX result formatting.
+ */
+export function resultToTeX(
+	result: unknown,
+	preProcessors: StringReplaceMap[],
+): string {
+	let processedResult = math.format(
+		result,
+		getLocaleFormatter('en-US', { useGrouping: false }),
+	);
+
+	for (const processor of preProcessors) {
+		processedResult = processedResult.replace(processor.regex, processor.replaceStr);
+	}
+
+	return texCurrencyReplacement(math.parse(processedResult).toTex());
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -434,7 +434,8 @@ export class NumeralsSettingTab extends PluginSettingTab {
 			.setDesc(htmlToElements(
 				`Evaluate math expressions in inline code when prefixed with a trigger string.<br>`
 				+ `For example: <code>#: 3ft in inches</code> renders as the result, `
-				+ `and <code>#=: 3ft + 2ft</code> shows the equation and result.`
+				+ `<code>#=: 3ft + 2ft</code> shows the equation and result, `
+				+ `and <code>#$: sqrt(144)</code> renders the result in TeX style.`
 			))
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.enableInlineNumerals)

--- a/styles.css
+++ b/styles.css
@@ -313,6 +313,10 @@ body {
     font-weight: var(--font-semibold, 600);
 }
 
+.numerals-inline .numerals-tex {
+    display: inline-block;
+}
+
 /* Faint separator between input and result in equation mode */
 .numerals-inline-equation .numerals-inline-separator {
     color: var(--text-faint);

--- a/tests/inline.test.ts
+++ b/tests/inline.test.ts
@@ -18,6 +18,7 @@ import * as math from 'mathjs';
 import { defaultCurrencyMap } from '../src/rendering/displayUtils';
 import {
 	InlineNumeralsMode,
+	NumeralsRenderStyle,
 	NumeralsScope,
 	StringReplaceMap,
 	mathjsFormat,
@@ -71,6 +72,7 @@ describe('parseInlineExpression', () => {
 			const result = parse('#: 3+2');
 			expect(result).not.toBeNull();
 			expect(result!.mode).toBe(InlineNumeralsMode.ResultOnly);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.Plain);
 			expect(result!.expression).toBe('3+2');
 		});
 
@@ -78,6 +80,23 @@ describe('parseInlineExpression', () => {
 			const result = parse('#=: 3+2');
 			expect(result).not.toBeNull();
 			expect(result!.mode).toBe(InlineNumeralsMode.Equation);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.Plain);
+			expect(result!.expression).toBe('3+2');
+		});
+
+		it('should parse TeX result-only trigger "#$: 3+2"', () => {
+			const result = parse('#$: 3+2');
+			expect(result).not.toBeNull();
+			expect(result!.mode).toBe(InlineNumeralsMode.ResultOnly);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.TeX);
+			expect(result!.expression).toBe('3+2');
+		});
+
+		it('should parse TeX equation trigger "#=$: 3+2"', () => {
+			const result = parse('#=$: 3+2');
+			expect(result).not.toBeNull();
+			expect(result!.mode).toBe(InlineNumeralsMode.Equation);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.TeX);
 			expect(result!.expression).toBe('3+2');
 		});
 
@@ -138,6 +157,13 @@ describe('parseInlineExpression', () => {
 			expect(result!.mode).toBe(InlineNumeralsMode.Equation);
 			expect(result!.expression).toBe('3ft in inches');
 		});
+
+		it('should preserve a leading $ variable after the TeX trigger delimiter', () => {
+			const result = parse('#$: $rate * 2');
+			expect(result).not.toBeNull();
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.TeX);
+			expect(result!.expression).toBe('$rate * 2');
+		});
 	});
 
 	// --- Custom triggers ----------------------------------------------------
@@ -165,6 +191,14 @@ describe('parseInlineExpression', () => {
 
 		it('should return null when text does not match custom triggers', () => {
 			expect(parse('=: 100', '@$:', '@=:')).toBeNull();
+		});
+
+		it('should still match fixed TeX triggers when plain triggers are customized', () => {
+			const result = parse('#=$: sqrt(144)', '@$:', '@=:');
+			expect(result).not.toBeNull();
+			expect(result!.mode).toBe(InlineNumeralsMode.Equation);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.TeX);
+			expect(result!.expression).toBe('sqrt(144)');
 		});
 	});
 
@@ -408,6 +442,11 @@ describe('evaluateInlineExpression', () => {
 		it('should use default format when format is undefined', () => {
 			const result = evaluateInlineExpression('2 + 2', emptyScope, undefined, noPreProcessors);
 			expect(result.formatted).toBe('4');
+		});
+
+		it('should return the processed expression used for TeX rendering', () => {
+			const result = evaluateInlineExpression('$1,000 + @prev', emptyScope, undefined, preProcessors, math.evaluate('5 USD'));
+			expect(result.processedExpression).toBe('1000 USD + __prev');
 		});
 	});
 });

--- a/tests/inlineLivePreview.test.ts
+++ b/tests/inlineLivePreview.test.ts
@@ -9,6 +9,12 @@
 jest.mock('obsidian', () => ({
 	editorInfoField: {},
 	editorLivePreviewField: {},
+	renderMath: jest.fn((tex: string) => {
+		const span = document.createElement('span');
+		span.textContent = `TeX:${tex}`;
+		return span;
+	}),
+	finishRenderMath: jest.fn().mockResolvedValue(undefined),
 }), { virtual: true });
 
 jest.mock('obsidian-dataview', () => ({
@@ -20,7 +26,7 @@ import {
 	getFormattingClasses,
 	selectionOverlapsRange,
 } from '../src/inline/inlineLivePreview';
-import { InlineNumeralsMode } from '../src/numerals.types';
+import { InlineNumeralsMode, NumeralsRenderStyle } from '../src/numerals.types';
 import { EditorSelection } from '@codemirror/state';
 
 beforeAll(() => {
@@ -143,6 +149,50 @@ describe('InlineNumeralsWidget', () => {
 			expect(el.querySelector('.numerals-inline-value')?.textContent).toBe('5 ft');
 		});
 
+		it('should render result-only TeX mode with MathJax inside the value span', async () => {
+			const widget = new InlineNumeralsWidget(
+				'12',
+				InlineNumeralsMode.ResultOnly,
+				'sqrt(144)',
+				' = ',
+				false,
+				[],
+				NumeralsRenderStyle.TeX,
+				12,
+				'sqrt(144)',
+				[],
+			);
+			const el = widget.toDOM();
+			await Promise.resolve();
+
+			expect(el.classList.contains('numerals-inline-result')).toBe(true);
+			expect(el.classList.contains('numerals-inline-tex')).toBe(true);
+			expect(el.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:12');
+		});
+
+		it('should render equation TeX mode with MathJax input and value spans', async () => {
+			const widget = new InlineNumeralsWidget(
+				'12',
+				InlineNumeralsMode.Equation,
+				'sqrt(144)',
+				' = ',
+				false,
+				[],
+				NumeralsRenderStyle.TeX,
+				12,
+				'sqrt(144)',
+				[],
+			);
+			const el = widget.toDOM();
+			await Promise.resolve();
+
+			expect(el.classList.contains('numerals-inline-equation')).toBe(true);
+			expect(el.classList.contains('numerals-inline-tex')).toBe(true);
+			expect(el.querySelector('.numerals-inline-input .numerals-tex')?.textContent).toBe('TeX:\\sqrt{144}');
+			expect(el.querySelector('.numerals-inline-separator')?.textContent).toBe(' = ');
+			expect(el.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:12');
+		});
+
 		it('should create widget nodes from the editor ownerDocument', () => {
 			const editorDocument = document.implementation.createHTMLDocument('editor');
 			const editorDom = editorDocument.createElement('div');
@@ -249,6 +299,12 @@ describe('InlineNumeralsWidget', () => {
 			const a = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong', 'cm-em']);
 			const b = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong', 'cm-em']);
 			expect(a.eq(b)).toBe(true);
+		});
+
+		it('should return false when render style differs', () => {
+			const a = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, [], NumeralsRenderStyle.Plain);
+			const b = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, [], NumeralsRenderStyle.TeX);
+			expect(a.eq(b)).toBe(false);
 		});
 	});
 });

--- a/tests/inlinePostProcessor.test.ts
+++ b/tests/inlinePostProcessor.test.ts
@@ -11,6 +11,12 @@ jest.mock("obsidian", () => ({
 	MarkdownRenderChild: class {
 		registerEvent = jest.fn((ref) => mockRegisteredEvents.push(ref));
 	},
+	renderMath: jest.fn((tex: string) => {
+		const span = document.createElement('span');
+		span.textContent = `TeX:${tex}`;
+		return span;
+	}),
+	finishRenderMath: jest.fn().mockResolvedValue(undefined),
 }), { virtual: true });
 jest.mock(
 	"obsidian-dataview",
@@ -146,6 +152,70 @@ describe('inline numerals integration', () => {
 			const output = simulateInlinePipeline('#=: sqrt(144)');
 			expect(output).not.toBeNull();
 			expect(output!.result).toBe('12');
+		});
+	});
+
+	describe('TeX rendering mode', () => {
+		it('should render "#$: sqrt(144)" as a TeX result in Reading mode', async () => {
+			const app = {
+				vault: { getAbstractFileByPath: jest.fn(() => ({ path: 'source.md' })) },
+				metadataCache: {
+					getFileCache: jest.fn(() => ({ frontmatter: {} })),
+					on: jest.fn(),
+				},
+			};
+			const ctx = { sourcePath: 'source.md', addChild: jest.fn() };
+			const container = document.createElement('p');
+			const code = document.createElement('code');
+			code.innerText = '#$: sqrt(144)';
+			container.appendChild(code);
+
+			const postProcessor = createInlineNumeralsPostProcessor(
+				app as any,
+				() => DEFAULT_SETTINGS,
+				() => undefined,
+				() => [],
+				new Map(),
+			);
+
+			postProcessor(container, ctx as any);
+			await Promise.resolve();
+
+			expect(code.classList.contains('numerals-inline-result')).toBe(true);
+			expect(code.classList.contains('numerals-inline-tex')).toBe(true);
+			expect(code.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:12');
+		});
+
+		it('should render "#=$: sqrt(144)" with TeX input and result in Reading mode', async () => {
+			const app = {
+				vault: { getAbstractFileByPath: jest.fn(() => ({ path: 'source.md' })) },
+				metadataCache: {
+					getFileCache: jest.fn(() => ({ frontmatter: {} })),
+					on: jest.fn(),
+				},
+			};
+			const ctx = { sourcePath: 'source.md', addChild: jest.fn() };
+			const container = document.createElement('p');
+			const code = document.createElement('code');
+			code.innerText = '#=$: sqrt(144)';
+			container.appendChild(code);
+
+			const postProcessor = createInlineNumeralsPostProcessor(
+				app as any,
+				() => DEFAULT_SETTINGS,
+				() => undefined,
+				() => [],
+				new Map(),
+			);
+
+			postProcessor(container, ctx as any);
+			await Promise.resolve();
+
+			expect(code.classList.contains('numerals-inline-equation')).toBe(true);
+			expect(code.classList.contains('numerals-inline-tex')).toBe(true);
+			expect(code.querySelector('.numerals-inline-input .numerals-tex')?.textContent).toBe('TeX:\\sqrt{144}');
+			expect(code.querySelector('.numerals-inline-separator')?.textContent).toBe(' = ');
+			expect(code.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:12');
 		});
 	});
 

--- a/tests/inlineSuggestor.test.ts
+++ b/tests/inlineSuggestor.test.ts
@@ -38,6 +38,22 @@ describe('findInlineNumeralsContext', () => {
 			expect(result!.triggerPrefix).toBe('#=:');
 		});
 
+		it('should detect cursor inside TeX result-only inline code', () => {
+			const line = 'text `#$: sqrt(144)` more';
+			const result = find(line, line.indexOf('`', 6)); // cursor before closing backtick
+			expect(result).not.toBeNull();
+			expect(result!.triggerPrefix).toBe('#$:');
+			expect(result!.expressionUpToCursor).toBe(' sqrt(144)');
+		});
+
+		it('should detect cursor inside TeX equation inline code', () => {
+			const line = 'text `#=$: sqrt(144)` more';
+			const result = find(line, line.indexOf('`', 6)); // cursor before closing backtick
+			expect(result).not.toBeNull();
+			expect(result!.triggerPrefix).toBe('#=$:');
+			expect(result!.expressionUpToCursor).toBe(' sqrt(144)');
+		});
+
 		it('should return null when cursor is outside inline code', () => {
 			const line = 'text `#: 3+2` more';
 			const result = find(line, 16); // cursor in 'more'
@@ -174,6 +190,13 @@ describe('findInlineNumeralsContext', () => {
 			const result = find(line, 10, 'nm:', 'nm=:');
 			expect(result).not.toBeNull();
 			expect(result!.triggerPrefix).toBe('nm:');
+		});
+
+		it('should keep fixed TeX trigger detection when plain triggers are customized', () => {
+			const line = '`#=$: sqrt(2)`';
+			const result = find(line, 13, 'nm:', 'nm=:');
+			expect(result).not.toBeNull();
+			expect(result!.triggerPrefix).toBe('#=$:');
 		});
 
 		it('should handle empty result trigger gracefully', () => {


### PR DESCRIPTION
## Feature spec

Closes #161.

Add per-expression TeX rendering for Inline Numerals without a global setting:

- `` `#$: expression` `` evaluates the expression with the existing inline pipeline and renders only the result with MathJax/TeX.
- `` `#=$: expression` `` evaluates the expression and renders the expression, inline equation separator, and result with MathJax/TeX.
- Existing plain inline syntax remains unchanged: `` `#: expression` `` and `` `#=: expression` `` keep rendering text output and continue to respect custom plain trigger settings.
- The fixed TeX triggers are intentionally colon-delimited so expressions that begin with `$` variables, such as `` `#$: $rate * 2` ``, are unambiguous.
- The inline enable toggle remains the feature gate; no new render-style setting is added.

## Architecture

The implementation keeps the existing inline pipeline boundaries intact:

- `inlineParser` owns trigger matching and now returns both the inline mode and render style. It also exposes the shared trigger candidate list so Reading mode, Live Preview, and autocomplete use the same prefix rules.
- `inlineEvaluator` still performs all mathjs evaluation and now returns the processed expression that was actually evaluated. TeX rendering uses that value instead of duplicating preprocessing or cross-note resolution.
- `src/rendering/texRendering.ts` contains shared mathjs-to-TeX helpers. Block `math-tex` rendering and inline TeX rendering now use the same conversion path for expressions, results, currency symbols, subscripts, and no-grouping result formatting.
- `src/inline/inlineRenderer.ts` centralizes inline DOM construction so Reading mode and Live Preview produce the same plain and TeX markup.

## Behavior notes

- Reading mode and Live Preview both support the new TeX syntax.
- Inline autocomplete recognizes the fixed TeX prefixes as Numerals contexts.
- Existing inline features are preserved: units, currencies, configured number formatting, frontmatter scope, note-global `$` variables, `@prev`, and cross-note references.
- If TeX conversion fails for a rendered segment, that segment falls back to the existing text display instead of breaking the whole inline expression.

## Changes

- Added fixed TeX inline triggers `#$:` and `#=$:`.
- Added shared inline render helpers and shared TeX conversion helpers.
- Refactored `TeXRenderer` to use the shared TeX conversion helpers.
- Updated tests for parser behavior, Reading mode rendering, Live Preview widgets, and inline autocomplete detection.
- Documented the new syntax in README, settings help text, and CHANGELOG.

## Verification

- `npm test -- --runInBand` - 405 tests passed
- `npm run lint` - passed
- `npm run build` - passed