### PR TITLE
feat: add TeX-style inline rendering triggers (#$: and #=$:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+- Per-expression TeX rendering for Inline Numerals via the new `#$:` (result only) and `#=$:` (equation) trigger prefixes, which render with MathJax in both Live Preview and Reading mode. Both prefixes are configurable in settings. (Closes #161)
+
 ## [1.10.2] - 2026-05-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -55,8 +55,12 @@ Inline Numerals expressions are ordinary inline code with a trigger prefix:
 | --- | --- | --- |
 | `` `#: 3ft * 4ft` `` | `12 ft^2` | Showing just the answer |
 | `` `#=: 3ft * 4ft` `` | `3 ft * 4 ft = 12 ft^2` | Showing the expression and answer |
+| `` `#$: 3ft * 4ft` `` | 12 ft² typeset with MathJax | A TeX-rendered answer |
+| `` `#=$: 3ft * 4ft` `` | 3 ft · 4 ft = 12 ft² typeset with MathJax | A TeX-rendered equation |
 
 Inline calculations work in Live Preview and Reading mode. They support the same math engine, number formatting, units, currency symbols, variables, frontmatter, and Dataview values as math blocks.
+
+The `#$:` and `#=$:` triggers render the result (and, in equation mode, the expression) as TeX-style MathJax — the same typesetting used by math blocks — chosen per expression rather than through a global setting. All four trigger prefixes are configurable in the Numerals settings.
 
 ### Math Blocks
 

--- a/src/NumeralsSuggestor.ts
+++ b/src/NumeralsSuggestor.ts
@@ -159,8 +159,12 @@ export class NumeralsSuggestor extends EditorSuggest<string> {
 		const inlineCtx = findInlineNumeralsContext(
 			currentLine,
 			cursor.ch,
-			this.plugin.settings.inlineResultTrigger,
-			this.plugin.settings.inlineEquationTrigger,
+			{
+				resultTrigger: this.plugin.settings.inlineResultTrigger,
+				equationTrigger: this.plugin.settings.inlineEquationTrigger,
+				texResultTrigger: this.plugin.settings.inlineTexResultTrigger,
+				texEquationTrigger: this.plugin.settings.inlineTexEquationTrigger,
+			},
 		);
 
 		if (!inlineCtx) {

--- a/src/NumeralsSuggestor.ts
+++ b/src/NumeralsSuggestor.ts
@@ -12,6 +12,7 @@ import {
  } from "obsidian";
 import { getMathJsSymbols } from "./mathjsUtilities";
 import { findInlineNumeralsContext } from "./inlineSuggestorUtils";
+import { getInlineTriggers } from "./inline/inlineParser";
 
 const greekSymbols = [
     { trigger: 'alpha', symbol: 'α' },
@@ -159,12 +160,7 @@ export class NumeralsSuggestor extends EditorSuggest<string> {
 		const inlineCtx = findInlineNumeralsContext(
 			currentLine,
 			cursor.ch,
-			{
-				resultTrigger: this.plugin.settings.inlineResultTrigger,
-				equationTrigger: this.plugin.settings.inlineEquationTrigger,
-				texResultTrigger: this.plugin.settings.inlineTexResultTrigger,
-				texEquationTrigger: this.plugin.settings.inlineTexEquationTrigger,
-			},
+			getInlineTriggers(this.plugin.settings),
 		);
 
 		if (!inlineCtx) {

--- a/src/inline/inlineEvaluator.ts
+++ b/src/inline/inlineEvaluator.ts
@@ -89,5 +89,5 @@ export function evaluateInlineExpression(
 		}
 	}
 
-	return { formatted, raw: result, globals, referencedPaths };
+	return { formatted, raw: result, processedExpression: processed, globals, referencedPaths };
 }

--- a/src/inline/inlineLivePreview.ts
+++ b/src/inline/inlineLivePreview.ts
@@ -42,11 +42,18 @@ import {
 	mathjsFormat,
 	StringReplaceMap,
 	InlineNumeralsMode,
+	NumeralsRenderStyle,
+	InlineTriggerSettings,
 } from '../numerals.types';
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
 import { parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
 import { getDataviewApi } from '../dataview';
+import {
+	preProcessorsEqual,
+	renderInlineInputContent,
+	renderInlineValueContent,
+} from './inlineRenderer';
 
 /****************************************************
  * Formatting context helpers
@@ -136,6 +143,10 @@ export class InlineNumeralsWidget extends WidgetType {
 		private readonly separator: string,
 		private readonly isError: boolean,
 		private readonly formattingClasses: string[] = [],
+		private readonly renderStyle: NumeralsRenderStyle = NumeralsRenderStyle.Plain,
+		private readonly rawResult: unknown = resultText,
+		private readonly processedExpression: string = rawExpression,
+		private readonly preProcessors: StringReplaceMap[] = [],
 	) {
 		super();
 	}
@@ -151,6 +162,12 @@ export class InlineNumeralsWidget extends WidgetType {
 			this.rawExpression === other.rawExpression &&
 			this.separator === other.separator &&
 			this.isError === other.isError &&
+			this.renderStyle === other.renderStyle &&
+			// rawResult is intentionally not compared: mathjs results can be
+			// fresh objects on every evaluation pass, and any visible change
+			// is already captured by resultText and processedExpression.
+			this.processedExpression === other.processedExpression &&
+			preProcessorsEqual(this.preProcessors, other.preProcessors) &&
 			this.formattingClasses.length === other.formattingClasses.length &&
 			this.formattingClasses.every((c, i) => c === other.formattingClasses[i])
 		);
@@ -160,6 +177,11 @@ export class InlineNumeralsWidget extends WidgetType {
 		const ownerDocument = view?.dom.ownerDocument ?? activeDocument;
 		const span = ownerDocument.createElement('span');
 		span.classList.add('cm-inline-code', 'numerals-inline');
+
+		// TeX-rendered spans strip the code chrome so they read as native inline math
+		if (this.renderStyle === NumeralsRenderStyle.TeX) {
+			span.classList.add('numerals-inline-tex');
+		}
 
 		// Apply inherited formatting (bold, italic, etc.)
 		for (const cls of this.formattingClasses) {
@@ -177,7 +199,12 @@ export class InlineNumeralsWidget extends WidgetType {
 
 			const inputEl = ownerDocument.createElement('span');
 			inputEl.className = 'numerals-inline-input';
-			inputEl.textContent = this.rawExpression;
+			renderInlineInputContent(
+				inputEl,
+				this.rawExpression,
+				this.processedExpression,
+				this.renderStyle
+			);
 
 			const sepEl = ownerDocument.createElement('span');
 			sepEl.className = 'numerals-inline-separator';
@@ -185,7 +212,13 @@ export class InlineNumeralsWidget extends WidgetType {
 
 			const valueEl = ownerDocument.createElement('span');
 			valueEl.className = 'numerals-inline-value';
-			valueEl.textContent = this.resultText;
+			renderInlineValueContent(
+				valueEl,
+				this.resultText,
+				this.rawResult,
+				this.renderStyle,
+				this.preProcessors
+			);
 
 			span.appendChild(inputEl);
 			span.appendChild(sepEl);
@@ -196,7 +229,13 @@ export class InlineNumeralsWidget extends WidgetType {
 
 			const valueEl = ownerDocument.createElement('span');
 			valueEl.className = 'numerals-inline-value';
-			valueEl.textContent = this.resultText;
+			renderInlineValueContent(
+				valueEl,
+				this.resultText,
+				this.rawResult,
+				this.renderStyle,
+				this.preProcessors
+			);
 
 			span.appendChild(valueEl);
 		}
@@ -220,8 +259,7 @@ interface PrevResultRef {
 /** Context assembled once per decoration pass. */
 interface DecorationContext {
 	settings: NumeralsSettings;
-	resultTrigger: string;
-	equationTrigger: string;
+	triggers: InlineTriggerSettings;
 	numberFormat: mathjsFormat | undefined;
 	preProcessors: StringReplaceMap[];
 	getScope: () => NumeralsScope;
@@ -247,9 +285,19 @@ function createDecorationContext(
 
 	if (!settings.enableInlineNumerals) return null;
 
-	const resultTrigger = settings.inlineResultTrigger;
-	const equationTrigger = settings.inlineEquationTrigger;
-	if (!resultTrigger && !equationTrigger) return null;
+	const triggers: InlineTriggerSettings = {
+		resultTrigger: settings.inlineResultTrigger,
+		equationTrigger: settings.inlineEquationTrigger,
+		texResultTrigger: settings.inlineTexResultTrigger,
+		texEquationTrigger: settings.inlineTexEquationTrigger,
+	};
+	// Guard against all triggers empty (would match every code span)
+	if (
+		!triggers.resultTrigger &&
+		!triggers.equationTrigger &&
+		!triggers.texResultTrigger &&
+		!triggers.texEquationTrigger
+	) return null;
 
 	// Lazy scope resolution — only built on first matching expression
 	let scope: NumeralsScope | null = null;
@@ -274,8 +322,7 @@ function createDecorationContext(
 
 	return {
 		settings,
-		resultTrigger,
-		equationTrigger,
+		triggers,
 		numberFormat: getNumberFormat(),
 		preProcessors,
 		getScope,
@@ -310,7 +357,7 @@ function tryBuildNodeDecoration(
 ): Range<Decoration> | null {
 	const text = doc.sliceString(nodeFrom, nodeTo);
 
-	const parsed = parseInlineExpression(text, ctx.resultTrigger, ctx.equationTrigger);
+	const parsed = parseInlineExpression(text, ctx.triggers);
 	if (!parsed) return null;
 
 	// Span includes backtick delimiters (1 char each side)
@@ -324,6 +371,8 @@ function tryBuildNodeDecoration(
 
 	// Evaluate
 	let resultText: string;
+	let rawResult: unknown = '';
+	let processedExpression = parsed.expression;
 	let isError = false;
 	try {
 		const scope = ctx.getScope();
@@ -338,6 +387,8 @@ function tryBuildNodeDecoration(
 			ctx.settings,
 		);
 		resultText = result.formatted;
+		rawResult = result.raw;
+		processedExpression = result.processedExpression;
 		prevResultRef.value = result.raw;
 		for (const path of result.referencedPaths) {
 			ctx.referencedPaths.add(path);
@@ -363,6 +414,8 @@ function tryBuildNodeDecoration(
 		}
 	} catch {
 		resultText = '';
+		rawResult = '';
+		processedExpression = parsed.expression;
 		isError = true;
 		prevResultRef.value = undefined;
 	}
@@ -376,6 +429,10 @@ function tryBuildNodeDecoration(
 		ctx.settings.inlineEquationSeparator,
 		isError,
 		formattingClasses,
+		parsed.renderStyle,
+		rawResult,
+		processedExpression,
+		ctx.preProcessors,
 	);
 
 	return Decoration.replace({ widget }).range(spanFrom, spanTo);

--- a/src/inline/inlineLivePreview.ts
+++ b/src/inline/inlineLivePreview.ts
@@ -46,7 +46,7 @@ import {
 	InlineTriggerSettings,
 } from '../numerals.types';
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
-import { parseInlineExpression } from './inlineParser';
+import { getActiveInlineTriggers, getInlineTriggers, parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
 import { getDataviewApi } from '../dataview';
 import {
@@ -285,19 +285,9 @@ function createDecorationContext(
 
 	if (!settings.enableInlineNumerals) return null;
 
-	const triggers: InlineTriggerSettings = {
-		resultTrigger: settings.inlineResultTrigger,
-		equationTrigger: settings.inlineEquationTrigger,
-		texResultTrigger: settings.inlineTexResultTrigger,
-		texEquationTrigger: settings.inlineTexEquationTrigger,
-	};
+	const triggers = getInlineTriggers(settings);
 	// Guard against all triggers empty (would match every code span)
-	if (
-		!triggers.resultTrigger &&
-		!triggers.equationTrigger &&
-		!triggers.texResultTrigger &&
-		!triggers.texEquationTrigger
-	) return null;
+	if (getActiveInlineTriggers(settings).length === 0) return null;
 
 	// Lazy scope resolution — only built on first matching expression
 	let scope: NumeralsScope | null = null;

--- a/src/inline/inlineParser.ts
+++ b/src/inline/inlineParser.ts
@@ -1,39 +1,46 @@
-import { InlineNumeralsMode, InlineNumeralsExpression } from '../numerals.types';
+import {
+	InlineNumeralsMode,
+	InlineNumeralsExpression,
+	InlineTriggerSettings,
+	NumeralsRenderStyle,
+} from '../numerals.types';
 
 /**
  * Attempt to parse an inline code string as a Numerals expression.
  *
- * Checks whether the text starts with a recognized trigger prefix.
- * The longer trigger is checked first to handle the case where
- * one trigger is a prefix of the other (e.g. "=:" vs "==:").
+ * Checks whether the text starts with a recognized trigger prefix. Each
+ * trigger maps to a rendering mode (result-only or equation) and a render
+ * style (plain text or TeX). Triggers are checked longest-first so that a
+ * longer trigger that has a shorter trigger as a prefix wins (e.g. "#=$:"
+ * before "#=:", "#$:", and "#:").
  *
  * Empty triggers are silently ignored to prevent matching all code spans.
  *
  * @param text - The raw inline code text
- * @param resultTrigger - Trigger prefix for result-only mode (e.g. "=:")
- * @param equationTrigger - Trigger prefix for equation mode (e.g. "==:")
- * @returns Parsed expression with mode, or null if no trigger matched
+ * @param triggers - The four configured trigger prefixes from settings
+ * @returns Parsed expression with mode and render style, or null if no trigger matched
  */
 export function parseInlineExpression(
 	text: string,
-	resultTrigger: string,
-	equationTrigger: string
+	triggers: InlineTriggerSettings
 ): InlineNumeralsExpression | null {
-	// Build candidate list, filtering out empty triggers
-	const candidates: [string, InlineNumeralsMode][] = [];
-	if (resultTrigger) candidates.push([resultTrigger, InlineNumeralsMode.ResultOnly]);
-	if (equationTrigger) candidates.push([equationTrigger, InlineNumeralsMode.Equation]);
+	// Build candidate list, filtering out empty triggers.
+	const candidates: [string, InlineNumeralsMode, NumeralsRenderStyle][] = [];
+	if (triggers.resultTrigger) candidates.push([triggers.resultTrigger, InlineNumeralsMode.ResultOnly, NumeralsRenderStyle.Plain]);
+	if (triggers.equationTrigger) candidates.push([triggers.equationTrigger, InlineNumeralsMode.Equation, NumeralsRenderStyle.Plain]);
+	if (triggers.texResultTrigger) candidates.push([triggers.texResultTrigger, InlineNumeralsMode.ResultOnly, NumeralsRenderStyle.TeX]);
+	if (triggers.texEquationTrigger) candidates.push([triggers.texEquationTrigger, InlineNumeralsMode.Equation, NumeralsRenderStyle.TeX]);
 
-	// Sort longest-first to avoid prefix conflicts ("==:" before "=:")
+	// Sort longest-first to avoid prefix conflicts ("#=$:" before "#=:")
 	candidates.sort((a, b) => b[0].length - a[0].length);
 
-	for (const [trigger, mode] of candidates) {
+	for (const [trigger, mode, renderStyle] of candidates) {
 		if (text.startsWith(trigger)) {
 			const expression = text.slice(trigger.length).trim();
 			if (expression.length === 0) {
 				return null;
 			}
-			return { mode, expression };
+			return { mode, renderStyle, expression };
 		}
 	}
 

--- a/src/inline/inlineParser.ts
+++ b/src/inline/inlineParser.ts
@@ -3,7 +3,43 @@ import {
 	InlineNumeralsExpression,
 	InlineTriggerSettings,
 	NumeralsRenderStyle,
+	NumeralsSettings,
 } from '../numerals.types';
+
+/**
+ * Collect the four inline trigger prefixes from plugin settings.
+ *
+ * Single source of truth for every consumer of the inline triggers
+ * (parser, post-processor, Live Preview, autocomplete suggestor), so a
+ * future trigger only needs to be added here.
+ */
+export function getInlineTriggers(settings: NumeralsSettings): InlineTriggerSettings {
+	return {
+		resultTrigger: settings.inlineResultTrigger,
+		equationTrigger: settings.inlineEquationTrigger,
+		texResultTrigger: settings.inlineTexResultTrigger,
+		texEquationTrigger: settings.inlineTexEquationTrigger,
+	};
+}
+
+/**
+ * List all trigger prefixes from an InlineTriggerSettings object.
+ */
+export function listInlineTriggers(triggers: InlineTriggerSettings): string[] {
+	return [
+		triggers.resultTrigger,
+		triggers.equationTrigger,
+		triggers.texResultTrigger,
+		triggers.texEquationTrigger,
+	];
+}
+
+/**
+ * The non-empty trigger prefixes from settings (empty string disables a trigger).
+ */
+export function getActiveInlineTriggers(settings: NumeralsSettings): string[] {
+	return listInlineTriggers(getInlineTriggers(settings)).filter(t => t.length > 0);
+}
 
 /**
  * Attempt to parse an inline code string as a Numerals expression.

--- a/src/inline/inlinePostProcessor.ts
+++ b/src/inline/inlinePostProcessor.ts
@@ -1,9 +1,10 @@
 import { App, MarkdownPostProcessorContext, MarkdownRenderChild } from 'obsidian';
-import { NumeralsSettings, NumeralsScope, mathjsFormat, StringReplaceMap, InlineNumeralsMode } from '../numerals.types';
+import { NumeralsSettings, NumeralsScope, mathjsFormat, StringReplaceMap, InlineNumeralsMode, InlineEvaluationResult, NumeralsRenderStyle } from '../numerals.types';
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
 import { parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
 import { getDataviewApi } from '../dataview';
+import { renderInlineInputContent, renderInlineValueContent } from './inlineRenderer';
 
 /**
  * Write `$`-prefixed globals to the shared scope cache.
@@ -34,6 +35,7 @@ function addGlobalsToScopeCache(
  * @param codeEl - The <code> element to render into
  * @param expression - The raw expression text (trigger already stripped)
  * @param mode - Whether to show result-only or equation style
+ * @param renderStyle - Whether to render as plain text or TeX (from the matched trigger)
  * @param result - The formatted result string
  * @param settings - Plugin settings (for separator string)
  */
@@ -41,20 +43,47 @@ function renderInlineResult(
 	codeEl: HTMLElement,
 	expression: string,
 	mode: InlineNumeralsMode,
-	result: string,
-	settings: NumeralsSettings
+	renderStyle: NumeralsRenderStyle,
+	result: InlineEvaluationResult,
+	settings: NumeralsSettings,
+	preProcessors: StringReplaceMap[]
 ): void {
 	codeEl.empty();
 	codeEl.addClass('numerals-inline');
 
+	// TeX-rendered spans strip the code chrome so they read as native inline math
+	if (renderStyle === NumeralsRenderStyle.TeX) {
+		codeEl.addClass('numerals-inline-tex');
+	}
+
 	if (mode === InlineNumeralsMode.Equation) {
 		codeEl.addClass('numerals-inline-equation');
-		codeEl.createEl('span', { cls: 'numerals-inline-input', text: expression });
+		const inputEl = codeEl.createEl('span', { cls: 'numerals-inline-input' });
+		renderInlineInputContent(
+			inputEl,
+			expression,
+			result.processedExpression,
+			renderStyle
+		);
 		codeEl.createEl('span', { cls: 'numerals-inline-separator', text: settings.inlineEquationSeparator });
-		codeEl.createEl('span', { cls: 'numerals-inline-value', text: result });
+		const valueEl = codeEl.createEl('span', { cls: 'numerals-inline-value' });
+		renderInlineValueContent(
+			valueEl,
+			result.formatted,
+			result.raw,
+			renderStyle,
+			preProcessors
+		);
 	} else {
 		codeEl.addClass('numerals-inline-result');
-		codeEl.createEl('span', { cls: 'numerals-inline-value', text: result });
+		const valueEl = codeEl.createEl('span', { cls: 'numerals-inline-value' });
+		renderInlineValueContent(
+			valueEl,
+			result.formatted,
+			result.raw,
+			renderStyle,
+			preProcessors
+		);
 	}
 }
 
@@ -117,11 +146,12 @@ function processInlineCodeElement(
 ): InlineProcessingResult {
 	const text = codeEl.dataset.numeralsInlineSource ?? codeEl.innerText;
 
-	const parsed = parseInlineExpression(
-		text,
-		settings.inlineResultTrigger,
-		settings.inlineEquationTrigger
-	);
+	const parsed = parseInlineExpression(text, {
+		resultTrigger: settings.inlineResultTrigger,
+		equationTrigger: settings.inlineEquationTrigger,
+		texResultTrigger: settings.inlineTexResultTrigger,
+		texEquationTrigger: settings.inlineTexEquationTrigger,
+	});
 
 	if (!parsed) return { referencedPaths: [] };
 
@@ -150,7 +180,7 @@ function processInlineCodeElement(
 			addGlobalsToScopeCache(scopeCache, sourcePath, result.globals);
 		}
 
-		renderInlineResult(codeEl, parsed.expression, parsed.mode, result.formatted, settings);
+		renderInlineResult(codeEl, parsed.expression, parsed.mode, parsed.renderStyle, result, settings, preProcessors);
 		return { referencedPaths: result.referencedPaths };
 	} catch {
 		prevResultRef.value = undefined;
@@ -189,11 +219,16 @@ export function createInlineNumeralsPostProcessor(
 		const settings = getSettings();
 		if (!settings.enableInlineNumerals) return;
 
-		const resultTrigger = settings.inlineResultTrigger;
-		const equationTrigger = settings.inlineEquationTrigger;
+		// Collect the non-empty triggers (empty string disables a trigger).
+		const activeTriggers = [
+			settings.inlineResultTrigger,
+			settings.inlineEquationTrigger,
+			settings.inlineTexResultTrigger,
+			settings.inlineTexEquationTrigger,
+		].filter(t => t.length > 0);
 
-		// Guard against empty triggers (would match every <code> element)
-		if (!resultTrigger && !equationTrigger) return;
+		// Guard against all triggers empty (would match every <code> element)
+		if (activeTriggers.length === 0) return;
 
 		const codeElements = el.querySelectorAll<HTMLElement>('code');
 		if (codeElements.length === 0) return;
@@ -201,8 +236,7 @@ export function createInlineNumeralsPostProcessor(
 		// Quick-reject: check if any code element starts with a trigger
 		// before building scope (which is the expensive part)
 		const hasMatch = Array.from(codeElements).some(code =>
-			code.innerText.startsWith(resultTrigger) ||
-			code.innerText.startsWith(equationTrigger)
+			activeTriggers.some(t => code.innerText.startsWith(t))
 		);
 		if (!hasMatch) return;
 

--- a/src/inline/inlinePostProcessor.ts
+++ b/src/inline/inlinePostProcessor.ts
@@ -1,7 +1,7 @@
 import { App, MarkdownPostProcessorContext, MarkdownRenderChild } from 'obsidian';
 import { NumeralsSettings, NumeralsScope, mathjsFormat, StringReplaceMap, InlineNumeralsMode, InlineEvaluationResult, NumeralsRenderStyle } from '../numerals.types';
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
-import { parseInlineExpression } from './inlineParser';
+import { getActiveInlineTriggers, getInlineTriggers, parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
 import { getDataviewApi } from '../dataview';
 import { renderInlineInputContent, renderInlineValueContent } from './inlineRenderer';
@@ -146,12 +146,7 @@ function processInlineCodeElement(
 ): InlineProcessingResult {
 	const text = codeEl.dataset.numeralsInlineSource ?? codeEl.innerText;
 
-	const parsed = parseInlineExpression(text, {
-		resultTrigger: settings.inlineResultTrigger,
-		equationTrigger: settings.inlineEquationTrigger,
-		texResultTrigger: settings.inlineTexResultTrigger,
-		texEquationTrigger: settings.inlineTexEquationTrigger,
-	});
+	const parsed = parseInlineExpression(text, getInlineTriggers(settings));
 
 	if (!parsed) return { referencedPaths: [] };
 
@@ -219,13 +214,7 @@ export function createInlineNumeralsPostProcessor(
 		const settings = getSettings();
 		if (!settings.enableInlineNumerals) return;
 
-		// Collect the non-empty triggers (empty string disables a trigger).
-		const activeTriggers = [
-			settings.inlineResultTrigger,
-			settings.inlineEquationTrigger,
-			settings.inlineTexResultTrigger,
-			settings.inlineTexEquationTrigger,
-		].filter(t => t.length > 0);
+		const activeTriggers = getActiveInlineTriggers(settings);
 
 		// Guard against all triggers empty (would match every <code> element)
 		if (activeTriggers.length === 0) return;

--- a/src/inline/inlineRenderer.ts
+++ b/src/inline/inlineRenderer.ts
@@ -21,8 +21,13 @@ function renderTexOrText(
 	}
 
 	try {
+		const tex = toTex();
 		const texElement = createSpan(container, 'numerals-tex');
-		void mathjaxLoop(texElement, toTex());
+		// mathjaxLoop is async, so a MathJax failure surfaces as a rejection
+		// that the surrounding try/catch cannot see — fall back to plain text.
+		void mathjaxLoop(texElement, tex).catch(() => {
+			texElement.textContent = text;
+		});
 	} catch {
 		container.textContent = text;
 	}

--- a/src/inline/inlineRenderer.ts
+++ b/src/inline/inlineRenderer.ts
@@ -1,0 +1,71 @@
+import { NumeralsRenderStyle, StringReplaceMap } from '../numerals.types';
+import { mathjaxLoop } from '../rendering/displayUtils';
+import { expressionToTeX, resultToTeX } from '../rendering/texRendering';
+
+function createSpan(parent: HTMLElement, className: string): HTMLElement {
+	const span = parent.ownerDocument.createElement('span');
+	span.className = className;
+	parent.appendChild(span);
+	return span;
+}
+
+function renderTexOrText(
+	container: HTMLElement,
+	text: string,
+	renderStyle: NumeralsRenderStyle,
+	toTex: () => string
+): void {
+	if (renderStyle !== NumeralsRenderStyle.TeX) {
+		container.textContent = text;
+		return;
+	}
+
+	try {
+		const texElement = createSpan(container, 'numerals-tex');
+		void mathjaxLoop(texElement, toTex());
+	} catch {
+		container.textContent = text;
+	}
+}
+
+export function renderInlineInputContent(
+	container: HTMLElement,
+	rawExpression: string,
+	processedExpression: string,
+	renderStyle: NumeralsRenderStyle
+): void {
+	renderTexOrText(
+		container,
+		rawExpression,
+		renderStyle,
+		() => expressionToTeX(processedExpression, rawExpression)
+	);
+}
+
+export function renderInlineValueContent(
+	container: HTMLElement,
+	formattedResult: string,
+	rawResult: unknown,
+	renderStyle: NumeralsRenderStyle,
+	preProcessors: StringReplaceMap[]
+): void {
+	renderTexOrText(
+		container,
+		formattedResult,
+		renderStyle,
+		() => resultToTeX(rawResult, preProcessors)
+	);
+}
+
+export function preProcessorsEqual(
+	a: StringReplaceMap[],
+	b: StringReplaceMap[]
+): boolean {
+	return (
+		a.length === b.length &&
+		a.every((processor, index) => (
+			processor.regex.toString() === b[index].regex.toString() &&
+			processor.replaceStr === b[index].replaceStr
+		))
+	);
+}

--- a/src/inlineSuggestorUtils.ts
+++ b/src/inlineSuggestorUtils.ts
@@ -7,6 +7,7 @@
  */
 
 import { InlineTriggerSettings } from './numerals.types';
+import { listInlineTriggers } from './inline/inlineParser';
 
 /**
  * Result of detecting an inline Numerals context on a line.
@@ -63,12 +64,7 @@ export function findInlineNumeralsContext(
 
 	// Build trigger candidates, filtering out empty triggers.
 	// Sort longest-first to handle prefix conflicts (e.g. '#=$:' before '#=:').
-	const triggers = [
-		triggerSettings.resultTrigger,
-		triggerSettings.equationTrigger,
-		triggerSettings.texResultTrigger,
-		triggerSettings.texEquationTrigger,
-	].filter(t => t.length > 0);
+	const triggers = listInlineTriggers(triggerSettings).filter(t => t.length > 0);
 	triggers.sort((a, b) => b.length - a.length);
 
 	if (triggers.length === 0) return null;

--- a/src/inlineSuggestorUtils.ts
+++ b/src/inlineSuggestorUtils.ts
@@ -6,6 +6,8 @@
  * for auto-complete suggestions.
  */
 
+import { InlineTriggerSettings } from './numerals.types';
+
 /**
  * Result of detecting an inline Numerals context on a line.
  */
@@ -49,23 +51,24 @@ function findInlineCodeSegments(line: string): Array<{ from: number; to: number 
  *
  * @param line - The full text of the current editor line
  * @param cursorCh - The cursor's column (0-based character offset)
- * @param resultTrigger - The trigger prefix for result-only mode (e.g. '#:')
- * @param equationTrigger - The trigger prefix for equation mode (e.g. '#=:')
+ * @param triggerSettings - The four configured trigger prefixes from settings
  * @returns Context if cursor is inside an inline Numerals span, null otherwise
  */
 export function findInlineNumeralsContext(
 	line: string,
 	cursorCh: number,
-	resultTrigger: string,
-	equationTrigger: string,
+	triggerSettings: InlineTriggerSettings,
 ): InlineNumeralsContext | null {
 	const segments = findInlineCodeSegments(line);
 
 	// Build trigger candidates, filtering out empty triggers.
-	// Sort longest-first to handle prefix conflicts (e.g. '#=:' before '#:').
-	const triggers: string[] = [];
-	if (resultTrigger) triggers.push(resultTrigger);
-	if (equationTrigger) triggers.push(equationTrigger);
+	// Sort longest-first to handle prefix conflicts (e.g. '#=$:' before '#=:').
+	const triggers = [
+		triggerSettings.resultTrigger,
+		triggerSettings.equationTrigger,
+		triggerSettings.texResultTrigger,
+		triggerSettings.texEquationTrigger,
+	].filter(t => t.length > 0);
 	triggers.sort((a, b) => b.length - a.length);
 
 	if (triggers.length === 0) return null;

--- a/src/numerals.types.ts
+++ b/src/numerals.types.ts
@@ -67,6 +67,8 @@ export interface NumeralsSettings {
 	enableInlineNumerals: boolean;
 	inlineResultTrigger: string;
 	inlineEquationTrigger: string;
+	inlineTexResultTrigger: string;
+	inlineTexEquationTrigger: string;
 	inlineEquationSeparator: string;
 	provideInlineSuggestions: boolean;
 	// Cross-note reference settings
@@ -93,6 +95,8 @@ export const DEFAULT_SETTINGS: NumeralsSettings = {
 	enableInlineNumerals:				true,
 	inlineResultTrigger:				"#:",
 	inlineEquationTrigger:				"#=:",
+	inlineTexResultTrigger:				"#$:",
+	inlineTexEquationTrigger:			"#=$:",
 	inlineEquationSeparator:				" = ",
 	provideInlineSuggestions:			true,
 	// Cross-note reference settings
@@ -221,10 +225,20 @@ export enum InlineNumeralsMode {
 	Equation = "Equation",
 }
 
+/** The four inline trigger prefixes, straight from settings. Empty string disables a trigger. */
+export interface InlineTriggerSettings {
+	resultTrigger: string;
+	equationTrigger: string;
+	texResultTrigger: string;
+	texEquationTrigger: string;
+}
+
 /** Parsed Inline Numerals expression */
 export interface InlineNumeralsExpression {
 	/** The rendering mode determined by which trigger was matched */
 	mode: InlineNumeralsMode;
+	/** The render style determined by which trigger was matched (Plain or TeX; never SyntaxHighlight) */
+	renderStyle: NumeralsRenderStyle;
 	/** The raw expression text after the trigger prefix */
 	expression: string;
 }
@@ -235,6 +249,8 @@ export interface InlineEvaluationResult {
 	formatted: string;
 	/** The raw mathjs result value (for chaining via @prev) */
 	raw: unknown;
+	/** Expression after cross-note resolution, preprocessing, and inline directives */
+	processedExpression: string;
 	/** Note-global ($-prefixed) variables that were assigned during evaluation */
 	globals: Map<string, unknown>;
 	/** File paths referenced via [[note]].property syntax */

--- a/src/renderers/TeXRenderer.ts
+++ b/src/renderers/TeXRenderer.ts
@@ -1,13 +1,7 @@
-import * as math from 'mathjs';
 import { LineRenderData, RenderContext } from '../numerals.types';
 import { BaseLineRenderer } from './BaseLineRenderer';
-import {
-	texCurrencyReplacement,
-	unescapeSubscripts,
-	mathjaxLoop,
-	replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw,
-	getLocaleFormatter,
-} from '../rendering/displayUtils';
+import { mathjaxLoop } from '../rendering/displayUtils';
+import { expressionToTeX, resultToTeX } from '../rendering/texRendering';
 
 /**
  * TeX renderer for Numerals blocks.
@@ -70,17 +64,10 @@ export class TeXRenderer extends BaseLineRenderer {
 	 * @private
 	 */
 	private renderInputTeX(inputElement: HTMLElement, lineData: LineRenderData): void {
-		// Convert input to TeX
-		const preprocessedTex = math.parse(lineData.processedInput).toTex();
-
-		// Apply transformations
-		let inputTex = replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw(
-			preprocessedTex,
-			lineData.rawInput + (lineData.comment || ''),
-			'@Sum()'
+		const inputTex = expressionToTeX(
+			lineData.processedInput,
+			lineData.rawInput + (lineData.comment || '')
 		);
-		inputTex = unescapeSubscripts(inputTex);
-		inputTex = texCurrencyReplacement(inputTex);
 
 		// Render with MathJax
 		const inputTexElement = inputElement.createEl('span', { cls: 'numerals-tex' });
@@ -107,20 +94,7 @@ export class TeXRenderer extends BaseLineRenderer {
 		lineData: LineRenderData,
 		context: RenderContext
 	): void {
-		// Format result to string with reasonable precision, no grouping
-		let processedResult = math.format(
-			lineData.result,
-			getLocaleFormatter('en-US', { useGrouping: false })
-		);
-
-		// Apply preprocessors (reverse currency transformations for parsing)
-		for (const processor of context.preProcessors) {
-			processedResult = processedResult.replace(processor.regex, processor.replaceStr);
-		}
-
-		// Convert to TeX
-		let texResult = math.parse(processedResult).toTex();
-		texResult = texCurrencyReplacement(texResult);
+		const texResult = resultToTeX(lineData.result, context.preProcessors);
 
 		// Render with MathJax
 		const resultTexElement = resultElement.createEl('span', { cls: 'numerals-tex' });

--- a/src/rendering/texRendering.ts
+++ b/src/rendering/texRendering.ts
@@ -1,0 +1,50 @@
+import * as math from 'mathjs';
+import { StringReplaceMap } from '../numerals.types';
+import {
+	texCurrencyReplacement,
+	unescapeSubscripts,
+	replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw,
+	getLocaleFormatter,
+} from './displayUtils';
+
+/**
+ * Convert a mathjs-ready expression into TeX, preserving Numerals display
+ * conventions such as escaped subscripts, currency symbols, and @sum labels.
+ */
+export function expressionToTeX(
+	processedExpression: string,
+	rawExpression = processedExpression
+): string {
+	const preprocessedTex = math.parse(processedExpression).toTex();
+	let tex = replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw(
+		preprocessedTex,
+		rawExpression,
+		'@Sum()'
+	);
+	// Restore the @prev directive for display: mathjs toTex() emits the
+	// substituted magic variable `__prev` as `\_\_prev`. Must run before
+	// unescapeSubscripts, which would rewrite `\_\_prev` into `\__{prev}`.
+	tex = tex.replace(/(\\_\\_|__)prev\b/g, '@prev');
+	tex = unescapeSubscripts(tex);
+	return texCurrencyReplacement(tex);
+}
+
+/**
+ * Convert an evaluated mathjs result into TeX using the same no-grouping,
+ * period-decimal formatting that block TeX rendering uses.
+ */
+export function resultToTeX(
+	result: unknown,
+	preProcessors: StringReplaceMap[]
+): string {
+	let processedResult = math.format(
+		result,
+		getLocaleFormatter('en-US', { useGrouping: false })
+	);
+
+	for (const processor of preProcessors) {
+		processedResult = processedResult.replace(processor.regex, processor.replaceStr);
+	}
+
+	return texCurrencyReplacement(math.parse(processedResult).toTex());
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -472,6 +472,34 @@ export class NumeralsSettingTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl)
+			.setName('TeX result trigger') // eslint-disable-line obsidianmd/ui/sentence-case
+			.setDesc(htmlToElements(
+				`Prefix for inline code that renders only the result with TeX (MathJax).<br>`
+				+ `Example: <code>#$: sqrt(2)/2</code> renders the result as typeset math`
+			))
+			.addText(text => text
+				.setPlaceholder('#$:')
+				.setValue(this.plugin.settings.inlineTexResultTrigger)
+				.onChange(async (value) => {
+					this.plugin.settings.inlineTexResultTrigger = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName('TeX equation trigger') // eslint-disable-line obsidianmd/ui/sentence-case
+			.setDesc(htmlToElements(
+				`Prefix for inline code that renders the expression and result with TeX (MathJax).<br>`
+				+ `Example: <code>#=$: sqrt(2)/2</code> renders as typeset math like <b>√2⁄2 = 0.7071</b>`
+			))
+			.addText(text => text
+				.setPlaceholder('#=$:')
+				.setValue(this.plugin.settings.inlineTexEquationTrigger)
+				.onChange(async (value) => {
+					this.plugin.settings.inlineTexEquationTrigger = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
 			.setName('Equation separator')
 			.setDesc('String shown between the expression and result in equation mode')
 			.addText(text => text

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -447,7 +447,8 @@ export class NumeralsSettingTab extends PluginSettingTab {
 			.setName('Result-only trigger')
 			.setDesc(htmlToElements(
 				`Prefix for inline code that shows only the result.<br>`
-				+ `Example: <code>#: 3 + 2</code> renders as <b>5</b>`
+				+ `Example: <code>#: 3 + 2</code> renders as <b>5</b><br>`
+				+ `Must differ from the other trigger prefixes.`
 			))
 			.addText(text => text
 				.setPlaceholder('#:')
@@ -461,7 +462,8 @@ export class NumeralsSettingTab extends PluginSettingTab {
 			.setName('Equation trigger')
 			.setDesc(htmlToElements(
 				`Prefix for inline code that shows input and result.<br>`
-				+ `Example: <code>#=: 3 + 2</code> renders as <b>3 + 2 = 5</b>`
+				+ `Example: <code>#=: 3 + 2</code> renders as <b>3 + 2 = 5</b><br>`
+				+ `Must differ from the other trigger prefixes.`
 			))
 			.addText(text => text
 				.setPlaceholder('#=:')
@@ -475,7 +477,8 @@ export class NumeralsSettingTab extends PluginSettingTab {
 			.setName('TeX result trigger') // eslint-disable-line obsidianmd/ui/sentence-case
 			.setDesc(htmlToElements(
 				`Prefix for inline code that renders only the result with TeX (MathJax).<br>`
-				+ `Example: <code>#$: sqrt(2)/2</code> renders the result as typeset math`
+				+ `Example: <code>#$: sqrt(2)/2</code> renders the result as typeset math<br>`
+				+ `Must differ from the other trigger prefixes.`
 			))
 			.addText(text => text
 				.setPlaceholder('#$:')
@@ -489,7 +492,8 @@ export class NumeralsSettingTab extends PluginSettingTab {
 			.setName('TeX equation trigger') // eslint-disable-line obsidianmd/ui/sentence-case
 			.setDesc(htmlToElements(
 				`Prefix for inline code that renders the expression and result with TeX (MathJax).<br>`
-				+ `Example: <code>#=$: sqrt(2)/2</code> renders as typeset math like <b>√2⁄2 = 0.7071</b>`
+				+ `Example: <code>#=$: sqrt(2)/2</code> renders as typeset math like <b>√2⁄2 = 0.7071</b><br>`
+				+ `Must differ from the other trigger prefixes.`
 			))
 			.addText(text => text
 				.setPlaceholder('#=$:')

--- a/styles.css
+++ b/styles.css
@@ -324,6 +324,16 @@ body {
     border-bottom: 1px dotted var(--text-error);
 }
 
+/* TeX-rendered inline numerals: look like native inline math, not code.
+ * Reading mode sits on a <code> element; Live Preview on a cm-inline-code span. */
+.numerals-inline-tex,
+.numerals-inline-tex.cm-inline-code {
+    background-color: transparent;
+    padding: 0;
+    font-family: inherit;
+    font-size: inherit;
+}
+
 /* Settings: currency mapping input fields */
 .numerals-settings-currency-input {
     text-align: center;

--- a/tests/inline.test.ts
+++ b/tests/inline.test.ts
@@ -18,6 +18,8 @@ import * as math from 'mathjs';
 import { defaultCurrencyMap } from '../src/rendering/displayUtils';
 import {
 	InlineNumeralsMode,
+	InlineTriggerSettings,
+	NumeralsRenderStyle,
 	NumeralsScope,
 	StringReplaceMap,
 	mathjsFormat,
@@ -53,11 +55,15 @@ for (const moneyType of defaultCurrencyMap) {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-const DEFAULT_RESULT_TRIGGER = '#:';
-const DEFAULT_EQUATION_TRIGGER = '#=:';
+const DEFAULT_TRIGGERS: InlineTriggerSettings = {
+	resultTrigger: '#:',
+	equationTrigger: '#=:',
+	texResultTrigger: '#$:',
+	texEquationTrigger: '#=$:',
+};
 
-function parse(text: string, resultTrigger = DEFAULT_RESULT_TRIGGER, equationTrigger = DEFAULT_EQUATION_TRIGGER) {
-	return parseInlineExpression(text, resultTrigger, equationTrigger);
+function parse(text: string, triggers: Partial<InlineTriggerSettings> = {}) {
+	return parseInlineExpression(text, { ...DEFAULT_TRIGGERS, ...triggers });
 }
 
 // ---------------------------------------------------------------------------
@@ -71,6 +77,7 @@ describe('parseInlineExpression', () => {
 			const result = parse('#: 3+2');
 			expect(result).not.toBeNull();
 			expect(result!.mode).toBe(InlineNumeralsMode.ResultOnly);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.Plain);
 			expect(result!.expression).toBe('3+2');
 		});
 
@@ -78,6 +85,23 @@ describe('parseInlineExpression', () => {
 			const result = parse('#=: 3+2');
 			expect(result).not.toBeNull();
 			expect(result!.mode).toBe(InlineNumeralsMode.Equation);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.Plain);
+			expect(result!.expression).toBe('3+2');
+		});
+
+		it('should parse TeX result-only trigger "#$: 3+2"', () => {
+			const result = parse('#$: 3+2');
+			expect(result).not.toBeNull();
+			expect(result!.mode).toBe(InlineNumeralsMode.ResultOnly);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.TeX);
+			expect(result!.expression).toBe('3+2');
+		});
+
+		it('should parse TeX equation trigger "#=$: 3+2"', () => {
+			const result = parse('#=$: 3+2');
+			expect(result).not.toBeNull();
+			expect(result!.mode).toBe(InlineNumeralsMode.Equation);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.TeX);
 			expect(result!.expression).toBe('3+2');
 		});
 
@@ -122,6 +146,22 @@ describe('parseInlineExpression', () => {
 			expect(result!.mode).toBe(InlineNumeralsMode.ResultOnly);
 			expect(result!.expression).toBe('5*3');
 		});
+
+		it('should check "#=$:" before "#=:", "#$:", and "#:" among the four defaults', () => {
+			const result = parse('#=$: 5*3');
+			expect(result).not.toBeNull();
+			expect(result!.mode).toBe(InlineNumeralsMode.Equation);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.TeX);
+			expect(result!.expression).toBe('5*3');
+		});
+
+		it('should parse "#$: 5*3" as TeX ResultOnly and not confuse it with "#:"', () => {
+			const result = parse('#$: 5*3');
+			expect(result).not.toBeNull();
+			expect(result!.mode).toBe(InlineNumeralsMode.ResultOnly);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.TeX);
+			expect(result!.expression).toBe('5*3');
+		});
 	});
 
 	// --- Whitespace handling ------------------------------------------------
@@ -142,29 +182,57 @@ describe('parseInlineExpression', () => {
 
 	// --- Custom triggers ----------------------------------------------------
 	describe('custom triggers', () => {
+		const allEmpty: InlineTriggerSettings = {
+			resultTrigger: '',
+			equationTrigger: '',
+			texResultTrigger: '',
+			texEquationTrigger: '',
+		};
+
 		it('should match custom result trigger "@$:"', () => {
-			const result = parse('@$: 100', '@$:', '@=:');
+			const result = parse('@$: 100', { ...allEmpty, resultTrigger: '@$:', equationTrigger: '@=:' });
 			expect(result).not.toBeNull();
 			expect(result!.mode).toBe(InlineNumeralsMode.ResultOnly);
 			expect(result!.expression).toBe('100');
 		});
 
 		it('should match custom equation trigger "@=:"', () => {
-			const result = parse('@=: 3+2', '@$:', '@=:');
+			const result = parse('@=: 3+2', { ...allEmpty, resultTrigger: '@$:', equationTrigger: '@=:' });
 			expect(result).not.toBeNull();
 			expect(result!.mode).toBe(InlineNumeralsMode.Equation);
 			expect(result!.expression).toBe('3+2');
 		});
 
 		it('should match custom triggers "nm:" and "nm=:"', () => {
-			const result = parse('nm=: 3+2', 'nm:', 'nm=:');
+			const result = parse('nm=: 3+2', { ...allEmpty, resultTrigger: 'nm:', equationTrigger: 'nm=:' });
 			expect(result).not.toBeNull();
 			expect(result!.mode).toBe(InlineNumeralsMode.Equation);
 			expect(result!.expression).toBe('3+2');
 		});
 
 		it('should return null when text does not match custom triggers', () => {
-			expect(parse('=: 100', '@$:', '@=:')).toBeNull();
+			expect(parse('=: 100', { ...allEmpty, resultTrigger: '@$:', equationTrigger: '@=:' })).toBeNull();
+		});
+
+		it('should resolve longest-first when one custom trigger is a prefix of another', () => {
+			// texResultTrigger '#' is a prefix of the plain resultTrigger '##';
+			// longest-first means '##' wins for text starting '##'.
+			const custom: InlineTriggerSettings = {
+				resultTrigger: '##',
+				equationTrigger: '',
+				texResultTrigger: '#',
+				texEquationTrigger: '',
+			};
+			const result = parse('## 3+2', custom);
+			expect(result).not.toBeNull();
+			expect(result!.mode).toBe(InlineNumeralsMode.ResultOnly);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.Plain);
+			expect(result!.expression).toBe('3+2');
+
+			const texResult = parse('# 3+2', custom);
+			expect(texResult).not.toBeNull();
+			expect(texResult!.renderStyle).toBe(NumeralsRenderStyle.TeX);
+			expect(texResult!.expression).toBe('3+2');
 		});
 	});
 
@@ -172,23 +240,32 @@ describe('parseInlineExpression', () => {
 	describe('empty trigger safety', () => {
 		it('should ignore empty result trigger', () => {
 			// Empty trigger would match everything — must be filtered out
-			const result = parse('some code', '', '#=:');
+			const result = parse('some code', { resultTrigger: '', equationTrigger: '#=:', texResultTrigger: '', texEquationTrigger: '' });
 			expect(result).toBeNull();
 		});
 
 		it('should ignore empty equation trigger', () => {
-			const result = parse('some code', '=:', '');
+			const result = parse('some code', { resultTrigger: '=:', equationTrigger: '', texResultTrigger: '', texEquationTrigger: '' });
 			expect(result).toBeNull();
 		});
 
-		it('should still match valid trigger when the other is empty', () => {
-			const result = parse('#: 3+2', '#:', '');
+		it('should still match valid trigger when the others are empty', () => {
+			const result = parse('#: 3+2', { resultTrigger: '#:', equationTrigger: '', texResultTrigger: '', texEquationTrigger: '' });
 			expect(result).not.toBeNull();
 			expect(result!.mode).toBe(InlineNumeralsMode.ResultOnly);
 		});
 
-		it('should return null when both triggers are empty', () => {
-			expect(parse('anything', '', '')).toBeNull();
+		it('should return null when all four triggers are empty', () => {
+			expect(parse('anything', { resultTrigger: '', equationTrigger: '', texResultTrigger: '', texEquationTrigger: '' })).toBeNull();
+		});
+
+		it('should disable only TeX modes when the TeX triggers are empty', () => {
+			const noTex: Partial<InlineTriggerSettings> = { texResultTrigger: '', texEquationTrigger: '' };
+			// Plain triggers still work
+			expect(parse('#: 3+2', noTex)!.renderStyle).toBe(NumeralsRenderStyle.Plain);
+			// TeX trigger text no longer matches a trigger
+			expect(parse('#$: 3+2', noTex)).toBeNull();
+			expect(parse('#=$: 3+2', noTex)).toBeNull();
 		});
 	});
 });
@@ -374,6 +451,11 @@ describe('evaluateInlineExpression', () => {
 			const result = evaluateInlineExpression('$1,000 * 2', emptyScope, defaultFormat, preProcessors);
 			expect(result.formatted).toContain('2000');
 			expect(result.formatted).toContain('USD');
+		});
+
+		it('should return the processed expression used for mathjs evaluation', () => {
+			const result = evaluateInlineExpression('$1,000 * 2', emptyScope, defaultFormat, preProcessors);
+			expect(result.processedExpression).toBe('1000 USD * 2');
 		});
 
 		it('should handle multiple thousands separators: "$1,000,000"', () => {

--- a/tests/inlineLivePreview.test.ts
+++ b/tests/inlineLivePreview.test.ts
@@ -28,6 +28,7 @@ import {
 } from '../src/inline/inlineLivePreview';
 import { InlineNumeralsMode, NumeralsRenderStyle } from '../src/numerals.types';
 import { EditorSelection } from '@codemirror/state';
+import { renderMath } from 'obsidian';
 
 beforeAll(() => {
 	(globalThis as { activeDocument?: Document }).activeDocument = document;
@@ -159,6 +160,22 @@ describe('InlineNumeralsWidget', () => {
 			expect(el.querySelector('.numerals-inline-input')?.textContent).toBe('3ft + 2ft');
 			expect(el.querySelector('.numerals-inline-separator')?.textContent).toBe(' = ');
 			expect(el.querySelector('.numerals-inline-value')?.textContent).toBe('5 ft');
+		});
+
+		it('should fall back to plain text when MathJax rendering fails asynchronously', async () => {
+			// mathjaxLoop is async, so a renderMath failure is a promise
+			// rejection — the renderer must catch it and fall back to text.
+			(renderMath as jest.Mock).mockImplementationOnce(() => {
+				throw new Error('MathJax unavailable');
+			});
+			const widget = new InlineNumeralsWidget(
+				'36', InlineNumeralsMode.ResultOnly, '3ft in inches', ' = ', false,
+				[], NumeralsRenderStyle.TeX, 36, '3 ft in inches', []
+			);
+			const el = widget.toDOM();
+			await Promise.resolve();
+
+			expect(el.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('36');
 		});
 
 		it('should render equation TeX mode with MathJax input and value spans', async () => {

--- a/tests/inlineLivePreview.test.ts
+++ b/tests/inlineLivePreview.test.ts
@@ -9,6 +9,12 @@
 jest.mock('obsidian', () => ({
 	editorInfoField: {},
 	editorLivePreviewField: {},
+	renderMath: jest.fn((tex: string) => {
+		const span = document.createElement('span');
+		span.textContent = `TeX:${tex}`;
+		return span;
+	}),
+	finishRenderMath: jest.fn().mockResolvedValue(undefined),
 }), { virtual: true });
 
 jest.mock('obsidian-dataview', () => ({
@@ -20,7 +26,7 @@ import {
 	getFormattingClasses,
 	selectionOverlapsRange,
 } from '../src/inline/inlineLivePreview';
-import { InlineNumeralsMode } from '../src/numerals.types';
+import { InlineNumeralsMode, NumeralsRenderStyle } from '../src/numerals.types';
 import { EditorSelection } from '@codemirror/state';
 
 beforeAll(() => {
@@ -131,6 +137,18 @@ describe('InlineNumeralsWidget', () => {
 			expect(el.querySelector('.numerals-inline-separator')).toBeNull();
 		});
 
+		it('should render result-only TeX mode with MathJax inside the value span', async () => {
+			const widget = new InlineNumeralsWidget(
+				'36', InlineNumeralsMode.ResultOnly, '3ft in inches', ' = ', false,
+				[], NumeralsRenderStyle.TeX, 36, '3 ft in inches', []
+			);
+			const el = widget.toDOM();
+			await Promise.resolve();
+
+			expect(el.classList.contains('numerals-inline-result')).toBe(true);
+			expect(el.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:36');
+		});
+
 		it('should render equation mode with input, separator, and value spans', () => {
 			const widget = new InlineNumeralsWidget(
 				'5 ft', InlineNumeralsMode.Equation, '3ft + 2ft', ' = ', false
@@ -141,6 +159,19 @@ describe('InlineNumeralsWidget', () => {
 			expect(el.querySelector('.numerals-inline-input')?.textContent).toBe('3ft + 2ft');
 			expect(el.querySelector('.numerals-inline-separator')?.textContent).toBe(' = ');
 			expect(el.querySelector('.numerals-inline-value')?.textContent).toBe('5 ft');
+		});
+
+		it('should render equation TeX mode with MathJax input and value spans', async () => {
+			const widget = new InlineNumeralsWidget(
+				'12', InlineNumeralsMode.Equation, 'sqrt(144)', ' = ', false,
+				[], NumeralsRenderStyle.TeX, 12, 'sqrt(144)', []
+			);
+			const el = widget.toDOM();
+			await Promise.resolve();
+
+			expect(el.querySelector('.numerals-inline-input .numerals-tex')?.textContent).toBe('TeX:\\sqrt{144}');
+			expect(el.querySelector('.numerals-inline-separator')?.textContent).toBe(' = ');
+			expect(el.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:12');
 		});
 
 		it('should create widget nodes from the editor ownerDocument', () => {
@@ -249,6 +280,34 @@ describe('InlineNumeralsWidget', () => {
 			const a = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong', 'cm-em']);
 			const b = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong', 'cm-em']);
 			expect(a.eq(b)).toBe(true);
+		});
+
+		it('should return true when only the rawResult object identity differs', () => {
+			// mathjs results (e.g. Unit objects) are fresh instances on every
+			// evaluation pass; comparing them by reference would force a DOM
+			// rebuild (and MathJax re-render) on every cursor move.
+			const a = new InlineNumeralsWidget(
+				'5 m', InlineNumeralsMode.ResultOnly, '2m+3m', ' = ', false,
+				[], NumeralsRenderStyle.TeX, { value: 5 }, '2m+3m', []
+			);
+			const b = new InlineNumeralsWidget(
+				'5 m', InlineNumeralsMode.ResultOnly, '2m+3m', ' = ', false,
+				[], NumeralsRenderStyle.TeX, { value: 5 }, '2m+3m', []
+			);
+			expect(a.eq(b)).toBe(true);
+		});
+
+		it('should return false when render style differs', () => {
+			const plain = new InlineNumeralsWidget(
+				'5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false,
+				[], NumeralsRenderStyle.Plain, 5, '3+2', []
+			);
+			const tex = new InlineNumeralsWidget(
+				'5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false,
+				[], NumeralsRenderStyle.TeX, 5, '3+2', []
+			);
+
+			expect(plain.eq(tex)).toBe(false);
 		});
 	});
 });

--- a/tests/inlinePostProcessor.test.ts
+++ b/tests/inlinePostProcessor.test.ts
@@ -11,6 +11,12 @@ jest.mock("obsidian", () => ({
 	MarkdownRenderChild: class {
 		registerEvent = jest.fn((ref) => mockRegisteredEvents.push(ref));
 	},
+	renderMath: jest.fn((tex: string) => {
+		const span = document.createElement('span');
+		span.textContent = `TeX:${tex}`;
+		return span;
+	}),
+	finishRenderMath: jest.fn().mockResolvedValue(undefined),
 }), { virtual: true });
 jest.mock(
 	"obsidian-dataview",
@@ -94,11 +100,12 @@ function simulateInlinePipeline(
 	scope: NumeralsScope = new NumeralsScope(),
 	settings: NumeralsSettings = DEFAULT_SETTINGS
 ): { mode: string; expression: string; result: string } | null {
-	const parsed = parseInlineExpression(
-		inlineText,
-		settings.inlineResultTrigger,
-		settings.inlineEquationTrigger
-	);
+	const parsed = parseInlineExpression(inlineText, {
+		resultTrigger: settings.inlineResultTrigger,
+		equationTrigger: settings.inlineEquationTrigger,
+		texResultTrigger: settings.inlineTexResultTrigger,
+		texEquationTrigger: settings.inlineTexEquationTrigger,
+	});
 	if (!parsed) return null;
 
 	const { formatted } = evaluateInlineExpression(
@@ -149,6 +156,88 @@ describe('inline numerals integration', () => {
 		});
 	});
 
+	describe('TeX rendering mode', () => {
+		// TeX rendering is chosen per-expression via the `#$:` / `#=$:` triggers,
+		// not a global setting. Uses DEFAULT_SETTINGS trigger prefixes unchanged.
+		function createPostProcessor(preProcessors: StringReplaceMap[] = []) {
+			const app = {
+				vault: {
+					getAbstractFileByPath: jest.fn(() => null),
+				},
+				metadataCache: {
+					getFileCache: jest.fn(),
+				},
+			};
+			return createInlineNumeralsPostProcessor(
+				app as any,
+				() => DEFAULT_SETTINGS,
+				() => undefined,
+				() => preProcessors,
+				new Map(),
+			);
+		}
+
+		function renderInline(inlineText: string, preProcessors: StringReplaceMap[] = []): HTMLElement {
+			const container = document.createElement('p');
+			const code = document.createElement('code');
+			code.innerText = inlineText;
+			container.appendChild(code);
+			createPostProcessor(preProcessors)(container, { sourcePath: 'source.md', addChild: jest.fn() } as any);
+			return code;
+		}
+
+		it('renders "#$:" result-only inline values with MathJax in Reading mode', async () => {
+			const code = renderInline('#$: 3ft in inches');
+			await Promise.resolve();
+
+			expect(code.classList.contains('numerals-inline-tex')).toBe(true);
+			const texValue = code.querySelector('.numerals-inline-value .numerals-tex');
+			expect(texValue).not.toBeNull();
+			expect(texValue?.textContent).toBe('TeX:36~\\mathrm{inches}');
+		});
+
+		it('renders "#=$:" equation input and result with MathJax in Reading mode', async () => {
+			const code = renderInline('#=$: sqrt(144)');
+			await Promise.resolve();
+
+			expect(code.classList.contains('numerals-inline-tex')).toBe(true);
+			expect(code.querySelector('.numerals-inline-input .numerals-tex')?.textContent).toBe('TeX:\\sqrt{144}');
+			expect(code.querySelector('.numerals-inline-separator')?.textContent).toBe(' = ');
+			expect(code.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:12');
+		});
+
+		it('renders plain "#:" results as text, without any MathJax span', () => {
+			const code = renderInline('#: 2+3');
+
+			expect(code.classList.contains('numerals-inline-tex')).toBe(false);
+			expect(code.querySelector('.numerals-tex')).toBeNull();
+			expect(code.querySelector('.numerals-inline-value')?.textContent).toBe('5');
+		});
+
+		it('renders a "#$:" currency result with MathJax', async () => {
+			const code = renderInline('#$: $100 + $20', preProcessors);
+			await Promise.resolve();
+
+			const texValue = code.querySelector('.numerals-inline-value .numerals-tex');
+			expect(texValue).not.toBeNull();
+			expect(texValue?.textContent).toContain('120');
+		});
+
+		it('renders the standard error span for an invalid TeX-trigger expression', () => {
+			const code = renderInline('#$: @@invalid@@');
+
+			expect(code.classList.contains('numerals-inline-error')).toBe(true);
+			expect(code.querySelector('.numerals-tex')).toBeNull();
+		});
+
+		it('quick-reject still matches when only TeX triggers appear in the document', async () => {
+			const code = renderInline('#=$: 2+3');
+			await Promise.resolve();
+
+			expect(code.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:5');
+		});
+	});
+
 	describe('scope isolation', () => {
 		it('should not mutate the shared scope', () => {
 			const scope = new NumeralsScope();
@@ -174,7 +263,12 @@ describe('inline numerals integration', () => {
 
 	describe('error handling', () => {
 		it('should throw on invalid expression', () => {
-			const parsed = parseInlineExpression('#: @@invalid@@', '#:', '#=:');
+			const parsed = parseInlineExpression('#: @@invalid@@', {
+				resultTrigger: '#:',
+				equationTrigger: '#=:',
+				texResultTrigger: '#$:',
+				texEquationTrigger: '#=$:',
+			});
 			expect(parsed).not.toBeNull();
 			expect(() => {
 				evaluateInlineExpression(parsed!.expression, new NumeralsScope(), undefined, []);

--- a/tests/inlineSuggestor.test.ts
+++ b/tests/inlineSuggestor.test.ts
@@ -10,12 +10,17 @@ jest.mock(
 );
 
 import { findInlineNumeralsContext } from '../src/inlineSuggestorUtils';
+import { InlineTriggerSettings } from '../src/numerals.types';
 
-const RESULT_TRIGGER = '#:';
-const EQUATION_TRIGGER = '#=:';
+const DEFAULT_TRIGGERS: InlineTriggerSettings = {
+	resultTrigger: '#:',
+	equationTrigger: '#=:',
+	texResultTrigger: '#$:',
+	texEquationTrigger: '#=$:',
+};
 
-function find(line: string, cursorCh: number, resultTrigger = RESULT_TRIGGER, equationTrigger = EQUATION_TRIGGER) {
-	return findInlineNumeralsContext(line, cursorCh, resultTrigger, equationTrigger);
+function find(line: string, cursorCh: number, triggers: Partial<InlineTriggerSettings> = {}) {
+	return findInlineNumeralsContext(line, cursorCh, { ...DEFAULT_TRIGGERS, ...triggers });
 }
 
 describe('findInlineNumeralsContext', () => {
@@ -167,25 +172,53 @@ describe('findInlineNumeralsContext', () => {
 		});
 	});
 
+	// --- TeX triggers ---
+	describe('TeX triggers', () => {
+		it('should detect cursor inside a TeX result-only span', () => {
+			// `(0)#(1)$(2):(3) (4)s(5)q(6)r(7)t(8)`(9)
+			const line = '`#$: sqrt`';
+			const result = find(line, 8); // cursor at 't' in sqrt
+			expect(result).not.toBeNull();
+			expect(result!.triggerPrefix).toBe('#$:');
+			expect(result!.expressionStartCh).toBe(4);
+		});
+
+		it('should detect cursor inside a TeX equation span', () => {
+			// `(0)#(1)=(2)$(3):(4) (5)x(6)`(7)
+			const line = '`#=$: x`';
+			const result = find(line, 6); // cursor at 'x'
+			expect(result).not.toBeNull();
+			expect(result!.triggerPrefix).toBe('#=$:');
+			expect(result!.expressionStartCh).toBe(5);
+		});
+	});
+
 	// --- Custom triggers ---
 	describe('custom triggers', () => {
+		const allEmpty: InlineTriggerSettings = {
+			resultTrigger: '',
+			equationTrigger: '',
+			texResultTrigger: '',
+			texEquationTrigger: '',
+		};
+
 		it('should work with custom trigger prefixes', () => {
 			const line = '`nm: sqrt(2)`';
-			const result = find(line, 10, 'nm:', 'nm=:');
+			const result = find(line, 10, { ...allEmpty, resultTrigger: 'nm:', equationTrigger: 'nm=:' });
 			expect(result).not.toBeNull();
 			expect(result!.triggerPrefix).toBe('nm:');
 		});
 
 		it('should handle empty result trigger gracefully', () => {
 			const line = '`#=: x`';
-			const result = find(line, 5, '', '#=:');
+			const result = find(line, 5, { ...allEmpty, equationTrigger: '#=:' });
 			expect(result).not.toBeNull();
 			expect(result!.triggerPrefix).toBe('#=:');
 		});
 
-		it('should return null when both triggers are empty', () => {
+		it('should return null when all triggers are empty', () => {
 			const line = '`anything`';
-			expect(find(line, 5, '', '')).toBeNull();
+			expect(find(line, 5, allEmpty)).toBeNull();
 		});
 	});
 
@@ -196,6 +229,13 @@ describe('findInlineNumeralsContext', () => {
 			const result = find(line, 7);
 			expect(result).not.toBeNull();
 			expect(result!.triggerPrefix).toBe('#=:');
+		});
+
+		it('should match "#=$:" over "#=:", "#$:", and "#:" among the four defaults', () => {
+			const line = '`#=$: 5*3`';
+			const result = find(line, 7);
+			expect(result).not.toBeNull();
+			expect(result!.triggerPrefix).toBe('#=$:');
 		});
 	});
 });

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -26,12 +26,14 @@ import {
 	SyntaxHighlightRenderer,
 	RendererFactory,
 } from '../src/renderers';
+import * as math from 'mathjs';
 import {
 	LineRenderData,
 	RenderContext,
 	NumeralsRenderStyle,
 	DEFAULT_SETTINGS,
 } from '../src/numerals.types';
+import { expressionToTeX, resultToTeX } from '../src/rendering/texRendering';
 import { getLocaleFormatter } from '../src/numeralsUtilities';
 
 // Mock Obsidian DOM methods
@@ -315,7 +317,18 @@ describe('Renderer Implementations', () => {
 			renderer = new TeXRenderer();
 		});
 
-		it('should render normal line', () => {
+		it('should convert expressions and results using shared TeX helpers', () => {
+			expect(expressionToTeX('sqrt(144)')).toBe('\\sqrt{144}');
+			expect(resultToTeX(math.evaluate('3 ft to inches'), [])).toBe('36~\\mathrm{inches}');
+		});
+
+		it('should restore the @prev directive in expressionToTeX', () => {
+			// Inline mode substitutes @prev with the __prev magic variable before
+			// evaluation; expressionToTeX restores it for display.
+			expect(expressionToTeX('__prev * 2')).toBe('@prev\\cdot2');
+		});
+
+		it('should render normal line', async () => {
 			const lineData: LineRenderData = {
 				index: 0,
 				rawInput: '2 + 2',
@@ -328,6 +341,7 @@ describe('Renderer Implementations', () => {
 			};
 
 			renderer.renderLine(container, lineData, context);
+			await Promise.resolve();
 
 			const input = container.querySelector('.numerals-input');
 			const result = container.querySelector('.numerals-result');
@@ -338,6 +352,8 @@ describe('Renderer Implementations', () => {
 			// Should have TeX spans
 			const texSpans = container.querySelectorAll('.numerals-tex');
 			expect(texSpans.length).toBe(2); // input and result
+			expect(input?.textContent).toContain('TeX:2+2');
+			expect(result?.textContent).toContain('TeX:4');
 		});
 
 		it('should render empty line', () => {


### PR DESCRIPTION
## Summary

Closes #161.

Adds **per-expression TeX rendering** for Inline Numerals via two new trigger prefixes, chosen by syntax rather than a global setting:

| Syntax | Renders as |
| --- | --- |
| `` `#$: e^(pi*i) + 1` `` | result only, typeset with MathJax |
| `` `#=$: e^(pi*i) + 1` `` | `expression = result`, typeset with MathJax |

Existing `#:` and `#=:` behavior is unchanged, and plain and TeX inline calculations can coexist in the same note. Both new prefixes are configurable in settings (`inlineTexResultTrigger`, `inlineTexEquationTrigger`); defaults keep the colon-terminated convention of the existing triggers (and match the syntax proposed in #161). Supersedes draft #162, which controlled this with a global `inlineRenderStyle` setting — this PR keeps that draft's shared-helper architecture but drops the setting in favor of per-use syntax.

## Design

**Parsing.** `parseInlineExpression` now takes all four trigger prefixes (`InlineTriggerSettings`) and returns a `renderStyle` (`Plain` | `TeX`, reusing `NumeralsRenderStyle`) alongside the existing mode. Triggers are matched longest-first, so overlapping prefixes (`#=$:` vs `#=:` vs `#$:` vs `#:`) resolve correctly even with custom configurations. Empty trigger strings disable individual triggers, as before.

**Shared TeX conversion.** `expressionToTeX` / `resultToTeX` are extracted from `TeXRenderer` into `src/rendering/texRendering.ts`, so block `math-tex` rendering and inline TeX rendering use identical mathjs→MathJax conventions: currency symbols (`$100 + $20` works inline), escaped subscripts, `@Sum` restoration, and no-grouping result formatting. `expressionToTeX` also restores `@prev` for display (inline mode substitutes it with the `__prev` magic variable before evaluation). `TeXRenderer` is refactored to use the shared helpers with no behavior change.

**Rendering.** Both render surfaces — the Reading-mode post-processor and the Live Preview CM6 widget — route input/value spans through a new `src/inline/inlineRenderer.ts`, which renders plain text or a `.numerals-tex` MathJax span based on the parsed `renderStyle`. The inline evaluator now returns `processedExpression` (the exact string mathjs evaluated, after cross-note resolution, preprocessors, and directive substitution) so equation-mode TeX never duplicates preprocessing logic. TeX-rendered spans get a `numerals-inline-tex` class that strips the inline-code chrome so they read like native `$...$` math.

**Everything else follows the plain path.** Evaluation semantics, `$`-prefixed note globals, `@prev` chaining, cross-note references, error styling, the cursor guard in Live Preview, and autocomplete (the suggestor recognizes the new triggers) all behave identically to plain inline mode.

**Edge cases.** If an expression evaluates fine but TeX conversion fails (e.g. mathjs can't re-parse the formatted result), the renderer falls back to plain text instead of showing an error, and evaluation side effects still apply. The Live Preview widget's `eq()` deliberately does not compare raw mathjs result objects by reference, so unit results don't force a MathJax re-render on every cursor move.

## Verification

- `npm test` — 14 suites, 414 tests passing (new coverage: parser trigger/precedence matrix, TeX rendering in both render surfaces, currency in TeX mode, error fallback, suggestor context inside `#$:` spans, widget `eq()` semantics, shared texRendering helpers incl. `@prev` restoration)
- `npm run lint` — clean
- `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
