### PR TITLE
feat: unify result formatting and add block overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 - Per-expression TeX rendering for Inline Numerals via the new `#$:` (result only) and `#=$:` (equation) trigger prefixes, which render with MathJax in both Live Preview and Reading mode. Both prefixes are configurable in settings. (Closes #161)
+- Block-level `@format` and `@decimalPlaces` directives for overriding result presentation without changing calculated values. (Closes #75, #140)
+
+### Changed
+- Centralized block, inline, TeX, and result-insertion formatting behind one result-formatting pipeline so evaluation always retains raw mathjs values.
 
 ## [1.10.2] - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. The format 
 ### Changed
 - Centralized block, inline, TeX, and result-insertion formatting behind one result-formatting pipeline so evaluation always retains raw mathjs values.
 
+### Fixed
+- Inline TeX triggers now use MathJax's inline mode in Reading mode and Live Preview instead of rendering as centered display math.
+
 ## [1.10.2] - 2026-05-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -254,6 +254,21 @@ Configure how rendered numbers are displayed:
 - **Engineering**: exponent is a multiple of 3.
 - **Formatted**: choose a specific thousands/decimal style.
 
+Override formatting for one math block with display-only directives:
+
+````markdown
+```math
+@format comma-period
+@decimalPlaces 2
+subtotal = 1234.5
+third = 1 / 3
+```
+````
+
+`@format` accepts `system`, `fixed`, `exponential` (or `scientific`), `engineering`, `comma-period`, `period-comma`, `space-comma`, and `indian`. `@decimalPlaces` accepts an integer from 0 through 20; `@decimalPlace` is also accepted.
+
+These directives change displayed and inserted results, not values in calculation scope. For computational rounding, use mathjs directly: `round(value, 2)` for numbers or `round(amount, 2, GBP)` for currency Units.
+
 ## Installation
 
 Install **Numerals** from Obsidian's Community Plugins browser.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Inline Numerals expressions are ordinary inline code with a trigger prefix:
 
 Inline calculations work in Live Preview and Reading mode. They support the same math engine, number formatting, units, currency symbols, variables, frontmatter, and Dataview values as math blocks.
 
-The `#$:` and `#=$:` triggers render the result (and, in equation mode, the expression) as TeX-style MathJax — the same typesetting used by math blocks — chosen per expression rather than through a global setting. All four trigger prefixes are configurable in the Numerals settings.
+The `#$:` and `#=$:` triggers render the result (and, in equation mode, the expression) as TeX-style MathJax, inline with surrounding text in both Live Preview and Reading mode. All four trigger prefixes are configurable in the Numerals settings.
 
 ### Math Blocks
 

--- a/docs/result-formatting.md
+++ b/docs/result-formatting.md
@@ -92,7 +92,7 @@ y = x * 3
 - Directive names and values are case-insensitive.
 - Leading and trailing whitespace are allowed.
 - The last valid directive of each kind wins.
-- A valid directive is replaced by an empty source line so evaluation and source line indexes stay aligned.
+- A valid directive is replaced by an empty source line and marked evaluation-transparent, so source indexes stay aligned without changing `@prev` or `@total` semantics.
 - An invalid directive stops block evaluation and produces a dedicated formatting-directive error that identifies the source line.
 - Formatting directives are block-scoped. Inline Numerals use global settings.
 

--- a/docs/result-formatting.md
+++ b/docs/result-formatting.md
@@ -1,0 +1,230 @@
+# Result formatting architecture
+
+## Goals
+
+Numerals evaluates expressions with mathjs and formats the resulting values for several independent output surfaces. Formatting must remain a display concern: it must never round or stringify values stored in calculation scope.
+
+This architecture addresses three related requests:
+
+- General display precision and block-local formatter selection (#75 and #140).
+- Currency-aware precision, symbols, and derived currency values (#160).
+- Consistent result presentation in blocks, inline Numerals, TeX, and result insertion.
+
+The work is split into two stacked pull requests. PR 1 introduces the shared formatting boundary and block directives. PR 2 adds opt-in currency presentation policies.
+
+## Formatting boundary
+
+Every evaluated value is sent to one `ResultFormatter`:
+
+```ts
+interface ResultFormatter {
+    format(value: unknown, overrides?: ResultFormatOverrides): FormattedResult;
+}
+
+interface FormattedResult {
+    text: string;
+    tex: string;
+    canonical: string;
+}
+```
+
+- `text` is localized user-facing output and does not include the configured result separator.
+- `tex` is MathJax-ready TeX generated from the raw result or non-localized structured parts.
+- `canonical` is the result-insertion form.
+
+PR 1 deliberately keeps `canonical` equal to the legacy formatted text so introducing the architecture does not silently rewrite existing notes. A future canonical-output migration must be explicit and independently documented.
+
+Evaluation returns raw mathjs values. Renderers and result insertion format them after evaluation. `@prev`, `@sum`, variables, and globals therefore retain full, unrounded values.
+
+## Number format profiles
+
+The existing setting is normalized into a `NumberFormatProfile`. A profile retains:
+
+- The original `NumeralsNumberFormat` value.
+- The resolved locale for system and locale-backed formats.
+- Notation: standard, fixed, exponential, or engineering.
+- Grouping policy.
+- The existing mathjs callback/options used by the compatibility path.
+
+Retaining locale identity is important. An opaque callback can format a number, but it cannot safely compose exact decimal places, currency minor units, localized digits, symbol placement, or TeX policy.
+
+Without an explicit override, the formatter delegates to the existing mathjs formatter byte-for-byte. Existing blocks and inline expressions must not change merely because the shared architecture is installed.
+
+## Block directives
+
+### Decimal places
+
+```text
+@decimalPlaces 2
+@decimalPlace 2
+```
+
+The singular form is an alias. The value must be an integer from 0 through 20. A valid directive applies to the complete block and is hidden from rendered input.
+
+The directive controls display only:
+
+```text
+@decimalPlaces 2
+x = 1 / 3
+y = x * 3
+```
+
+`x` displays as `0.33`, but the value stored in `x` remains the full result of `1 / 3`, so `y` evaluates to `1`, not `0.99`.
+
+### Number format
+
+```text
+@format system
+@format fixed
+@format exponential
+@format scientific
+@format engineering
+@format comma-period
+@format period-comma
+@format space-comma
+@format indian
+```
+
+`scientific` is an alias for `exponential`. The remaining names map directly to the choices in Numerals settings.
+
+### Parsing rules
+
+- Directive names and values are case-insensitive.
+- Leading and trailing whitespace are allowed.
+- The last valid directive of each kind wins.
+- A valid directive is replaced by an empty source line so evaluation and source line indexes stay aligned.
+- An invalid directive stops block evaluation and produces a dedicated formatting-directive error that identifies the source line.
+- Formatting directives are block-scoped. Inline Numerals use global settings.
+
+### Precedence
+
+Formatting policy has one stable precedence order:
+
+```text
+@decimalPlaces override
+    > automatic currency-standard decimal places
+        > block @format profile
+            > global number format
+```
+
+`@format` selects notation and locale. `@decimalPlaces` controls exact coefficient/numeric decimal places without silently changing exponential or engineering notation to fixed notation.
+
+## Output surfaces
+
+The same formatter result is consumed everywhere:
+
+- Plain block results use `text`.
+- Syntax-highlighted block results use `text`.
+- TeX block results use `tex`.
+- Inline Reading mode uses `text` or `tex`, based on its trigger.
+- Inline Live Preview uses `text` or `tex`, based on its trigger.
+- `@[name::result]` insertion uses `canonical`.
+
+Inline evaluation itself does not format results. This keeps `@prev` and note-global values raw and prevents Live Preview and Reading mode from drifting apart.
+
+## Currency registry
+
+An immutable `CurrencyRegistry` is built from the active Numerals currency map after the plugin creates the corresponding mathjs units. It clones the settings-derived map and uses only public mathjs APIs:
+
+- `math.isUnit`
+- `math.unit`
+- `Unit.equalBase`
+- `Unit.toNumber`
+
+It does not inspect `Unit.units`, `Unit.value`, `Unit.UNITS`, or other mathjs internals.
+
+A result is pure currency when its dimensions equal one active currency unit. This recognizes derived expressions such as `remaining / 8` and dimensionally simplified currency results, while excluding compound values such as `GBP / hour`.
+
+Mathjs cannot remove registered units. Rebuilding the immutable registry changes which units receive currency presentation, even though stale mathjs unit definitions may remain until Obsidian reloads.
+
+## Currency presentation (PR 2)
+
+PR 2 adds two independent settings:
+
+### Currency decimal places
+
+- `Use rendered number format` is the compatibility default.
+- `Use currency standard` uses ISO 4217 minor units obtained from `Intl.NumberFormat.resolvedOptions()`.
+
+Examples of standard digits:
+
+- GBP and USD: 2
+- JPY: 0
+- KWD: 3
+
+Custom/non-ISO currencies default to 2 and expose a validated custom decimal-place setting from 0 through 20.
+
+### Currency display
+
+- `ISO code` is the compatibility default, such as `12.50 GBP`.
+- `Configured symbol` uses the symbol in Numerals' active currency map.
+
+Symbol placement comes from `Intl.NumberFormat.formatToParts()`. The formatter replaces only the `currency` part with the configured symbol. This preserves locale order, spacing, digits, signs, and bidirectional marks without accepting Intl's choice of symbol. For example, a `$` mapping to CAD continues to display the configured `$`, not an automatically selected `CA$`.
+
+### Currency precedence and scope
+
+- An explicit `@decimalPlaces` value overrides the currency-standard digit count.
+- Pure configured currencies receive currency policy.
+- Compound currency rates retain the selected general number format.
+- TeX uses the same rounding decision, with a period decimal and no locale grouping.
+- Result insertion continues using an ISO/custom unit code, never a display symbol.
+
+Compatibility defaults mean users see no currency presentation change until they opt in.
+
+## Rounding versus display formatting
+
+`@decimalPlaces` changes presentation, not computation. When a calculation itself must be rounded, use mathjs' rounding functions.
+
+For numbers:
+
+```text
+round(2.555, 2)
+```
+
+For a mathjs Unit, the unit-aware signature requires the target unit:
+
+```text
+round(amount, 2, GBP)
+```
+
+The two-argument Unit form is not supported by mathjs. Numerals should not override `round()` or add `toFixed()` to expression scope. `toFixed()` produces a string, which would mix display values into subsequent calculations and blur the computation/display boundary.
+
+Conventional two-place rounding examples are:
+
+```text
+120      -> 120.00
+120.1    -> 120.10
+120.32   -> 120.32
+120.35   -> 120.35
+120.3499 -> 120.35
+```
+
+## Compatibility and migration policy
+
+PR 1 requirements:
+
+- Default `text`, `tex`, and `canonical` output matches current behavior.
+- Existing settings JSON remains valid.
+- No result is rounded in scope.
+- No mathjs formatter or Unit internal is patched for presentation.
+- Only explicit block directives change output.
+
+PR 2 requirements:
+
+- Currency code and current number-format behavior remain the defaults.
+- Automatic currency digits and configured symbols are opt-in.
+- The settings tab stays on the imperative API because `minAppVersion` remains below Obsidian 1.13.0.
+- Symbol/unit remapping retains the existing reload requirement where mathjs aliases cannot be removed safely.
+
+## Acceptance matrix
+
+The implementation must cover:
+
+- All global number profiles with and without block overrides.
+- Plain, syntax-highlighted, TeX, inline Reading mode, inline Live Preview, and result insertion.
+- Preservation of raw values through assignments, `@prev`, `@sum`, and globals.
+- GBP/USD, JPY, KWD, remapped `$`, and custom currencies.
+- Scalar-derived currency and compound currency rates.
+- Negative midpoint values such as `-1.255 GBP`.
+- `en-US`, `fr-FR`, and `ar-EG`, including non-Latin digits and bidi parts.
+- TeX/text agreement without reparsing localized display output.

--- a/src/formatting/currencyRegistry.ts
+++ b/src/formatting/currencyRegistry.ts
@@ -1,0 +1,115 @@
+import * as math from 'mathjs';
+import type { CurrencyType } from '../numerals.types';
+import type {
+	CurrencyDefinition,
+	CurrencyMatch,
+} from './types';
+
+const DEFAULT_CURRENCY_FRACTION_DIGITS = 2;
+
+export interface CurrencyRegistryOptions {
+	locale?: string;
+	fractionDigitsByCode?: ReadonlyMap<string, number>;
+}
+
+/**
+ * Immutable view of the currency units active in Numerals.
+ *
+ * Unit creation remains a plugin lifecycle concern. The registry only captures
+ * already-created units and classifies evaluated values through public mathjs
+ * Unit APIs.
+ */
+export class CurrencyRegistry {
+	private readonly definitionsByCode: ReadonlyMap<string, CurrencyDefinition>;
+	readonly definitions: readonly CurrencyDefinition[];
+
+	private constructor(definitions: CurrencyDefinition[]) {
+		this.definitions = Object.freeze(definitions.map(definition => Object.freeze(definition)));
+		this.definitionsByCode = new Map(
+			this.definitions.map(definition => [definition.code, definition])
+		);
+	}
+
+	static create(
+		currencyMap: readonly CurrencyType[],
+		options: CurrencyRegistryOptions = {}
+	): CurrencyRegistry {
+		const clonedEntries = currencyMap.map(entry => ({ ...entry }));
+		const definitionsByCode = new Map<string, CurrencyDefinition>();
+
+		for (const entry of clonedEntries) {
+			const code = entry.currency.trim();
+			if (code.length === 0) {
+				continue;
+			}
+
+			let unit: math.Unit;
+			try {
+				unit = math.unit(code);
+			} catch {
+				// A malformed or not-yet-created custom unit is not active.
+				continue;
+			}
+
+			const configuredDigits = options.fractionDigitsByCode?.get(code);
+			const fractionDigits = configuredDigits ??
+				getCurrencyFractionDigits(code, options.locale);
+
+			definitionsByCode.set(code, {
+				code,
+				symbol: entry.symbol,
+				texCommand: `\\${entry.name}`,
+				fractionDigits,
+				unit,
+			});
+		}
+
+		return new CurrencyRegistry([...definitionsByCode.values()]);
+	}
+
+	get(code: string): CurrencyDefinition | undefined {
+		return this.definitionsByCode.get(code);
+	}
+
+	/** Match a dimensionally pure currency result from the active registry. */
+	match(value: unknown): CurrencyMatch | undefined {
+		if (!math.isUnit(value)) {
+			return undefined;
+		}
+
+		for (const definition of this.definitions) {
+			if (!value.equalBase(definition.unit)) {
+				continue;
+			}
+
+			try {
+				return {
+					definition,
+					amount: value.toNumber(definition.code),
+				};
+			} catch {
+				// A matching base should convert, but a bad custom definition must
+				// not make result formatting fail for unrelated output.
+				return undefined;
+			}
+		}
+
+		return undefined;
+	}
+}
+
+function getCurrencyFractionDigits(code: string, locale?: string): number {
+	if (!/^[A-Za-z]{3}$/u.test(code)) {
+		return DEFAULT_CURRENCY_FRACTION_DIGITS;
+	}
+
+	try {
+		return new Intl.NumberFormat(locale, {
+			style: 'currency',
+			currency: code.toUpperCase(),
+		}).resolvedOptions().maximumFractionDigits ??
+			DEFAULT_CURRENCY_FRACTION_DIGITS;
+	} catch {
+		return DEFAULT_CURRENCY_FRACTION_DIGITS;
+	}
+}

--- a/src/formatting/index.ts
+++ b/src/formatting/index.ts
@@ -1,0 +1,19 @@
+export { CurrencyRegistry } from './currencyRegistry';
+export type { CurrencyRegistryOptions } from './currencyRegistry';
+export {
+	createNumberFormatProfile,
+	formatNumberWithProfile,
+	formatWithNumberFormatProfile,
+	isValidDecimalPlaces,
+	resolveNumberFormatProfile,
+} from './numberFormat';
+export { createResultFormatter } from './resultFormatter';
+export type { ResultFormatterConfig } from './resultFormatter';
+export type {
+	CurrencyDefinition,
+	CurrencyMatch,
+	FormattedResult,
+	NumberFormatProfile,
+	ResultFormatOverrides,
+	ResultFormatter,
+} from './types';

--- a/src/formatting/numberFormat.ts
+++ b/src/formatting/numberFormat.ts
@@ -1,0 +1,419 @@
+import * as math from 'mathjs';
+import { NumeralsNumberFormat } from '../numerals.types';
+import { getLocaleFormatter } from '../rendering/displayUtils';
+import type {
+	NumberFormatProfile,
+	ResultFormatOverrides,
+} from './types';
+
+const MIN_DECIMAL_PLACES = 0;
+const MAX_DECIMAL_PLACES = 20;
+
+/** Return whether a decimal-place value is supported by the formatter. */
+export function isValidDecimalPlaces(value: number): boolean {
+	return Number.isInteger(value) &&
+		value >= MIN_DECIMAL_PLACES &&
+		value <= MAX_DECIMAL_PLACES;
+}
+
+/**
+ * Normalize a persisted number-format setting without discarding its locale.
+ * The `mathjsFormat` field is exactly the formatter Numerals used before the
+ * result-formatting architecture was introduced.
+ */
+export function createNumberFormatProfile(
+	format: NumeralsNumberFormat,
+	systemLocale?: string
+): NumberFormatProfile {
+	const resolvedSystemLocale = new Intl.NumberFormat(systemLocale)
+		.resolvedOptions().locale;
+
+	switch (format) {
+		case NumeralsNumberFormat.System:
+			return localeProfile(
+				format,
+				resolvedSystemLocale,
+				resolvedSystemLocale,
+				getLocaleFormatter(systemLocale)
+			);
+		case NumeralsNumberFormat.Fixed:
+			return {
+				id: format,
+				systemLocale: resolvedSystemLocale,
+				notation: 'fixed',
+				useGrouping: false,
+				mathjsFormat: { notation: 'fixed' },
+			};
+		case NumeralsNumberFormat.Exponential:
+			return {
+				id: format,
+				systemLocale: resolvedSystemLocale,
+				notation: 'exponential',
+				useGrouping: false,
+				mathjsFormat: { notation: 'exponential' },
+			};
+		case NumeralsNumberFormat.Engineering:
+			return {
+				id: format,
+				systemLocale: resolvedSystemLocale,
+				notation: 'engineering',
+				useGrouping: false,
+				mathjsFormat: { notation: 'engineering' },
+			};
+		case NumeralsNumberFormat.Format_CommaThousands_PeriodDecimal:
+			return localeProfile(format, resolvedSystemLocale, 'en-US', getLocaleFormatter('en-US'));
+		case NumeralsNumberFormat.Format_PeriodThousands_CommaDecimal:
+			return localeProfile(format, resolvedSystemLocale, 'de-DE', getLocaleFormatter('de-DE'));
+		case NumeralsNumberFormat.Format_SpaceThousands_CommaDecimal:
+			return localeProfile(format, resolvedSystemLocale, 'fr-FR', getLocaleFormatter('fr-FR'));
+		case NumeralsNumberFormat.Format_Indian:
+			return localeProfile(format, resolvedSystemLocale, 'en-IN', getLocaleFormatter('en-IN'));
+		default:
+			return {
+				id: NumeralsNumberFormat.Fixed,
+				systemLocale: resolvedSystemLocale,
+				notation: 'fixed',
+				useGrouping: false,
+				mathjsFormat: { notation: 'fixed' },
+			};
+	}
+}
+
+function localeProfile(
+	id: NumeralsNumberFormat,
+	systemLocale: string,
+	locale: string | undefined,
+	mathjsFormat: NumberFormatProfile['mathjsFormat']
+): NumberFormatProfile {
+	return {
+		id,
+		systemLocale,
+		locale: new Intl.NumberFormat(locale).resolvedOptions().locale,
+		notation: 'standard',
+		useGrouping: true,
+		mathjsFormat,
+	};
+}
+
+/** Resolve an optional per-block number-format selection. */
+export function resolveNumberFormatProfile(
+	defaultProfile: NumberFormatProfile,
+	overrides?: ResultFormatOverrides
+): NumberFormatProfile {
+	if (overrides?.numberFormat === undefined) {
+		return defaultProfile;
+	}
+
+	return createNumberFormatProfile(
+		overrides.numberFormat,
+		defaultProfile.systemLocale
+	);
+}
+
+/**
+ * Format a mathjs result with a normalized profile.
+ *
+ * With no decimal override this delegates to the exact legacy formatter. An
+ * explicit decimal override is a presentation policy only; it does not mutate
+ * or round the evaluated value held in scope.
+ */
+export function formatWithNumberFormatProfile(
+	value: unknown,
+	profile: NumberFormatProfile,
+	decimalPlaces?: number
+): string {
+	if (decimalPlaces === undefined || !isValidDecimalPlaces(decimalPlaces)) {
+		return math.format(value, profile.mathjsFormat);
+	}
+	if (math.isFraction(value)) {
+		return formatNumberWithProfile(Number(value.valueOf()), profile, decimalPlaces);
+	}
+
+	const numberFormatter = createOverrideNumberFormatter(profile, decimalPlaces);
+	return math.format(value, numberFormatter);
+}
+
+/**
+ * Format a single numeric value under an explicit override.
+ * Exported so TeX and the currency layer can share the exact same rounding.
+ */
+export function formatNumberWithProfile(
+	value: number,
+	profile: NumberFormatProfile,
+	decimalPlaces: number
+): string {
+	if (!isValidDecimalPlaces(decimalPlaces)) {
+		return math.format(value, profile.mathjsFormat);
+	}
+
+	return createOverrideNumberFormatter(profile, decimalPlaces)(value);
+}
+
+function createOverrideNumberFormatter(
+	profile: NumberFormatProfile,
+	decimalPlaces: number
+): (value: unknown) => string {
+	return (value: unknown): string => {
+		if (math.isBigNumber(value)) {
+			return formatBigNumberWithProfile(value, profile, decimalPlaces);
+		}
+		if (math.isFraction(value)) {
+			return formatNumberWithProfile(
+				Number(value.valueOf()),
+				profile,
+				decimalPlaces
+			);
+		}
+		if (typeof value !== 'number') {
+			return math.format(value, {
+				notation: profile.notation === 'standard' ? 'fixed' : profile.notation,
+				precision: decimalPlaces,
+			});
+		}
+
+		if (!Number.isFinite(value)) {
+			return math.format(value);
+		}
+
+		switch (profile.notation) {
+			case 'exponential':
+				return formatExponential(value, decimalPlaces);
+			case 'engineering':
+				return formatEngineering(value, decimalPlaces);
+			case 'fixed':
+				return formatRoundedFixed(value, decimalPlaces);
+			case 'standard':
+			default:
+				return new Intl.NumberFormat(profile.locale, {
+					useGrouping: profile.useGrouping,
+					minimumFractionDigits: decimalPlaces,
+					maximumFractionDigits: decimalPlaces,
+				}).format(value);
+		}
+	};
+}
+
+function formatExponential(value: number, decimalPlaces: number): string {
+	if (value === 0) {
+		return `${formatRoundedFixed(value, decimalPlaces)}e+0`;
+	}
+
+	let { coefficient, exponent } = decomposeNumber(value);
+	let formattedCoefficient = formatRoundedFixed(coefficient, decimalPlaces);
+
+	// Decimal rounding can promote 9.99 to 10.00; normalize the exponent.
+	if (Math.abs(Number(formattedCoefficient)) >= 10) {
+		exponent += 1;
+		coefficient /= 10;
+		formattedCoefficient = formatRoundedFixed(coefficient, decimalPlaces);
+	}
+
+	return `${formattedCoefficient}e${exponent >= 0 ? '+' : ''}${exponent}`;
+}
+
+function formatEngineering(value: number, decimalPlaces: number): string {
+	if (value === 0) {
+		return `${formatRoundedFixed(value, decimalPlaces)}e+0`;
+	}
+
+	const scientific = decomposeNumber(value);
+	let exponent = Math.floor(scientific.exponent / 3) * 3;
+	let coefficient = scientific.coefficient *
+		Math.pow(10, scientific.exponent - exponent);
+	let formattedCoefficient = formatRoundedFixed(coefficient, decimalPlaces);
+
+	// Rounding can promote 999.99 to 1000.00; normalize it to the next group.
+	if (Math.abs(Number(formattedCoefficient)) >= 1000) {
+		exponent += 3;
+		coefficient /= 1000;
+		formattedCoefficient = formatRoundedFixed(coefficient, decimalPlaces);
+	}
+
+	return `${formattedCoefficient}e${exponent >= 0 ? '+' : ''}${exponent}`;
+}
+
+function formatRoundedFixed(value: number, decimalPlaces: number): string {
+	return math.format(value, {
+		notation: 'fixed',
+		precision: decimalPlaces,
+	});
+}
+
+function decomposeNumber(value: number): {
+	coefficient: number;
+	exponent: number;
+} {
+	const [coefficient, exponent] = value.toExponential().split('e');
+	return {
+		coefficient: Number(coefficient),
+		exponent: Number(exponent),
+	};
+}
+
+function formatBigNumberWithProfile(
+	value: math.BigNumber,
+	profile: NumberFormatProfile,
+	decimalPlaces: number
+): string {
+	if (!value.isFinite()) {
+		return math.format(value);
+	}
+
+	switch (profile.notation) {
+		case 'exponential':
+			return normalizeExponent(value.toExponential(decimalPlaces));
+		case 'engineering':
+			return formatBigNumberEngineering(value, decimalPlaces);
+		case 'fixed':
+			return value.toFixed(decimalPlaces);
+		case 'standard':
+		default:
+			return localizeFixedDecimal(
+				value.toFixed(decimalPlaces),
+				profile.locale,
+				profile.useGrouping
+			);
+	}
+}
+
+function formatBigNumberEngineering(
+	value: math.BigNumber,
+	decimalPlaces: number
+): string {
+	if (value.isZero()) {
+		return `${value.toFixed(decimalPlaces)}e+0`;
+	}
+
+	const [coefficientText, exponentText] = value.toExponential().split('e');
+	const scientificExponent = Number(exponentText);
+	let exponent = Math.floor(scientificExponent / 3) * 3;
+	let coefficient = math.bignumber(coefficientText).times(
+		Math.pow(10, scientificExponent - exponent)
+	);
+	let formattedCoefficient = coefficient.toFixed(decimalPlaces);
+
+	if (Math.abs(Number(formattedCoefficient)) >= 1000) {
+		exponent += 3;
+		coefficient = coefficient.dividedBy(1000);
+		formattedCoefficient = coefficient.toFixed(decimalPlaces);
+	}
+
+	return `${formattedCoefficient}e${exponent >= 0 ? '+' : ''}${exponent}`;
+}
+
+function localizeFixedDecimal(
+	value: string,
+	locale: string | undefined,
+	useGrouping: boolean
+): string {
+	const negative = value.startsWith('-');
+	const unsignedValue = negative ? value.slice(1) : value;
+	const [integer, fraction] = unsignedValue.split('.');
+	const partsFormatter = new Intl.NumberFormat(locale, {
+		useGrouping: true,
+		maximumFractionDigits: 1,
+	});
+	const sampleParts = partsFormatter.formatToParts(123456789.1);
+	const groupSeparator = sampleParts.find((part) => part.type === 'group')?.value ?? '';
+	const decimalSeparator = sampleParts.find((part) => part.type === 'decimal')?.value ?? '.';
+	const integerGroupLengths = sampleParts
+		.filter((part) => part.type === 'integer')
+		.map((part) => part.value.length);
+	const primaryGroupSize = integerGroupLengths[integerGroupLengths.length - 1] ?? 3;
+	const secondaryGroupSize = integerGroupLengths[integerGroupLengths.length - 2] ??
+		primaryGroupSize;
+	const minimumGroupedLength = findMinimumGroupedLength(locale);
+	const groupedInteger = useGrouping
+		? groupInteger(
+			integer,
+			groupSeparator,
+			primaryGroupSize,
+			secondaryGroupSize,
+			minimumGroupedLength
+		)
+		: integer;
+	const { prefix, suffix } = getSignAffixes(locale, negative);
+	const localizedValue = `${prefix}${groupedInteger}${
+		fraction === undefined ? '' : `${decimalSeparator}${fraction}`
+	}${suffix}`;
+
+	return localizeDigits(localizedValue, locale);
+}
+
+function groupInteger(
+	integer: string,
+	separator: string,
+	primarySize: number,
+	secondarySize: number,
+	minimumGroupedLength: number
+): string {
+	if (integer.length < minimumGroupedLength || separator === '') {
+		return integer;
+	}
+
+	const groups: string[] = [];
+	let cursor = integer.length;
+	let groupSize = primarySize;
+	while (cursor > 0) {
+		const start = Math.max(0, cursor - groupSize);
+		groups.unshift(integer.slice(start, cursor));
+		cursor = start;
+		groupSize = secondarySize;
+	}
+
+	return groups.join(separator);
+}
+
+function findMinimumGroupedLength(locale: string | undefined): number {
+	const formatter = new Intl.NumberFormat(locale, {
+		useGrouping: true,
+		maximumFractionDigits: 0,
+	});
+	for (let length = 4; length <= 15; length++) {
+		const sample = Math.pow(10, length - 1);
+		if (formatter.formatToParts(sample).some((part) => part.type === 'group')) {
+			return length;
+		}
+	}
+
+	return Number.POSITIVE_INFINITY;
+}
+
+function getSignAffixes(
+	locale: string | undefined,
+	negative: boolean
+): { prefix: string; suffix: string } {
+	if (!negative) {
+		return { prefix: '', suffix: '' };
+	}
+
+	const parts = new Intl.NumberFormat(locale, {
+		useGrouping: false,
+		maximumFractionDigits: 0,
+	}).formatToParts(-1);
+	const integerIndex = parts.findIndex((part) => part.type === 'integer');
+	return {
+		prefix: parts.slice(0, integerIndex).map((part) => part.value).join(''),
+		suffix: parts.slice(integerIndex + 1).map((part) => part.value).join(''),
+	};
+}
+
+function localizeDigits(value: string, locale: string | undefined): string {
+	const digitFormatter = new Intl.NumberFormat(locale, {
+		useGrouping: false,
+		maximumFractionDigits: 0,
+	});
+	const digits = Array.from({ length: 10 }, (_unused, digit) =>
+		digitFormatter.format(digit)
+	);
+
+	return value.replace(/\d/gu, (digit) => digits[Number(digit)]);
+}
+
+function normalizeExponent(value: string): string {
+	return value.replace(/e([+-]?)(\d+)$/u, (
+		_match,
+		sign: string,
+		exponent: string
+	) => `e${sign || '+'}${Number(exponent)}`);
+}

--- a/src/formatting/resultFormatter.ts
+++ b/src/formatting/resultFormatter.ts
@@ -1,0 +1,331 @@
+import * as math from 'mathjs';
+import type { StringReplaceMap } from '../numerals.types';
+import {
+	getLocaleFormatter,
+	texCurrencyReplacement,
+} from '../rendering/displayUtils';
+import { resultToTeX } from '../rendering/texRendering';
+import type { CurrencyRegistry } from './currencyRegistry';
+import {
+	formatWithNumberFormatProfile,
+	formatNumberWithProfile,
+	resolveNumberFormatProfile,
+} from './numberFormat';
+import type {
+	FormattedResult,
+	NumberFormatProfile,
+	ResultFormatOverrides,
+	ResultFormatter,
+} from './types';
+
+export interface ResultFormatterConfig {
+	profile: NumberFormatProfile;
+	/** Wired in PR 1 so PR 2 can add policy without changing call sites. */
+	currencies?: CurrencyRegistry;
+	/** Legacy TeX conversion applies these source preprocessing rules. */
+	preProcessors?: StringReplaceMap[];
+}
+
+/** Create the shared formatter used by block, inline, TeX, and insertion paths. */
+export function createResultFormatter(
+	config: ResultFormatterConfig
+): ResultFormatter {
+	return new DefaultResultFormatter(config);
+}
+
+class DefaultResultFormatter implements ResultFormatter {
+	private readonly profile: NumberFormatProfile;
+	private readonly preProcessors: StringReplaceMap[];
+
+	constructor(config: ResultFormatterConfig) {
+		this.profile = config.profile;
+		this.preProcessors = [...(config.preProcessors ?? [])];
+		// Retain the registry in the public construction contract for PR 2.
+		// PR 1 intentionally applies no currency-special presentation policy.
+		void config.currencies;
+	}
+
+	format(value: unknown, overrides?: ResultFormatOverrides): FormattedResult {
+		const profile = resolveNumberFormatProfile(this.profile, overrides);
+		const text = formatWithNumberFormatProfile(
+			value,
+			profile,
+			overrides?.decimalPlaces
+		);
+
+		const tex = overrides?.decimalPlaces === undefined &&
+			overrides?.numberFormat === undefined
+			? legacyResultToTeX(value, this.preProcessors)
+			: formatOverrideAsTeX(
+				value,
+				profile,
+				overrides?.decimalPlaces,
+				this.preProcessors
+			);
+
+		return {
+			text,
+			tex,
+			// PR 1 preserves the result-insertion contract byte-for-byte.
+			canonical: text,
+		};
+	}
+}
+
+function legacyResultToTeX(
+	value: unknown,
+	preProcessors: StringReplaceMap[]
+): string {
+	try {
+		return resultToTeX(value, preProcessors);
+	} catch {
+		if (value === Number.POSITIVE_INFINITY) {
+			return '\\infty';
+		}
+		if (value === Number.NEGATIVE_INFINITY) {
+			return '-\\infty';
+		}
+		if (typeof value === 'number' && Number.isNaN(value)) {
+			return '\\mathrm{NaN}';
+		}
+		return `\\text{${escapeTexText(math.format(value))}}`;
+	}
+}
+
+function formatOverrideAsTeX(
+	value: unknown,
+	profile: NumberFormatProfile,
+	decimalPlaces: number | undefined,
+	preProcessors: StringReplaceMap[]
+): string {
+	if (typeof value === 'number') {
+		return numberToTeX(value, profile, decimalPlaces);
+	}
+	if (math.isBigNumber(value)) {
+		return bigNumberToTeX(value, profile, decimalPlaces);
+	}
+	if (math.isFraction(value)) {
+		return numberToTeX(Number(value.valueOf()), profile, decimalPlaces);
+	}
+
+	if (math.isComplex(value)) {
+		return complexToTeX(value, profile, decimalPlaces);
+	}
+
+	const collectionTex = collectionToTeX(
+		value,
+		profile,
+		decimalPlaces,
+		preProcessors
+	);
+	if (collectionTex !== undefined) {
+		return collectionTex;
+	}
+
+	if (math.isUnit(value)) {
+		try {
+			const units = value.formatUnits();
+			const numericValue = value.toNumber(units);
+			const numberTex = numberToTeX(numericValue, profile, decimalPlaces);
+			let unitExpression = `1 ${units}`;
+			unitExpression = applyPreProcessors(unitExpression, preProcessors);
+			const unitTex = texCurrencyReplacement(
+				math.parse(unitExpression).toTex()
+			);
+			return unitTex.replace(/1/u, () => numberTex);
+		} catch {
+			// Fall through to the generic result conversion.
+		}
+	}
+
+	let processedResult = formatWithNumberFormatProfile(
+		value,
+		texProfile(profile),
+		decimalPlaces
+	);
+	processedResult = applyPreProcessors(processedResult, preProcessors);
+
+	try {
+		return texCurrencyReplacement(math.parse(processedResult).toTex());
+	} catch {
+		// Keep the fallback value-driven and non-localized. Some uncommon
+		// mathjs result types cannot be round-tripped through expression text.
+		return resultToTeX(value, preProcessors);
+	}
+}
+
+function numberToTeX(
+	value: number,
+	profile: NumberFormatProfile,
+	decimalPlaces: number | undefined
+): string {
+	const specialValue = specialNumberToTeX(value);
+	if (specialValue !== undefined) {
+		return specialValue;
+	}
+
+	return numberStringToTeX(formatNumberForTeX(value, profile, decimalPlaces));
+}
+
+function bigNumberToTeX(
+	value: math.BigNumber,
+	profile: NumberFormatProfile,
+	decimalPlaces: number | undefined
+): string {
+	if (value.isNaN()) {
+		return '\\mathrm{NaN}';
+	}
+	if (!value.isFinite()) {
+		return `${value.isNegative() ? '-' : ''}\\infty`;
+	}
+
+	return numberStringToTeX(formatWithNumberFormatProfile(
+		value,
+		texProfile(profile),
+		decimalPlaces
+	));
+}
+
+function specialNumberToTeX(value: number): string | undefined {
+	if (value === Number.POSITIVE_INFINITY) {
+		return '\\infty';
+	}
+	if (value === Number.NEGATIVE_INFINITY) {
+		return '-\\infty';
+	}
+	if (Number.isNaN(value)) {
+		return '\\mathrm{NaN}';
+	}
+
+	return undefined;
+}
+
+function complexToTeX(
+	value: math.Complex,
+	profile: NumberFormatProfile,
+	decimalPlaces: number | undefined
+): string {
+	const realTex = numberToTeX(value.re, profile, decimalPlaces);
+	const imaginaryTex = numberToTeX(
+		Math.abs(value.im),
+		profile,
+		decimalPlaces
+	);
+
+	if (value.im === 0) {
+		return realTex;
+	}
+	if (value.re === 0) {
+		return `${value.im < 0 ? '-' : ''}${imaginaryTex}~ i`;
+	}
+
+	return `${realTex} ${value.im < 0 ? '-' : '+'} ${imaginaryTex}~ i`;
+}
+
+function collectionToTeX(
+	value: unknown,
+	profile: NumberFormatProfile,
+	decimalPlaces: number | undefined,
+	preProcessors: StringReplaceMap[]
+): string | undefined {
+	let collection: unknown = value;
+	if (math.isMatrix(value)) {
+		collection = value.toArray();
+	}
+	if (!Array.isArray(collection)) {
+		return undefined;
+	}
+	const collectionItems = collection as unknown[];
+	if (collectionItems.length === 0) {
+		return '\\begin{bmatrix}\\end{bmatrix}';
+	}
+
+	let rows: unknown[][];
+	if (collectionItems.every((item) => !Array.isArray(item))) {
+		rows = collectionItems.map((item) => [item]);
+	} else if (isRegularMatrix(collectionItems)) {
+		rows = collectionItems;
+	} else {
+		const renderedItems = collectionItems.map((item) =>
+			formatOverrideAsTeX(item, profile, decimalPlaces, preProcessors)
+		);
+		return `\\left[${renderedItems.join(', ')}\\right]`;
+	}
+
+	const renderedRows = rows.map((row) => row.map((cell) =>
+		formatOverrideAsTeX(cell, profile, decimalPlaces, preProcessors)
+	).join('&'));
+
+	return `\\begin{bmatrix}${renderedRows.join('\\\\')}\\end{bmatrix}`;
+}
+
+function isRegularMatrix(value: unknown[]): value is unknown[][] {
+	if (!value.every(isFlatCollectionRow)) {
+		return false;
+	}
+
+	const columnCount = value[0].length;
+	return value.every((row) => row.length === columnCount);
+}
+
+function isFlatCollectionRow(value: unknown): value is unknown[] {
+	return Array.isArray(value) &&
+		(value as unknown[]).every((cell) => !Array.isArray(cell));
+}
+
+function applyPreProcessors(
+	value: string,
+	preProcessors: StringReplaceMap[]
+): string {
+	let processedResult = value;
+	for (const processor of preProcessors) {
+		processedResult = processedResult.replace(
+			processor.regex,
+			processor.replaceStr
+		);
+	}
+	return processedResult;
+}
+
+function formatNumberForTeX(
+	value: number,
+	profile: NumberFormatProfile,
+	decimalPlaces: number | undefined
+): string {
+	const profileForTeX = texProfile(profile);
+	if (decimalPlaces !== undefined) {
+		return formatNumberWithProfile(value, profileForTeX, decimalPlaces);
+	}
+
+	return math.format(value, profileForTeX.mathjsFormat);
+}
+
+function texProfile(profile: NumberFormatProfile): NumberFormatProfile {
+	if (profile.notation !== 'standard') {
+		return profile;
+	}
+
+	return {
+		...profile,
+		locale: 'en-US',
+		useGrouping: false,
+		mathjsFormat: getLocaleFormatter('en-US', { useGrouping: false }),
+	};
+}
+
+function numberStringToTeX(value: string): string {
+	const exponential = value.match(/^(.+)[eE]([+-]?\d+)$/u);
+	if (!exponential) {
+		return value;
+	}
+
+	return `${exponential[1]} \\times 10^{${Number(exponential[2])}}`;
+}
+
+function escapeTexText(value: string): string {
+	return value
+		.replace(/\\/gu, '\\textbackslash{}')
+		.replace(/([{}#$%&_])/gu, '\\$1')
+		.replace(/\^/gu, '\\textasciicircum{}')
+		.replace(/~/gu, '\\textasciitilde{}');
+}

--- a/src/formatting/resultFormatter.ts
+++ b/src/formatting/resultFormatter.ts
@@ -125,8 +125,12 @@ function formatOverrideAsTeX(
 	if (math.isUnit(value)) {
 		try {
 			const units = value.formatUnits();
-			const numericValue = value.toNumber(units);
-			const numberTex = numberToTeX(numericValue, profile, decimalPlaces);
+			const numericValue = value.toNumeric(units);
+			const numberTex = numericValueToTeX(
+				numericValue,
+				profile,
+				decimalPlaces
+			);
 			let unitExpression = `1 ${units}`;
 			unitExpression = applyPreProcessors(unitExpression, preProcessors);
 			const unitTex = texCurrencyReplacement(
@@ -152,6 +156,20 @@ function formatOverrideAsTeX(
 		// mathjs result types cannot be round-tripped through expression text.
 		return resultToTeX(value, preProcessors);
 	}
+}
+
+function numericValueToTeX(
+	value: number | math.BigNumber | math.Fraction,
+	profile: NumberFormatProfile,
+	decimalPlaces: number | undefined
+): string {
+	if (math.isBigNumber(value)) {
+		return bigNumberToTeX(value, profile, decimalPlaces);
+	}
+	if (math.isFraction(value)) {
+		return numberToTeX(Number(value.valueOf()), profile, decimalPlaces);
+	}
+	return numberToTeX(value, profile, decimalPlaces);
 }
 
 function numberToTeX(

--- a/src/formatting/types.ts
+++ b/src/formatting/types.ts
@@ -1,0 +1,65 @@
+import type * as math from 'mathjs';
+import type {
+	NumeralsNumberFormat,
+	mathjsFormat,
+} from '../numerals.types';
+
+/** Per-block display policy parsed from Numerals formatting directives. */
+export interface ResultFormatOverrides {
+	/** Override the globally selected number format for this block. */
+	numberFormat?: NumeralsNumberFormat;
+	/** Render numeric components with exactly this many decimal places. */
+	decimalPlaces?: number;
+}
+
+/**
+ * A normalized number-format selection.
+ *
+ * `mathjsFormat` preserves Numerals' existing formatter for the compatibility
+ * path, while the remaining fields retain the locale and notation identity
+ * needed to compose explicit decimal-place and currency policies.
+ */
+export interface NumberFormatProfile {
+	/** The setting value from which this profile was created. */
+	id: NumeralsNumberFormat;
+	/** Resolved system locale, retained even when another profile is active. */
+	systemLocale: string;
+	/** Resolved BCP 47 locale for locale-backed formats. */
+	locale?: string;
+	/** Normalized notation used when an explicit display override is active. */
+	notation: 'standard' | 'fixed' | 'exponential' | 'engineering';
+	/** Whether locale-backed formatting groups thousands. */
+	useGrouping: boolean;
+	/** Existing mathjs-compatible format used when there is no override. */
+	mathjsFormat: mathjsFormat;
+}
+
+/** All presentation forms of one evaluated result. */
+export interface FormattedResult {
+	/** Localized, user-facing output. Does not include a result separator. */
+	text: string;
+	/** MathJax-ready TeX source. */
+	tex: string;
+	/** Persistable output. PR 1 intentionally preserves legacy text here. */
+	canonical: string;
+}
+
+/** The single formatting boundary used by every result-rendering surface. */
+export interface ResultFormatter {
+	format(value: unknown, overrides?: ResultFormatOverrides): FormattedResult;
+}
+
+/** Immutable metadata for one active currency unit. */
+export interface CurrencyDefinition {
+	code: string;
+	symbol: string;
+	texCommand: string;
+	fractionDigits: number;
+	unit: math.Unit;
+}
+
+/** A pure currency value matched against the active currency registry. */
+export interface CurrencyMatch {
+	definition: CurrencyDefinition;
+	amount: number;
+}

--- a/src/inline/inlineEvaluator.ts
+++ b/src/inline/inlineEvaluator.ts
@@ -1,6 +1,6 @@
 import * as math from 'mathjs';
 import { App } from 'obsidian';
-import { NumeralsScope, NumeralsSettings, mathjsFormat, StringReplaceMap, InlineEvaluationResult } from '../numerals.types';
+import { NumeralsScope, NumeralsSettings, StringReplaceMap, InlineEvaluationResult } from '../numerals.types';
 import { replaceStringsInTextFromMap } from '../processing/preprocessor';
 import { resolveCrossNoteReferences } from '../processing/crossNoteResolver';
 
@@ -9,25 +9,24 @@ import { resolveCrossNoteReferences } from '../processing/crossNoteResolver';
  *
  * Applies preprocessors (currency symbols, thousands separators),
  * handles the `@prev` directive (substituted to `__prev`),
- * evaluates via mathjs, and formats the result. The scope is cloned
+ * evaluates via mathjs, and returns the raw result. The scope is cloned
  * to prevent inline expressions from polluting the shared scope.
  *
  * @param expression - The math expression to evaluate (trigger prefix already stripped)
  * @param scope - Variable scope (note-globals + frontmatter)
- * @param numberFormat - mathjs format options for result display
  * @param preProcessors - String replacement rules (currency, thousands, etc.)
  * @param prevResult - The raw result of the previous inline expression (for @prev support).
  *                     Pass `undefined` when there is no previous result.
  * @param app - The Obsidian App instance (optional; required for cross-note references)
  * @param sourcePath - Path of the current file (optional; required for cross-note references)
  * @param settings - Numerals settings (optional; required for cross-note references)
- * @returns Object with `formatted` (display string) and `raw` (mathjs value for chaining)
+ * @returns The raw mathjs value and evaluation metadata. Display formatting is
+ * handled by the rendering layer.
  * @throws If mathjs cannot evaluate the expression, or @prev is used without a previous result
  */
 export function evaluateInlineExpression(
 	expression: string,
 	scope: NumeralsScope,
-	numberFormat: mathjsFormat,
 	preProcessors: StringReplaceMap[],
 	prevResult?: unknown,
 	app?: App,
@@ -76,10 +75,6 @@ export function evaluateInlineExpression(
 		throw new Error('Expression produced no result');
 	}
 
-	const formatted = numberFormat !== undefined
-		? math.format(result, numberFormat)
-		: math.format(result);
-
 	// Extract note-global ($-prefixed) variable assignments.
 	// Compare the local scope against the original to find new or changed $-keys.
 	const globals = new Map<string, unknown>();
@@ -89,5 +84,5 @@ export function evaluateInlineExpression(
 		}
 	}
 
-	return { formatted, raw: result, processedExpression: processed, globals, referencedPaths };
+	return { raw: result, processedExpression: processed, globals, referencedPaths };
 }

--- a/src/inline/inlineLivePreview.ts
+++ b/src/inline/inlineLivePreview.ts
@@ -39,18 +39,17 @@ import { editorInfoField, editorLivePreviewField } from 'obsidian';
 import {
 	NumeralsSettings,
 	NumeralsScope,
-	mathjsFormat,
 	StringReplaceMap,
 	InlineNumeralsMode,
 	NumeralsRenderStyle,
 	InlineTriggerSettings,
 } from '../numerals.types';
+import type { FormattedResult, ResultFormatter } from '../formatting';
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
 import { getActiveInlineTriggers, getInlineTriggers, parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
 import { getDataviewApi } from '../dataview';
 import {
-	preProcessorsEqual,
 	renderInlineInputContent,
 	renderInlineValueContent,
 } from './inlineRenderer';
@@ -137,16 +136,14 @@ export function selectionOverlapsRange(
  */
 export class InlineNumeralsWidget extends WidgetType {
 	constructor(
-		private readonly resultText: string,
+		private readonly formattedResult: FormattedResult,
 		private readonly mode: InlineNumeralsMode,
 		private readonly rawExpression: string,
 		private readonly separator: string,
 		private readonly isError: boolean,
 		private readonly formattingClasses: string[] = [],
 		private readonly renderStyle: NumeralsRenderStyle = NumeralsRenderStyle.Plain,
-		private readonly rawResult: unknown = resultText,
 		private readonly processedExpression: string = rawExpression,
-		private readonly preProcessors: StringReplaceMap[] = [],
 	) {
 		super();
 	}
@@ -157,17 +154,17 @@ export class InlineNumeralsWidget extends WidgetType {
 	 */
 	eq(other: InlineNumeralsWidget): boolean {
 		return (
-			this.resultText === other.resultText &&
+			this.formattedResult.text === other.formattedResult.text &&
+			this.formattedResult.tex === other.formattedResult.tex &&
+			this.formattedResult.canonical === other.formattedResult.canonical &&
 			this.mode === other.mode &&
 			this.rawExpression === other.rawExpression &&
 			this.separator === other.separator &&
 			this.isError === other.isError &&
 			this.renderStyle === other.renderStyle &&
-			// rawResult is intentionally not compared: mathjs results can be
-			// fresh objects on every evaluation pass, and any visible change
-			// is already captured by resultText and processedExpression.
+			// Raw mathjs objects never enter the widget. Visible equality is
+			// captured by the formatted result and processed expression.
 			this.processedExpression === other.processedExpression &&
-			preProcessorsEqual(this.preProcessors, other.preProcessors) &&
 			this.formattingClasses.length === other.formattingClasses.length &&
 			this.formattingClasses.every((c, i) => c === other.formattingClasses[i])
 		);
@@ -214,10 +211,8 @@ export class InlineNumeralsWidget extends WidgetType {
 			valueEl.className = 'numerals-inline-value';
 			renderInlineValueContent(
 				valueEl,
-				this.resultText,
-				this.rawResult,
-				this.renderStyle,
-				this.preProcessors
+				this.formattedResult,
+				this.renderStyle
 			);
 
 			span.appendChild(inputEl);
@@ -231,10 +226,8 @@ export class InlineNumeralsWidget extends WidgetType {
 			valueEl.className = 'numerals-inline-value';
 			renderInlineValueContent(
 				valueEl,
-				this.resultText,
-				this.rawResult,
-				this.renderStyle,
-				this.preProcessors
+				this.formattedResult,
+				this.renderStyle
 			);
 
 			span.appendChild(valueEl);
@@ -260,7 +253,7 @@ interface PrevResultRef {
 interface DecorationContext {
 	settings: NumeralsSettings;
 	triggers: InlineTriggerSettings;
-	numberFormat: mathjsFormat | undefined;
+	formatter: ResultFormatter;
 	preProcessors: StringReplaceMap[];
 	getScope: () => NumeralsScope;
 	scopeCache: Map<string, NumeralsScope>;
@@ -275,7 +268,7 @@ interface DecorationContext {
  */
 function createDecorationContext(
 	getSettings: () => NumeralsSettings,
-	getNumberFormat: () => mathjsFormat | undefined,
+	getFormatter: () => ResultFormatter,
 	preProcessors: StringReplaceMap[],
 	scopeCache: Map<string, NumeralsScope>,
 	app: App,
@@ -313,7 +306,7 @@ function createDecorationContext(
 	return {
 		settings,
 		triggers,
-		numberFormat: getNumberFormat(),
+		formatter: getFormatter(),
 		preProcessors,
 		getScope,
 		scopeCache,
@@ -360,8 +353,7 @@ function tryBuildNodeDecoration(
 	}
 
 	// Evaluate
-	let resultText: string;
-	let rawResult: unknown = '';
+	let formattedResult: FormattedResult = { text: '', tex: '', canonical: '' };
 	let processedExpression = parsed.expression;
 	let isError = false;
 	try {
@@ -369,15 +361,13 @@ function tryBuildNodeDecoration(
 		const result = evaluateInlineExpression(
 			parsed.expression,
 			scope,
-			ctx.numberFormat,
 			ctx.preProcessors,
 			prevResultRef.value,
 			ctx.app,
 			ctx.filePath,
 			ctx.settings,
 		);
-		resultText = result.formatted;
-		rawResult = result.raw;
+		formattedResult = ctx.formatter.format(result.raw);
 		processedExpression = result.processedExpression;
 		prevResultRef.value = result.raw;
 		for (const path of result.referencedPaths) {
@@ -403,8 +393,7 @@ function tryBuildNodeDecoration(
 			}
 		}
 	} catch {
-		resultText = '';
-		rawResult = '';
+		formattedResult = { text: '', tex: '', canonical: '' };
 		processedExpression = parsed.expression;
 		isError = true;
 		prevResultRef.value = undefined;
@@ -413,16 +402,14 @@ function tryBuildNodeDecoration(
 	const formattingClasses = getFormattingClasses(tokenProps);
 
 	const widget = new InlineNumeralsWidget(
-		resultText,
+		formattedResult,
 		parsed.mode,
 		parsed.expression,
 		ctx.settings.inlineEquationSeparator,
 		isError,
 		formattingClasses,
 		parsed.renderStyle,
-		rawResult,
 		processedExpression,
-		ctx.preProcessors,
 	);
 
 	return Decoration.replace({ widget }).range(spanFrom, spanTo);
@@ -557,7 +544,7 @@ function updateDecorations(
  * as evaluated widgets in Obsidian's Live Preview mode.
  *
  * @param getSettings     - Returns current plugin settings (called on each update for hot-reload)
- * @param getNumberFormat - Returns the active mathjs number format
+ * @param getFormatter      - Returns the active shared result formatter
  * @param getPreProcessors - Returns current string replacement preprocessors (currency symbols, etc.)
  * @param scopeCache        - Shared cache of per-file variable scopes
  * @param app               - The Obsidian App instance
@@ -565,7 +552,7 @@ function updateDecorations(
  */
 export function createInlineLivePreviewExtension(
 	getSettings: () => NumeralsSettings,
-	getNumberFormat: () => mathjsFormat | undefined,
+	getFormatter: () => ResultFormatter,
 	getPreProcessors: () => StringReplaceMap[],
 	scopeCache: Map<string, NumeralsScope>,
 	app: App,
@@ -680,7 +667,7 @@ export function createInlineLivePreviewExtension(
 
 				return createDecorationContext(
 					getSettings,
-					getNumberFormat,
+					getFormatter,
 					getPreProcessors(),
 					scopeCache,
 					app,

--- a/src/inline/inlinePostProcessor.ts
+++ b/src/inline/inlinePostProcessor.ts
@@ -1,5 +1,6 @@
 import { App, MarkdownPostProcessorContext, MarkdownRenderChild } from 'obsidian';
-import { NumeralsSettings, NumeralsScope, mathjsFormat, StringReplaceMap, InlineNumeralsMode, InlineEvaluationResult, NumeralsRenderStyle } from '../numerals.types';
+import { NumeralsSettings, NumeralsScope, StringReplaceMap, InlineNumeralsMode, InlineEvaluationResult, NumeralsRenderStyle } from '../numerals.types';
+import type { FormattedResult, ResultFormatter } from '../formatting';
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
 import { getActiveInlineTriggers, getInlineTriggers, parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
@@ -45,8 +46,8 @@ function renderInlineResult(
 	mode: InlineNumeralsMode,
 	renderStyle: NumeralsRenderStyle,
 	result: InlineEvaluationResult,
+	formattedResult: FormattedResult,
 	settings: NumeralsSettings,
-	preProcessors: StringReplaceMap[]
 ): void {
 	codeEl.empty();
 	codeEl.addClass('numerals-inline');
@@ -69,20 +70,16 @@ function renderInlineResult(
 		const valueEl = codeEl.createEl('span', { cls: 'numerals-inline-value' });
 		renderInlineValueContent(
 			valueEl,
-			result.formatted,
-			result.raw,
-			renderStyle,
-			preProcessors
+			formattedResult,
+			renderStyle
 		);
 	} else {
 		codeEl.addClass('numerals-inline-result');
 		const valueEl = codeEl.createEl('span', { cls: 'numerals-inline-value' });
 		renderInlineValueContent(
 			valueEl,
-			result.formatted,
-			result.raw,
-			renderStyle,
-			preProcessors
+			formattedResult,
+			renderStyle
 		);
 	}
 }
@@ -127,7 +124,7 @@ interface InlineProcessingResult {
  * @param codeEl - The inline <code> element
  * @param scope - The variable scope to evaluate against (also updated with globals)
  * @param settings - Plugin settings
- * @param numberFormat - Number formatting options
+ * @param formatter - Shared result formatter
  * @param preProcessors - String replacement preprocessors
  * @param prevResultRef - Mutable ref tracking the previous inline result (for @prev support)
  * @param scopeCache - Shared scope cache for note-global variables
@@ -137,7 +134,7 @@ function processInlineCodeElement(
 	codeEl: HTMLElement,
 	scope: NumeralsScope,
 	settings: NumeralsSettings,
-	numberFormat: mathjsFormat,
+	formatter: ResultFormatter,
 	preProcessors: StringReplaceMap[],
 	prevResultRef: PrevResultRef,
 	scopeCache: Map<string, NumeralsScope>,
@@ -156,13 +153,13 @@ function processInlineCodeElement(
 		const result = evaluateInlineExpression(
 			parsed.expression,
 			scope,
-			numberFormat,
 			preProcessors,
 			prevResultRef.value,
 			app,
 			sourcePath,
 			settings,
 		);
+		const formattedResult = formatter.format(result.raw);
 		prevResultRef.value = result.raw;
 
 		// Propagate $-prefixed globals for note-wide visibility
@@ -175,7 +172,15 @@ function processInlineCodeElement(
 			addGlobalsToScopeCache(scopeCache, sourcePath, result.globals);
 		}
 
-		renderInlineResult(codeEl, parsed.expression, parsed.mode, parsed.renderStyle, result, settings, preProcessors);
+		renderInlineResult(
+			codeEl,
+			parsed.expression,
+			parsed.mode,
+			parsed.renderStyle,
+			result,
+			formattedResult,
+			settings
+		);
 		return { referencedPaths: result.referencedPaths };
 	} catch {
 		prevResultRef.value = undefined;
@@ -198,7 +203,7 @@ function processInlineCodeElement(
  *
  * @param app - The Obsidian App instance
  * @param settings - Plugin settings (read at call time for hot-reload)
- * @param numberFormat - Number formatting configuration
+ * @param getFormatter - Returns the active shared result formatter
  * @param getPreProcessors - Returns current preprocessing rules (currency, thousands, etc.)
  * @param scopeCache - Shared scope cache for note-global variables
  * @returns The post-processor function (for registration with Plugin.registerMarkdownPostProcessor)
@@ -206,7 +211,7 @@ function processInlineCodeElement(
 export function createInlineNumeralsPostProcessor(
 	app: App,
 	getSettings: () => NumeralsSettings,
-	getNumberFormat: () => mathjsFormat,
+	getFormatter: () => ResultFormatter,
 	getPreProcessors: () => StringReplaceMap[],
 	scopeCache: Map<string, NumeralsScope>
 ): (el: HTMLElement, ctx: MarkdownPostProcessorContext) => void {
@@ -245,7 +250,7 @@ export function createInlineNumeralsPostProcessor(
 				preProcessors
 			);
 
-			const numberFormat = getNumberFormat();
+			const formatter = getFormatter();
 
 			// Track previous result for @prev support.
 			// Resets per section (post-processor call), so @prev only chains
@@ -259,7 +264,7 @@ export function createInlineNumeralsPostProcessor(
 					codeEl,
 					scope,
 					currentSettings,
-					numberFormat,
+					formatter,
 					preProcessors,
 					prevResultRef,
 					scopeCache,

--- a/src/inline/inlineRenderer.ts
+++ b/src/inline/inlineRenderer.ts
@@ -26,7 +26,7 @@ function renderTexOrText(
 		const texElement = createSpan(container, 'numerals-tex');
 		// mathjaxLoop is async, so a MathJax failure surfaces as a rejection
 		// that the surrounding try/catch cannot see — fall back to plain text.
-		void mathjaxLoop(texElement, tex).catch(() => {
+		void mathjaxLoop(texElement, tex, false).catch(() => {
 			texElement.textContent = text;
 		});
 	} catch {

--- a/src/inline/inlineRenderer.ts
+++ b/src/inline/inlineRenderer.ts
@@ -1,6 +1,7 @@
-import { NumeralsRenderStyle, StringReplaceMap } from '../numerals.types';
+import { NumeralsRenderStyle } from '../numerals.types';
+import type { FormattedResult } from '../formatting';
 import { mathjaxLoop } from '../rendering/displayUtils';
-import { expressionToTeX, resultToTeX } from '../rendering/texRendering';
+import { expressionToTeX } from '../rendering/texRendering';
 
 function createSpan(parent: HTMLElement, className: string): HTMLElement {
 	const span = parent.ownerDocument.createElement('span');
@@ -49,28 +50,13 @@ export function renderInlineInputContent(
 
 export function renderInlineValueContent(
 	container: HTMLElement,
-	formattedResult: string,
-	rawResult: unknown,
-	renderStyle: NumeralsRenderStyle,
-	preProcessors: StringReplaceMap[]
+	formattedResult: FormattedResult,
+	renderStyle: NumeralsRenderStyle
 ): void {
 	renderTexOrText(
 		container,
-		formattedResult,
+		formattedResult.text,
 		renderStyle,
-		() => resultToTeX(rawResult, preProcessors)
-	);
-}
-
-export function preProcessorsEqual(
-	a: StringReplaceMap[],
-	b: StringReplaceMap[]
-): boolean {
-	return (
-		a.length === b.length &&
-		a.every((processor, index) => (
-			processor.regex.toString() === b[index].regex.toString() &&
-			processor.replaceStr === b[index].replaceStr
-		))
+		() => formattedResult.tex
 	);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,11 @@
 import { NumeralsSuggestor } from "./NumeralsSuggestor";
-import { defaultCurrencyMap, getLocaleFormatter } from "./rendering/displayUtils";
+import { defaultCurrencyMap } from "./rendering/displayUtils";
+import {
+	createNumberFormatProfile,
+	createResultFormatter,
+	CurrencyRegistry,
+	ResultFormatter,
+} from "./formatting";
 import { processAndRenderNumeralsBlockFromSource } from "./rendering/orchestrator";
 import { handleNumeralsBlockClick } from "./rendering/editorNavigation";
 import { getMetadataForFileAtPath, addGlobalsFromScopeToPageCache } from "./processing/scope";
@@ -8,9 +14,7 @@ import {
 	CurrencyType,
 	NumeralsLayout,
 	NumeralsRenderStyle,
-	NumeralsNumberFormat,
 	NumeralsSettings,
-	mathjsFormat,
 	DEFAULT_SETTINGS,
 	NumeralsScope,
 	StringReplaceMap,
@@ -52,38 +56,14 @@ function (c: string) {
    @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call,
    @typescript-eslint/no-unsafe-return */
 
-
-/**
- * Map Numerals Number Format to mathjs format options
- */
-function getMathjsFormat(format: NumeralsNumberFormat): mathjsFormat {
-	switch (format) {
-		case NumeralsNumberFormat.System:
-			return getLocaleFormatter();
-		case NumeralsNumberFormat.Fixed:
-			return {notation: "fixed"};
-		case NumeralsNumberFormat.Exponential:
-			return {notation: "exponential"};
-		case NumeralsNumberFormat.Engineering:
-			return {notation: "engineering"};
-		case NumeralsNumberFormat.Format_CommaThousands_PeriodDecimal:
-			return getLocaleFormatter('en-US');
-		case NumeralsNumberFormat.Format_PeriodThousands_CommaDecimal:
-			return getLocaleFormatter('de-DE');
-		case NumeralsNumberFormat.Format_SpaceThousands_CommaDecimal:
-			return getLocaleFormatter('fr-FR');
-		case NumeralsNumberFormat.Format_Indian:
-			return getLocaleFormatter('en-IN');
-		default:
-			return {notation: "fixed"};
-	}
-}
-
 export default class NumeralsPlugin extends Plugin {
 	settings!: NumeralsSettings;
 	private currencyMap: CurrencyType[] = defaultCurrencyMap;
-	private preProcessors!: StringReplaceMap[];
-	private numberFormat: mathjsFormat;
+	private preProcessors: StringReplaceMap[] = [];
+	private currencyRegistry = CurrencyRegistry.create([]);
+	private resultFormatter: ResultFormatter = createResultFormatter({
+		profile: createNumberFormatProfile(DEFAULT_SETTINGS.numberFormat),
+	});
 	public scopeCache: Map<string, NumeralsScope> = new Map<string, NumeralsScope>();
 
 	/**
@@ -121,7 +101,7 @@ export default class NumeralsPlugin extends Plugin {
 			metadata,
 			type,
 			this.settings,
-			this.numberFormat,
+			this.resultFormatter,
 			this.preProcessors,
 			this.app
 		);
@@ -158,7 +138,7 @@ export default class NumeralsPlugin extends Plugin {
 				metadata,
 				type,
 				this.settings,
-				this.numberFormat,
+				this.resultFormatter,
 				this.preProcessors,
 				this.app
 			);
@@ -194,16 +174,17 @@ export default class NumeralsPlugin extends Plugin {
 			customCurrency: CurrencyType | null
 		): CurrencyType[] {
 		let currencyMap: CurrencyType[] = defaultCurrencyMap.map(m => {
+			const currency = { ...m };
 			if (m.symbol === "$") {
 				if (Object.keys(currencyCodesForDollarSign).includes(dollarCurrency)) {
-					m.currency = dollarCurrency;
+					currency.currency = dollarCurrency;
 				}
 			} else if (m.symbol === "¥") {
 				if (Object.keys(currencyCodesForYenSign).includes(yenCurrency)) {
-					m.currency = yenCurrency;
+					currency.currency = yenCurrency;
 				}
 			}
-			return m;
+			return currency;
 		});
 		if (customCurrency && customCurrency.symbol != "" && customCurrency.currency != "") {
 			const customCurrencyType: CurrencyType = {
@@ -227,6 +208,7 @@ export default class NumeralsPlugin extends Plugin {
 			this.settings.customCurrencySymbol
 		);
 		this.updatePreProcessors();
+		this.updateFormatting();
 	}
 
 	private updatePreProcessors() {
@@ -263,6 +245,7 @@ export default class NumeralsPlugin extends Plugin {
 				}
 			}
 		}
+		this.updateFormatting();
 
 		// Register Markdown Code Block Processors
 		const priority = 100;
@@ -278,7 +261,7 @@ export default class NumeralsPlugin extends Plugin {
 			createInlineNumeralsPostProcessor(
 				this.app,
 				() => this.settings,
-				() => this.numberFormat,
+				() => this.resultFormatter,
 				() => this.preProcessors,
 				this.scopeCache
 			)
@@ -288,7 +271,7 @@ export default class NumeralsPlugin extends Plugin {
 		this.registerEditorExtension(
 			createInlineLivePreviewExtension(
 				() => this.settings,
-				() => this.numberFormat,
+				() => this.resultFormatter,
 				() => this.preProcessors,
 				this.scopeCache,
 				this.app
@@ -354,6 +337,15 @@ export default class NumeralsPlugin extends Plugin {
 	}
 
 	updateLocale(): void {
-		this.numberFormat = getMathjsFormat(this.settings.numberFormat);
+		this.updateFormatting();
+	}
+
+	private updateFormatting(): void {
+		this.currencyRegistry = CurrencyRegistry.create(this.currencyMap);
+		this.resultFormatter = createResultFormatter({
+			profile: createNumberFormatProfile(this.settings.numberFormat),
+			currencies: this.currencyRegistry,
+			preProcessors: this.preProcessors,
+		});
 	}
 }

--- a/src/numerals.types.ts
+++ b/src/numerals.types.ts
@@ -154,6 +154,8 @@ export interface ProcessedBlock {
 	rawRows: string[];
 	/** Processed source string with directives replaced, ready for mathjs evaluation */
 	processedSource: string;
+	/** Source rows preserved for alignment but ignored by evaluator state. */
+	transparentLineIndexes: number[];
 	/** Metadata about special lines (emitters, insertions, etc.) */
 	blockInfo: numeralsBlockInfo;
 	/** Display-only overrides declared by block formatting directives. */

--- a/src/numerals.types.ts
+++ b/src/numerals.types.ts
@@ -1,4 +1,11 @@
 /****************************************************
+ * Shared Type Imports
+ ****************************************************/
+
+import type { ResultFormatOverrides, ResultFormatter } from './formatting/types';
+import type { InvalidFormatDirective } from './processing/formatDirectives';
+
+/****************************************************
  * Error Types
  ****************************************************/
 
@@ -149,6 +156,10 @@ export interface ProcessedBlock {
 	processedSource: string;
 	/** Metadata about special lines (emitters, insertions, etc.) */
 	blockInfo: numeralsBlockInfo;
+	/** Display-only overrides declared by block formatting directives. */
+	formatOverrides: ResultFormatOverrides;
+	/** Invalid formatting directives that prevent block evaluation. */
+	invalidFormatDirectives: InvalidFormatDirective[];
 }
 
 /**
@@ -198,8 +209,10 @@ export interface RenderContext {
 	renderStyle: NumeralsRenderStyle;
 	/** User settings affecting display and formatting */
 	settings: NumeralsSettings;
-	/** Number formatting configuration for displaying results */
-	numberFormat: mathjsFormat;
+	/** Shared result formatter used by every output surface. */
+	formatter: ResultFormatter;
+	/** Display-only overrides applying to the whole block. */
+	formatOverrides: ResultFormatOverrides;
 	/** String replacements to apply (e.g., currency symbols) */
 	preProcessors: StringReplaceMap[];
 }
@@ -245,8 +258,6 @@ export interface InlineNumeralsExpression {
 
 /** Result of evaluating an inline Numerals expression */
 export interface InlineEvaluationResult {
-	/** The formatted result string for display */
-	formatted: string;
 	/** The raw mathjs result value (for chaining via @prev) */
 	raw: unknown;
 	/** Expression after cross-note resolution, preprocessing, and inline directives */

--- a/src/processing/evaluator.ts
+++ b/src/processing/evaluator.ts
@@ -21,7 +21,8 @@ import { NumeralsScope, NumeralsError } from '../numerals.types';
  */
 export function evaluateMathFromSourceStrings(
 	processedSource: string,
-	scope: NumeralsScope
+	scope: NumeralsScope,
+	transparentLineIndexes: readonly number[] = []
 ): {
 	results: unknown[];
 	inputs: string[];
@@ -34,18 +35,27 @@ export function evaluateMathFromSourceStrings(
 	const rows: string[] = processedSource.split("\n");
 	const results: unknown[] = [];
 	const inputs: string[] = [];
+	const transparentLines = new Set(transparentLineIndexes);
+	const segmentResults: unknown[] = [];
+	let hasPreviousEvaluation = false;
+	let previousResult: unknown;
 
 	// Last row is empty in reader view, so ignore it if empty
 	const isLastRowEmpty = rows.slice(-1)[0] === "";
 	const rowsToProcess = isLastRowEmpty ? rows.slice(0, -1) : rows;
 
 	for (const [index, row] of rowsToProcess.entries()) {
-		const lastUndefinedRowIndex = results.slice(0, index).lastIndexOf(undefined);
+		if (transparentLines.has(index)) {
+			// Preserve source/result index alignment without allowing a display-only
+			// directive row to change @prev or reset the current @total segment.
+			results.push(undefined);
+			inputs.push(row);
+			continue;
+		}
 
 		try {
-			if (index > 0 && results.length > 0) {
-				const prevResult = results[results.length - 1];
-				scope.set("__prev", prevResult);
+			if (hasPreviousEvaluation) {
+				scope.set("__prev", previousResult);
 			} else {
 				scope.set("__prev", undefined);
 				if (/__prev/i.test(row)) {
@@ -55,11 +65,10 @@ export function evaluateMathFromSourceStrings(
 				}
 			}
 			
-			const partialResults = results.slice(lastUndefinedRowIndex+1, index).filter(result => result !== undefined);
-			if (partialResults.length > 1) {
+			if (segmentResults.length > 1) {
 				try {
 					// eslint-disable-next-line prefer-spread
-					const rollingSum = math.add.apply(math, partialResults as [math.MathType, math.MathType, ...math.MathType[]]);
+					const rollingSum = math.add.apply(math, segmentResults as [math.MathType, math.MathType, ...math.MathType[]]);
 					scope.set("__total", rollingSum);
 				} catch {
 					scope.set("__total", undefined);
@@ -71,13 +80,22 @@ export function evaluateMathFromSourceStrings(
 					}						
 				}
 
-			} else if (partialResults.length === 1) {
-				scope.set("__total", partialResults[0]);
+			} else if (segmentResults.length === 1) {
+				scope.set("__total", segmentResults[0]);
 			} else {
 				scope.set("__total", undefined);
 			}
-			results.push(math.evaluate(row, scope));
+
+			const result = math.evaluate(row, scope) as unknown;
+			results.push(result);
 			inputs.push(row); // Only pushes if evaluate is successful
+			hasPreviousEvaluation = true;
+			previousResult = result;
+			if (result === undefined) {
+				segmentResults.length = 0;
+			} else {
+				segmentResults.push(result);
+			}
 		} catch (error: unknown) {
 			errorMsg = error instanceof Error ? error : new Error(String(error));
 			errorInput = row;

--- a/src/processing/formatDirectives.ts
+++ b/src/processing/formatDirectives.ts
@@ -1,0 +1,222 @@
+export const MIN_DECIMAL_PLACES = 0;
+export const MAX_DECIMAL_PLACES = 20;
+
+export type BlockNumberFormat =
+	| 'system'
+	| 'fixed'
+	| 'exponential'
+	| 'engineering'
+	| 'comma-period'
+	| 'period-comma'
+	| 'space-comma'
+	| 'indian';
+
+export type FormatDirective =
+	| { kind: 'format'; value: BlockNumberFormat }
+	| { kind: 'decimalPlaces'; value: number };
+
+export type InvalidFormatDirectiveReason =
+	| 'missing-value'
+	| 'unknown-format'
+	| 'not-an-integer'
+	| 'out-of-range';
+
+export interface InvalidFormatDirective {
+	kind: FormatDirective['kind'];
+	lineIndex: number;
+	source: string;
+	value: string;
+	reason: InvalidFormatDirectiveReason;
+	message: string;
+}
+
+export type FormatDirectiveLineResult =
+	| { status: 'not-directive' }
+	| {
+		status: 'valid';
+		lineIndex: number;
+		source: string;
+		directive: FormatDirective;
+	}
+	| {
+		status: 'invalid';
+		error: InvalidFormatDirective;
+	};
+
+export interface CollectedFormatDirectives {
+	format?: BlockNumberFormat;
+	decimalPlaces?: number;
+	/** Zero-based source indexes for every recognized format directive. */
+	directiveLineIndexes: number[];
+	/** Zero-based source indexes for valid directives only. */
+	validDirectiveLineIndexes: number[];
+	invalidDirectives: InvalidFormatDirective[];
+	/**
+	 * Source with every recognized format directive replaced by an empty row.
+	 * The row count and original LF/CRLF line-ending style are preserved.
+	 */
+	sourceWithoutDirectives: string;
+}
+
+const formatAliases: Readonly<Record<string, BlockNumberFormat>> = {
+	system: 'system',
+	fixed: 'fixed',
+	exponential: 'exponential',
+	scientific: 'exponential',
+	engineering: 'engineering',
+	'comma-period': 'comma-period',
+	'period-comma': 'period-comma',
+	'space-comma': 'space-comma',
+	indian: 'indian',
+};
+
+const directiveLineRegex = /^[\t ]*@(format|decimalPlaces?)(?=$|[\t \r])([\s\S]*?)[\t ]*\r?$/i;
+
+function invalidDirective(
+	kind: FormatDirective['kind'],
+	lineIndex: number,
+	source: string,
+	value: string,
+	reason: InvalidFormatDirectiveReason,
+	message: string,
+): FormatDirectiveLineResult {
+	return {
+		status: 'invalid',
+		error: { kind, lineIndex, source, value, reason, message },
+	};
+}
+
+/**
+ * Parses one source row as a block formatting directive.
+ *
+ * Only complete-line directives are recognized. `scientific` is accepted as
+ * an alias and normalized to the canonical `exponential` format.
+ */
+export function parseFormatDirectiveLine(
+	source: string,
+	lineIndex: number,
+): FormatDirectiveLineResult {
+	const match = source.match(directiveLineRegex);
+	if (!match) {
+		return { status: 'not-directive' };
+	}
+
+	const command = match[1].toLowerCase();
+	const value = match[2].trim();
+	if (command === 'format') {
+		if (value.length === 0) {
+			return invalidDirective(
+				'format',
+				lineIndex,
+				source,
+				value,
+				'missing-value',
+				'Missing @format value.',
+			);
+		}
+
+		const format = formatAliases[value.toLowerCase()];
+		if (!format) {
+			return invalidDirective(
+				'format',
+				lineIndex,
+				source,
+				value,
+				'unknown-format',
+				`Unknown @format value: ${value}.`,
+			);
+		}
+
+		return {
+			status: 'valid',
+			lineIndex,
+			source,
+			directive: { kind: 'format', value: format },
+		};
+	}
+
+	if (value.length === 0) {
+		return invalidDirective(
+			'decimalPlaces',
+			lineIndex,
+			source,
+			value,
+			'missing-value',
+			`Missing @decimalPlaces value; expected an integer from ${MIN_DECIMAL_PLACES} to ${MAX_DECIMAL_PLACES}.`,
+		);
+	}
+
+	if (!/^\d+$/.test(value)) {
+		return invalidDirective(
+			'decimalPlaces',
+			lineIndex,
+			source,
+			value,
+			'not-an-integer',
+			`Invalid @decimalPlaces value: ${value}; expected an integer from ${MIN_DECIMAL_PLACES} to ${MAX_DECIMAL_PLACES}.`,
+		);
+	}
+
+	const decimalPlaces = Number(value);
+	if (decimalPlaces < MIN_DECIMAL_PLACES || decimalPlaces > MAX_DECIMAL_PLACES) {
+		return invalidDirective(
+			'decimalPlaces',
+			lineIndex,
+			source,
+			value,
+			'out-of-range',
+			`Invalid @decimalPlaces value: ${value}; expected an integer from ${MIN_DECIMAL_PLACES} to ${MAX_DECIMAL_PLACES}.`,
+		);
+	}
+
+	return {
+		status: 'valid',
+		lineIndex,
+		source,
+		directive: { kind: 'decimalPlaces', value: decimalPlaces },
+	};
+}
+
+/**
+ * Collects block formatting directives without changing source row indexes.
+ * When a directive occurs more than once, the last valid value wins.
+ */
+export function collectFormatDirectives(source: string): CollectedFormatDirectives {
+	const rows = source.split('\n');
+	const directiveLineIndexes: number[] = [];
+	const validDirectiveLineIndexes: number[] = [];
+	const invalidDirectives: InvalidFormatDirective[] = [];
+	let format: BlockNumberFormat | undefined;
+	let decimalPlaces: number | undefined;
+
+	const sourceRows = rows.map((row, lineIndex) => {
+		const result = parseFormatDirectiveLine(row, lineIndex);
+		if (result.status === 'not-directive') {
+			return row;
+		}
+
+		directiveLineIndexes.push(lineIndex);
+		if (result.status === 'invalid') {
+			invalidDirectives.push(result.error);
+		} else {
+			validDirectiveLineIndexes.push(lineIndex);
+			if (result.directive.kind === 'format') {
+				format = result.directive.value;
+			} else {
+				decimalPlaces = result.directive.value;
+			}
+		}
+
+		// Keep the original line ending while removing the directive content.
+		return row.endsWith('\r') ? '\r' : '';
+	});
+
+	return {
+		format,
+		decimalPlaces,
+		directiveLineIndexes,
+		validDirectiveLineIndexes,
+		invalidDirectives,
+		sourceWithoutDirectives: sourceRows.join('\n'),
+	};
+}

--- a/src/processing/preprocessor.ts
+++ b/src/processing/preprocessor.ts
@@ -106,6 +106,7 @@ export function preProcessBlockForNumeralsDirectives(
 	return {
 		rawRows,
 		processedSource,
+		transparentLineIndexes: formatDirectives.directiveLineIndexes,
 		formatOverrides: {
 			numberFormat: formatDirectives.format === undefined
 				? undefined

--- a/src/processing/preprocessor.ts
+++ b/src/processing/preprocessor.ts
@@ -1,4 +1,23 @@
-import { StringReplaceMap, numeralsBlockInfo } from '../numerals.types';
+import {
+	NumeralsNumberFormat,
+	ProcessedBlock,
+	StringReplaceMap,
+} from '../numerals.types';
+import {
+	BlockNumberFormat,
+	collectFormatDirectives,
+} from './formatDirectives';
+
+const blockNumberFormatMap: Record<BlockNumberFormat, NumeralsNumberFormat> = {
+	system: NumeralsNumberFormat.System,
+	fixed: NumeralsNumberFormat.Fixed,
+	exponential: NumeralsNumberFormat.Exponential,
+	engineering: NumeralsNumberFormat.Engineering,
+	'comma-period': NumeralsNumberFormat.Format_CommaThousands_PeriodDecimal,
+	'period-comma': NumeralsNumberFormat.Format_PeriodThousands_CommaDecimal,
+	'space-comma': NumeralsNumberFormat.Format_SpaceThousands_CommaDecimal,
+	indian: NumeralsNumberFormat.Format_Indian,
+};
 
 /**
  * Process a block of text to convert from Numerals syntax to MathJax syntax
@@ -26,18 +45,16 @@ export function replaceStringsInTextFromMap(text: string, stringReplaceMap: Stri
 export function preProcessBlockForNumeralsDirectives(
 	source: string,
 	preProcessors: StringReplaceMap[] | undefined,
-): {
-	rawRows: string[],
-	processedSource: string,
-	blockInfo: numeralsBlockInfo
-} {
+): ProcessedBlock {
 
 	const rawRows: string[] = source.split("\n");
-	let processedSource:string = source;
+	const formatDirectives = collectFormatDirectives(source);
+	let processedSource:string = formatDirectives.sourceWithoutDirectives;
 
 	const emitter_lines: number[] = [];
 	const insertion_lines: number[] = [];
 	const hidden_lines: number[] = [];
+	hidden_lines.push(...formatDirectives.directiveLineIndexes);
 	let shouldHideNonEmitterLines = false;
 
 	// Find emitter and result insertion lines before modifying source
@@ -89,6 +106,13 @@ export function preProcessBlockForNumeralsDirectives(
 	return {
 		rawRows,
 		processedSource,
+		formatOverrides: {
+			numberFormat: formatDirectives.format === undefined
+				? undefined
+				: blockNumberFormatMap[formatDirectives.format],
+			decimalPlaces: formatDirectives.decimalPlaces,
+		},
+		invalidFormatDirectives: formatDirectives.invalidDirectives,
 		blockInfo: {
 			emitter_lines,
 			insertion_lines,

--- a/src/renderers/BaseLineRenderer.ts
+++ b/src/renderers/BaseLineRenderer.ts
@@ -1,4 +1,3 @@
-import * as math from 'mathjs';
 import { LineRenderData, RenderContext } from '../numerals.types';
 import { renderComment } from '../rendering/linePreparation';
 import { ILineRenderer } from './ILineRenderer';
@@ -90,7 +89,10 @@ export abstract class BaseLineRenderer implements ILineRenderer {
 	): void {
 		const formattedResult =
 			context.settings.resultSeparator +
-			math.format(lineData.result, context.numberFormat);
+			context.formatter.format(
+				lineData.result,
+				context.formatOverrides
+			).text;
 		resultElement.setText(formattedResult);
 	}
 }

--- a/src/renderers/TeXRenderer.ts
+++ b/src/renderers/TeXRenderer.ts
@@ -1,7 +1,7 @@
 import { LineRenderData, RenderContext } from '../numerals.types';
 import { BaseLineRenderer } from './BaseLineRenderer';
 import { mathjaxLoop } from '../rendering/displayUtils';
-import { expressionToTeX, resultToTeX } from '../rendering/texRendering';
+import { expressionToTeX } from '../rendering/texRendering';
 
 /**
  * TeX renderer for Numerals blocks.
@@ -94,7 +94,10 @@ export class TeXRenderer extends BaseLineRenderer {
 		lineData: LineRenderData,
 		context: RenderContext
 	): void {
-		const texResult = resultToTeX(lineData.result, context.preProcessors);
+		const texResult = context.formatter.format(
+			lineData.result,
+			context.formatOverrides
+		).tex;
 
 		// Render with MathJax
 		const resultTexElement = resultElement.createEl('span', { cls: 'numerals-tex' });

--- a/src/rendering/displayUtils.ts
+++ b/src/rendering/displayUtils.ts
@@ -122,9 +122,13 @@ export function htmlToElements(html: string): DocumentFragment {
 	return sanitizedHTML;
   }
 
-export async function mathjaxLoop(container: HTMLElement, value: string) {
-	const html = renderMath(value, true);
-	await finishRenderMath()
+export async function mathjaxLoop(
+	container: HTMLElement,
+	value: string,
+	displayMode = true
+): Promise<void> {
+	const html = renderMath(value, displayMode);
+	await finishRenderMath();
 
 	// container.empty();
 	container.append(html);

--- a/src/rendering/orchestrator.ts
+++ b/src/rendering/orchestrator.ts
@@ -1,6 +1,6 @@
-import * as math from 'mathjs';
 import { App, MarkdownPostProcessorContext } from 'obsidian';
-import { NumeralsLayout, NumeralsRenderStyle, NumeralsSettings, NumeralsError, NumeralsBlockResult, mathjsFormat, NumeralsScope, StringReplaceMap, ProcessedBlock, EvaluationResult, RenderContext } from '../numerals.types';
+import { NumeralsLayout, NumeralsRenderStyle, NumeralsSettings, NumeralsError, NumeralsBlockResult, NumeralsScope, StringReplaceMap, ProcessedBlock, EvaluationResult, RenderContext } from '../numerals.types';
+import type { ResultFormatOverrides, ResultFormatter } from '../formatting';
 import { RendererFactory } from '../renderers';
 import { getScopeFromFrontmatter } from '../processing/scope';
 import { preProcessBlockForNumeralsDirectives } from '../processing/preprocessor';
@@ -94,7 +94,7 @@ export function renderNumeralsBlock(
  *
  * @param results - Array of evaluated results
  * @param insertionLines - Array of line indices that have insertion directives
- * @param numberFormat - Format specification for displaying numbers
+ * @param formatter - Shared result formatter
  * @param ctx - Markdown post processor context (provides section info)
  * @param app - Obsidian App instance (provides editor access)
  * @param el - The HTML element being rendered (used to get section info)
@@ -124,7 +124,8 @@ export function renderNumeralsBlock(
 export function handleResultInsertions(
 	results: unknown[],
 	insertionLines: number[],
-	numberFormat: mathjsFormat,
+	formatter: ResultFormatter,
+	formatOverrides: ResultFormatOverrides,
 	ctx: MarkdownPostProcessorContext,
 	app: App,
 	el: HTMLElement
@@ -151,7 +152,7 @@ export function handleResultInsertions(
 
 		const curLine = lineStart + i + 1;
 		const sourceLine = editor.getLine(curLine);
-		const insertionValue = math.format(results[i], numberFormat);
+		const insertionValue = formatter.format(results[i], formatOverrides).canonical;
 
 		// Replace @[variable] or @[variable::oldValue] with @[variable::newValue]
 		const modifiedSource = sourceLine.replace(
@@ -186,7 +187,7 @@ export function handleResultInsertions(
  * @param settings - A NumeralsSettings object that provides settings for the rendering process. These   
  * settings can control aspects such as the layout style, whether to alternate row colors, and whether   
  * to hide lines without markup when emitting.  
- * @param numberFormat - A mathjsFormat function that is used to format numbers in the Numerals block.  
+ * @param formatter - Shared formatter used for all result output.
  * @param preProcessors - An array of StringReplaceMap objects that specify text replacements to be   
  * made in the source string before it is processed.  
  * @param app - The Obsidian App instance.
@@ -201,7 +202,7 @@ export function processAndRenderNumeralsBlockFromSource(
 	metadata: {[key: string]: unknown} | undefined,
 	type: NumeralsRenderStyle | undefined,
 	settings: NumeralsSettings,
-	numberFormat: mathjsFormat,
+	formatter: ResultFormatter,
 	preProcessors: StringReplaceMap[],
 	app: App
 ): NumeralsBlockResult {
@@ -232,6 +233,17 @@ export function processAndRenderNumeralsBlockFromSource(
 
 	// Phase 2: Preprocess (using cross-note resolved source)
 	const processedBlock = preProcessBlockForNumeralsDirectives(crossNoteResult.resolvedSource, preProcessors);
+	if (processedBlock.invalidFormatDirectives.length > 0) {
+		applyBlockStyles({ el, settings, blockRenderStyle });
+		const directiveError = processedBlock.invalidFormatDirectives[0];
+		renderError(el, {
+			results: [],
+			inputs: [],
+			errorMsg: new NumeralsError('Formatting Directive Error', directiveError.message),
+			errorInput: directiveError.source,
+		});
+		return { scope: new NumeralsScope(), referencedPaths: crossNoteResult.referencedPaths };
+	}
 
 	// Phase 3: Apply block styles
 	applyBlockStyles({
@@ -259,7 +271,8 @@ export function processAndRenderNumeralsBlockFromSource(
 	handleResultInsertions(
 		evaluationResult.results,
 		processedBlock.blockInfo.insertion_lines,
-		numberFormat,
+		formatter,
+		processedBlock.formatOverrides,
 		ctx,
 		app,
 		el
@@ -269,7 +282,8 @@ export function processAndRenderNumeralsBlockFromSource(
 	const renderContext: RenderContext = {
 		renderStyle: blockRenderStyle,
 		settings,
-		numberFormat,
+		formatter,
+		formatOverrides: processedBlock.formatOverrides,
 		preProcessors,
 	};
 

--- a/src/rendering/orchestrator.ts
+++ b/src/rendering/orchestrator.ts
@@ -264,7 +264,8 @@ export function processAndRenderNumeralsBlockFromSource(
 	// Phase 5: Evaluate
 	const evaluationResult = evaluateMathFromSourceStrings(
 		processedBlock.processedSource,
-		scope
+		scope,
+		processedBlock.transparentLineIndexes
 	);
 
 	// Phase 6: Handle side effects (result insertions)

--- a/tests/currencyRegistry.test.ts
+++ b/tests/currencyRegistry.test.ts
@@ -1,0 +1,86 @@
+import * as math from 'mathjs';
+import { CurrencyRegistry } from '../src/formatting/currencyRegistry';
+import type { CurrencyType } from '../src/numerals.types';
+
+function ensureCurrencyUnit(code: string): void {
+	try {
+		math.createUnit(code, { aliases: [code.toLowerCase()] });
+	} catch {
+		// mathjs units are global and may have been created by another suite.
+	}
+}
+
+const currencyMap: CurrencyType[] = [
+	{ symbol: '£', unicode: 'x00A3', name: 'pound', currency: 'GBP' },
+	{ symbol: '¥', unicode: 'x00A5', name: 'yen', currency: 'JPY' },
+	{ symbol: 'د.ك', unicode: 'x0000', name: 'dinar', currency: 'KWD' },
+];
+
+describe('CurrencyRegistry', () => {
+	beforeAll(() => {
+		for (const { currency } of currencyMap) {
+			ensureCurrencyUnit(currency);
+		}
+	});
+
+	it('clones and freezes active definitions', () => {
+		const mutableMap = currencyMap.map(entry => ({ ...entry }));
+		const registry = CurrencyRegistry.create(mutableMap, { locale: 'en-US' });
+
+		mutableMap[0].symbol = 'changed';
+		mutableMap[0].currency = 'CHANGED';
+
+		expect(registry.get('GBP')?.symbol).toBe('£');
+		expect(registry.get('CHANGED')).toBeUndefined();
+		expect(Object.isFrozen(registry.definitions)).toBe(true);
+		expect(Object.isFrozen(registry.get('GBP'))).toBe(true);
+	});
+
+	it('gets standard minor-unit digits and honors a configured override', () => {
+		const registry = CurrencyRegistry.create(currencyMap, {
+			locale: 'en-US',
+			fractionDigitsByCode: new Map([['GBP', 4]]),
+		});
+
+		expect(registry.get('GBP')?.fractionDigits).toBe(4);
+		expect(registry.get('JPY')?.fractionDigits).toBe(0);
+		expect(registry.get('KWD')?.fractionDigits).toBe(3);
+	});
+
+	it('matches scalar-derived currency through public Unit APIs', () => {
+		const registry = CurrencyRegistry.create(currencyMap);
+		const remaining = math.unit(80, 'GBP');
+		const derived = math.divide(remaining, 8) as math.Unit;
+		const equalBase = jest.spyOn(derived, 'equalBase');
+		const toNumber = jest.spyOn(derived, 'toNumber');
+		const before = derived.toString();
+
+		const match = registry.match(derived);
+
+		expect(match?.definition.code).toBe('GBP');
+		expect(match?.amount).toBe(10);
+		expect(equalBase).toHaveBeenCalled();
+		expect(toNumber).toHaveBeenCalledWith('GBP');
+		expect(derived.toString()).toBe(before);
+	});
+
+	it('does not classify compound currency rates as pure currency', () => {
+		const registry = CurrencyRegistry.create(currencyMap);
+		const rate = math.divide(
+			math.unit(80, 'GBP'),
+			math.unit(2, 'hour')
+		) as math.Unit;
+
+		expect(registry.match(rate)).toBeUndefined();
+	});
+
+	it('ignores non-Unit results and inactive unit definitions', () => {
+		const registry = CurrencyRegistry.create([
+			...currencyMap,
+			{ symbol: '¤', unicode: 'x00A4', name: 'missing', currency: 'NOT_CREATED' },
+		]);
+
+		expect(registry.match(12)).toBeUndefined();
+		expect(registry.get('NOT_CREATED')).toBeUndefined();
+	});
+});

--- a/tests/formatDirectives.test.ts
+++ b/tests/formatDirectives.test.ts
@@ -1,0 +1,154 @@
+import {
+	collectFormatDirectives,
+	parseFormatDirectiveLine,
+} from '../src/processing/formatDirectives';
+
+describe('format directives', () => {
+	describe('parseFormatDirectiveLine', () => {
+		it.each([
+			['system', 'system'],
+			['fixed', 'fixed'],
+			['exponential', 'exponential'],
+			['scientific', 'exponential'],
+			['engineering', 'engineering'],
+			['comma-period', 'comma-period'],
+			['period-comma', 'period-comma'],
+			['space-comma', 'space-comma'],
+			['indian', 'indian'],
+		])('accepts @format %s and normalizes it to %s', (input, expected) => {
+			const result = parseFormatDirectiveLine(`@format ${input}`, 4);
+
+			expect(result).toEqual({
+				status: 'valid',
+				lineIndex: 4,
+				source: `@format ${input}`,
+				directive: { kind: 'format', value: expected },
+			});
+		});
+
+		it('is case-insensitive and permits surrounding whitespace', () => {
+			const result = parseFormatDirectiveLine('  \t@FoRmAt CoMmA-PeRiOd  ', 0);
+
+			expect(result).toMatchObject({
+				status: 'valid',
+				directive: { kind: 'format', value: 'comma-period' },
+			});
+		});
+
+		it.each([
+			['@decimalPlaces 0', 0],
+			['@decimalPlace 2', 2],
+			['@DECIMALPLACES 20', 20],
+		])('accepts the bounded decimal directive %s', (source, expected) => {
+			const result = parseFormatDirectiveLine(source, 1);
+
+			expect(result).toMatchObject({
+				status: 'valid',
+				directive: { kind: 'decimalPlaces', value: expected },
+			});
+		});
+
+		it.each([
+			['@format', 'format', 'missing-value'],
+			['@format hexadecimal', 'format', 'unknown-format'],
+			['@decimalPlaces', 'decimalPlaces', 'missing-value'],
+			['@decimalPlaces -1', 'decimalPlaces', 'not-an-integer'],
+			['@decimalPlaces 1.5', 'decimalPlaces', 'not-an-integer'],
+			['@decimalPlaces two', 'decimalPlaces', 'not-an-integer'],
+			['@decimalPlaces 21', 'decimalPlaces', 'out-of-range'],
+		])('returns a structured error for %s', (source, kind, reason) => {
+			const result = parseFormatDirectiveLine(source, 7);
+
+			expect(result).toMatchObject({
+				status: 'invalid',
+				error: {
+					kind,
+					lineIndex: 7,
+					source,
+					reason,
+				},
+			});
+		});
+
+		it.each([
+			'value = @format fixed',
+			'@formatter fixed',
+			'prefix @decimalPlaces 2',
+		])('does not claim non-directive source: %s', (source) => {
+			expect(parseFormatDirectiveLine(source, 0)).toEqual({ status: 'not-directive' });
+		});
+	});
+
+	describe('collectFormatDirectives', () => {
+		it('keeps source row indexes stable while removing directive rows', () => {
+			const source = [
+				'value = 1',
+				'@format fixed',
+				'value = 2',
+				'@decimalPlaces 2',
+				'value = 3',
+			].join('\n');
+
+			const result = collectFormatDirectives(source);
+
+			expect(result.sourceWithoutDirectives).toBe('value = 1\n\nvalue = 2\n\nvalue = 3');
+			expect(result.directiveLineIndexes).toEqual([1, 3]);
+			expect(result.validDirectiveLineIndexes).toEqual([1, 3]);
+			expect(result.invalidDirectives).toEqual([]);
+			expect(result.format).toBe('fixed');
+			expect(result.decimalPlaces).toBe(2);
+		});
+
+		it('uses the last valid directive of each kind', () => {
+			const result = collectFormatDirectives([
+				'@format system',
+				'@decimalPlaces 2',
+				'@format scientific',
+				'@decimalPlace 4',
+			].join('\n'));
+
+			expect(result.format).toBe('exponential');
+			expect(result.decimalPlaces).toBe(4);
+		});
+
+		it('retains the last valid value while collecting later invalid directives', () => {
+			const result = collectFormatDirectives([
+				'@format fixed',
+				'@format unknown',
+				'@decimalPlaces 3',
+				'@decimalPlaces 99',
+			].join('\n'));
+
+			expect(result.format).toBe('fixed');
+			expect(result.decimalPlaces).toBe(3);
+			expect(result.directiveLineIndexes).toEqual([0, 1, 2, 3]);
+			expect(result.validDirectiveLineIndexes).toEqual([0, 2]);
+			expect(result.invalidDirectives.map(({ lineIndex, reason }) => ({ lineIndex, reason }))).toEqual([
+				{ lineIndex: 1, reason: 'unknown-format' },
+				{ lineIndex: 3, reason: 'out-of-range' },
+			]);
+			expect(result.sourceWithoutDirectives).toBe('\n\n\n');
+		});
+
+		it('leaves source without directives unchanged', () => {
+			const source = 'a = 1\nb = a + 1';
+
+			expect(collectFormatDirectives(source)).toEqual({
+				format: undefined,
+				decimalPlaces: undefined,
+				directiveLineIndexes: [],
+				validDirectiveLineIndexes: [],
+				invalidDirectives: [],
+				sourceWithoutDirectives: source,
+			});
+		});
+
+		it('preserves CRLF line endings and row count', () => {
+			const source = 'a = 1\r\n@format fixed\r\nb = 2\r\n';
+			const result = collectFormatDirectives(source);
+
+			expect(result.sourceWithoutDirectives).toBe('a = 1\r\n\r\nb = 2\r\n');
+			expect(result.sourceWithoutDirectives.split('\n')).toHaveLength(source.split('\n').length);
+		});
+	});
+});

--- a/tests/inline.test.ts
+++ b/tests/inline.test.ts
@@ -19,13 +19,18 @@ import { defaultCurrencyMap } from '../src/rendering/displayUtils';
 import {
 	InlineNumeralsMode,
 	InlineTriggerSettings,
+	NumeralsNumberFormat,
 	NumeralsRenderStyle,
 	NumeralsScope,
 	StringReplaceMap,
-	mathjsFormat,
 } from '../src/numerals.types';
 import { parseInlineExpression } from '../src/inline/inlineParser';
 import { evaluateInlineExpression } from '../src/inline/inlineEvaluator';
+import {
+	createNumberFormatProfile,
+	createResultFormatter,
+	type ResultFormatter,
+} from '../src/formatting';
 
 // ---------------------------------------------------------------------------
 // Currency setup (mirrors numeralsUtilities.test.ts)
@@ -64,6 +69,25 @@ const DEFAULT_TRIGGERS: InlineTriggerSettings = {
 
 function parse(text: string, triggers: Partial<InlineTriggerSettings> = {}) {
 	return parseInlineExpression(text, { ...DEFAULT_TRIGGERS, ...triggers });
+}
+
+function testFormatter(
+	format: NumeralsNumberFormat = NumeralsNumberFormat.System,
+	processors: StringReplaceMap[] = preProcessors,
+): ResultFormatter {
+	return createResultFormatter({
+		profile: createNumberFormatProfile(format, 'en-US'),
+		preProcessors: processors,
+	});
+}
+
+const defaultFormatter = testFormatter();
+
+function formattedText(
+	result: ReturnType<typeof evaluateInlineExpression>,
+	formatter: ResultFormatter = defaultFormatter,
+): string {
+	return formatter.format(result.raw).text;
 }
 
 // ---------------------------------------------------------------------------
@@ -275,7 +299,6 @@ describe('parseInlineExpression', () => {
 // ---------------------------------------------------------------------------
 describe('evaluateInlineExpression', () => {
 	const emptyScope = new NumeralsScope();
-	const defaultFormat: mathjsFormat = undefined;
 	const noPreProcessors: StringReplaceMap[] = [];
 	const crossNoteSettings = {
 		enableCrossNoteReferences: true,
@@ -285,29 +308,29 @@ describe('evaluateInlineExpression', () => {
 	// --- Basic arithmetic ---------------------------------------------------
 	describe('basic arithmetic', () => {
 		it('should evaluate "3 + 2" to "5"', () => {
-			const result = evaluateInlineExpression('3 + 2', emptyScope, defaultFormat, noPreProcessors);
-			expect(result.formatted).toBe('5');
+			const result = evaluateInlineExpression('3 + 2', emptyScope, noPreProcessors);
+			expect(result.raw).toBe(5);
+			expect(formattedText(result)).toBe('5');
 		});
 
 		it('should evaluate "10 / 3" with fixed format containing "3.333"', () => {
-			const fixedFormat: mathjsFormat = { notation: 'fixed', precision: 4 };
-			const result = evaluateInlineExpression('10 / 3', emptyScope, fixedFormat, noPreProcessors);
-			expect(result.formatted).toContain('3.333');
+			const result = evaluateInlineExpression('10 / 3', emptyScope, noPreProcessors);
+			expect(formattedText(result, testFormatter(NumeralsNumberFormat.Fixed))).toContain('3.333');
 		});
 
 		it('should evaluate multiplication', () => {
-			const result = evaluateInlineExpression('7 * 6', emptyScope, defaultFormat, noPreProcessors);
-			expect(result.formatted).toBe('42');
+			const result = evaluateInlineExpression('7 * 6', emptyScope, noPreProcessors);
+			expect(result.raw).toBe(42);
 		});
 
 		it('should evaluate subtraction', () => {
-			const result = evaluateInlineExpression('100 - 37', emptyScope, defaultFormat, noPreProcessors);
-			expect(result.formatted).toBe('63');
+			const result = evaluateInlineExpression('100 - 37', emptyScope, noPreProcessors);
+			expect(result.raw).toBe(63);
 		});
 
 		it('should evaluate exponentiation', () => {
-			const result = evaluateInlineExpression('2^10', emptyScope, defaultFormat, noPreProcessors);
-			expect(result.formatted).toBe('1024');
+			const result = evaluateInlineExpression('2^10', emptyScope, noPreProcessors);
+			expect(result.raw).toBe(1024);
 		});
 	});
 
@@ -329,7 +352,6 @@ describe('evaluateInlineExpression', () => {
 			const result = evaluateInlineExpression(
 				'[[materials]].price * 2',
 				emptyScope,
-				defaultFormat,
 				noPreProcessors,
 				undefined,
 				app as any,
@@ -337,7 +359,8 @@ describe('evaluateInlineExpression', () => {
 				crossNoteSettings,
 			);
 
-			expect(result.formatted).toBe('20');
+			expect(result.raw).toBe(20);
+			expect(formattedText(result)).toBe('20');
 			expect(result.referencedPaths).toEqual(['materials.md']);
 		});
 	});
@@ -345,33 +368,33 @@ describe('evaluateInlineExpression', () => {
 	// --- Units --------------------------------------------------------------
 	describe('units', () => {
 		it('should convert "3 ft to inches" and contain "36"', () => {
-			const result = evaluateInlineExpression('3 ft to inches', emptyScope, defaultFormat, noPreProcessors);
-			expect(result.formatted).toContain('36');
+			const result = evaluateInlineExpression('3 ft to inches', emptyScope, noPreProcessors);
+			expect(formattedText(result)).toContain('36');
 		});
 
 		it('should convert "100 km/hr in mi/hr" to approximately 62.137', () => {
-			const result = evaluateInlineExpression('100 km/hr in mi/hr', emptyScope, defaultFormat, noPreProcessors);
-			expect(result.formatted).toMatch(/62\.137/);
+			const result = evaluateInlineExpression('100 km/hr in mi/hr', emptyScope, noPreProcessors);
+			expect(formattedText(result)).toMatch(/62\.137/);
 		});
 
 		it('should convert "1 kg to lb"', () => {
-			const result = evaluateInlineExpression('1 kg to lb', emptyScope, defaultFormat, noPreProcessors);
-			expect(result.formatted).toContain('2.20');
+			const result = evaluateInlineExpression('1 kg to lb', emptyScope, noPreProcessors);
+			expect(formattedText(result)).toContain('2.20');
 		});
 	});
 
 	// --- Currency ------------------------------------------------------------
 	describe('currency', () => {
 		it('should evaluate "$100 * 2" and produce result with "200" and "USD"', () => {
-			const result = evaluateInlineExpression('$100 * 2', emptyScope, defaultFormat, preProcessors);
-			expect(result.formatted).toContain('200');
-			expect(result.formatted).toContain('USD');
+			const result = evaluateInlineExpression('$100 * 2', emptyScope, preProcessors);
+			expect(formattedText(result)).toContain('200');
+			expect(formattedText(result)).toContain('USD');
 		});
 
 		it('should evaluate "€50 + €25" with EUR currency', () => {
-			const result = evaluateInlineExpression('€50 + €25', emptyScope, defaultFormat, preProcessors);
-			expect(result.formatted).toContain('75');
-			expect(result.formatted).toContain('EUR');
+			const result = evaluateInlineExpression('€50 + €25', emptyScope, preProcessors);
+			expect(formattedText(result)).toContain('75');
+			expect(formattedText(result)).toContain('EUR');
 		});
 	});
 
@@ -380,8 +403,8 @@ describe('evaluateInlineExpression', () => {
 		it('should access variable from scope: x = 5, evaluate "x * 2" to "10"', () => {
 			const scope = new NumeralsScope();
 			scope.set('x', 5);
-			const result = evaluateInlineExpression('x * 2', scope, defaultFormat, noPreProcessors);
-			expect(result.formatted).toBe('10');
+			const result = evaluateInlineExpression('x * 2', scope, noPreProcessors);
+			expect(result.raw).toBe(10);
 		});
 
 		it('should access currency variable from scope', () => {
@@ -390,18 +413,17 @@ describe('evaluateInlineExpression', () => {
 			const result = evaluateInlineExpression(
 				'$36.03 + $2 * 3 + $pizza',
 				scope,
-				defaultFormat,
 				preProcessors
 			);
-			expect(result.formatted).toContain('52.03');
+			expect(formattedText(result)).toContain('52.03');
 		});
 
 		it('should access multiple variables from scope', () => {
 			const scope = new NumeralsScope();
 			scope.set('a', 10);
 			scope.set('b', 20);
-			const result = evaluateInlineExpression('a + b', scope, defaultFormat, noPreProcessors);
-			expect(result.formatted).toBe('30');
+			const result = evaluateInlineExpression('a + b', scope, noPreProcessors);
+			expect(result.raw).toBe(30);
 		});
 
 		it('should use scope values that were set by prior evaluations', () => {
@@ -411,11 +433,10 @@ describe('evaluateInlineExpression', () => {
 			const result = evaluateInlineExpression(
 				'totalCost * taxRate',
 				scope,
-				defaultFormat,
 				preProcessors
 			);
-			expect(result.formatted).toContain('20');
-			expect(result.formatted).toContain('USD');
+			expect(formattedText(result)).toContain('20');
+			expect(formattedText(result)).toContain('USD');
 		});
 	});
 
@@ -423,73 +444,72 @@ describe('evaluateInlineExpression', () => {
 	describe('error cases', () => {
 		it('should throw on invalid expression "definitely not math @@@@"', () => {
 			expect(() => {
-				evaluateInlineExpression('definitely not math @@@@', emptyScope, defaultFormat, noPreProcessors);
+				evaluateInlineExpression('definitely not math @@@@', emptyScope, noPreProcessors);
 			}).toThrow();
 		});
 
-		it('should return "Infinity" for "1/0"', () => {
-			const result = evaluateInlineExpression('1/0', emptyScope, defaultFormat, noPreProcessors);
-			expect(result.formatted).toBe('Infinity');
+		it('should return and format Infinity for "1/0"', () => {
+			const result = evaluateInlineExpression('1/0', emptyScope, noPreProcessors);
+			expect(result.raw).toBe(Infinity);
+			expect(formattedText(result)).toBe('∞');
 		});
 
 		it('should throw when referencing an undefined variable', () => {
 			expect(() => {
-				evaluateInlineExpression('undefinedVar * 2', emptyScope, defaultFormat, noPreProcessors);
+				evaluateInlineExpression('undefinedVar * 2', emptyScope, noPreProcessors);
 			}).toThrow();
 		});
 
 		it('should throw when expression evaluates to undefined (e.g. comment)', () => {
 			expect(() => {
-				evaluateInlineExpression('# just a comment', emptyScope, defaultFormat, noPreProcessors);
+				evaluateInlineExpression('# just a comment', emptyScope, noPreProcessors);
 			}).toThrow('Expression produced no result');
 		});
 	});
 
 	// --- Preprocessing -------------------------------------------------------
 	describe('preprocessing', () => {
-		it('should handle thousands separators: "$1,000 * 2" → contains "2000" and "USD"', () => {
-			const result = evaluateInlineExpression('$1,000 * 2', emptyScope, defaultFormat, preProcessors);
-			expect(result.formatted).toContain('2000');
-			expect(result.formatted).toContain('USD');
+		it('should handle thousands separators and preserve localized grouping', () => {
+			const result = evaluateInlineExpression('$1,000 * 2', emptyScope, preProcessors);
+			expect(formattedText(result)).toContain('2,000');
+			expect(formattedText(result)).toContain('USD');
 		});
 
 		it('should return the processed expression used for mathjs evaluation', () => {
-			const result = evaluateInlineExpression('$1,000 * 2', emptyScope, defaultFormat, preProcessors);
+			const result = evaluateInlineExpression('$1,000 * 2', emptyScope, preProcessors);
 			expect(result.processedExpression).toBe('1000 USD * 2');
 		});
 
 		it('should handle multiple thousands separators: "$1,000,000"', () => {
-			const result = evaluateInlineExpression('$1,000,000 + $0', emptyScope, defaultFormat, preProcessors);
+			const result = evaluateInlineExpression('$1,000,000 + $0', emptyScope, preProcessors);
 			// mathjs uses exponential notation for large numbers by default
-			expect(result.formatted).toMatch(/1e\+6|1000000/);
+			expect(formattedText(result)).toMatch(/1e\+6|1,000,000|1000000/);
 		});
 
 		it('should apply custom preprocessors', () => {
 			const customPreProcessors: StringReplaceMap[] = [
 				{ regex: /apples/g, replaceStr: '3' },
 			];
-			const result = evaluateInlineExpression('apples + 2', emptyScope, defaultFormat, customPreProcessors);
-			expect(result.formatted).toBe('5');
+			const result = evaluateInlineExpression('apples + 2', emptyScope, customPreProcessors);
+			expect(result.raw).toBe(5);
 		});
 	});
 
 	// --- Number format -------------------------------------------------------
 	describe('number formatting', () => {
 		it('should respect exponential notation format', () => {
-			const expFormat: mathjsFormat = { notation: 'exponential', precision: 3 };
-			const result = evaluateInlineExpression('1234567', emptyScope, expFormat, noPreProcessors);
-			expect(result.formatted).toMatch(/1\.23.*e\+6/);
+			const result = evaluateInlineExpression('1234567', emptyScope, noPreProcessors);
+			expect(formattedText(result, testFormatter(NumeralsNumberFormat.Exponential))).toMatch(/1\.234567e\+6/);
 		});
 
 		it('should respect engineering notation format', () => {
-			const engFormat: mathjsFormat = { notation: 'engineering', precision: 3 };
-			const result = evaluateInlineExpression('1234567', emptyScope, engFormat, noPreProcessors);
-			expect(result.formatted).toMatch(/1\.23.*e\+6/);
+			const result = evaluateInlineExpression('1234567', emptyScope, noPreProcessors);
+			expect(formattedText(result, testFormatter(NumeralsNumberFormat.Engineering))).toMatch(/1\.234567e\+6/);
 		});
 
 		it('should use default format when format is undefined', () => {
-			const result = evaluateInlineExpression('2 + 2', emptyScope, undefined, noPreProcessors);
-			expect(result.formatted).toBe('4');
+			const result = evaluateInlineExpression('2 + 2', emptyScope, noPreProcessors);
+			expect(formattedText(result)).toBe('4');
 		});
 	});
 });
@@ -499,34 +519,32 @@ describe('evaluateInlineExpression', () => {
 // ---------------------------------------------------------------------------
 describe('evaluateInlineExpression — @prev directive', () => {
 	const emptyScope = new NumeralsScope();
-	const defaultFormat: mathjsFormat = undefined;
 	const noPreProcessors: StringReplaceMap[] = [];
 
 	describe('basic @prev usage', () => {
 		it('should evaluate @prev when prevResult is provided', () => {
-			const result = evaluateInlineExpression('@prev * 2', emptyScope, defaultFormat, noPreProcessors, 5);
-			expect(result.formatted).toBe('10');
+			const result = evaluateInlineExpression('@prev * 2', emptyScope, noPreProcessors, 5);
 			expect(result.raw).toBe(10);
 		});
 
 		it('should throw when @prev is used with no previous result', () => {
 			expect(() => {
-				evaluateInlineExpression('@prev + 1', emptyScope, defaultFormat, noPreProcessors, undefined);
+				evaluateInlineExpression('@prev + 1', emptyScope, noPreProcessors, undefined);
 			}).toThrow(/previous/i);
 		});
 
 		it('should throw when @prev is used with no prevResult argument', () => {
 			expect(() => {
-				evaluateInlineExpression('@prev + 1', emptyScope, defaultFormat, noPreProcessors);
+				evaluateInlineExpression('@prev + 1', emptyScope, noPreProcessors);
 			}).toThrow(/previous/i);
 		});
 
 		it('should be case-insensitive (@Prev, @PREV)', () => {
-			const r1 = evaluateInlineExpression('@Prev + 1', emptyScope, defaultFormat, noPreProcessors, 10);
-			expect(r1.formatted).toBe('11');
+			const r1 = evaluateInlineExpression('@Prev + 1', emptyScope, noPreProcessors, 10);
+			expect(r1.raw).toBe(11);
 
-			const r2 = evaluateInlineExpression('@PREV + 1', emptyScope, defaultFormat, noPreProcessors, 10);
-			expect(r2.formatted).toBe('11');
+			const r2 = evaluateInlineExpression('@PREV + 1', emptyScope, noPreProcessors, 10);
+			expect(r2.raw).toBe(11);
 		});
 	});
 
@@ -534,34 +552,34 @@ describe('evaluateInlineExpression — @prev directive', () => {
 		it('should work when prevResult has units', () => {
 			const prevValue = math.evaluate('10 kg');
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-			const result = evaluateInlineExpression('@prev * 2', emptyScope, defaultFormat, noPreProcessors, prevValue);
-			expect(result.formatted).toContain('20');
-			expect(result.formatted).toContain('kg');
+			const result = evaluateInlineExpression('@prev * 2', emptyScope, noPreProcessors, prevValue);
+			expect(formattedText(result)).toContain('20');
+			expect(formattedText(result)).toContain('kg');
 		});
 
 		it('should work when prevResult is a currency', () => {
 			const prevValue = math.evaluate('100 USD');
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-			const result = evaluateInlineExpression('@prev * 1.08', emptyScope, defaultFormat, preProcessors, prevValue);
-			expect(result.formatted).toContain('108');
-			expect(result.formatted).toContain('USD');
+			const result = evaluateInlineExpression('@prev * 1.08', emptyScope, preProcessors, prevValue);
+			expect(formattedText(result)).toContain('108');
+			expect(formattedText(result)).toContain('USD');
 		});
 	});
 
 	describe('@prev chaining', () => {
 		it('should chain: evaluate first, then use result as prevResult for second', () => {
-			const r1 = evaluateInlineExpression('50 + 50', emptyScope, defaultFormat, noPreProcessors);
-			expect(r1.formatted).toBe('100');
+			const r1 = evaluateInlineExpression('50 + 50', emptyScope, noPreProcessors);
+			expect(r1.raw).toBe(100);
 
-			const r2 = evaluateInlineExpression('@prev / 4', emptyScope, defaultFormat, noPreProcessors, r1.raw);
-			expect(r2.formatted).toBe('25');
+			const r2 = evaluateInlineExpression('@prev / 4', emptyScope, noPreProcessors, r1.raw);
+			expect(r2.raw).toBe(25);
 		});
 
 		it('should chain three expressions', () => {
-			const r1 = evaluateInlineExpression('10', emptyScope, defaultFormat, noPreProcessors);
-			const r2 = evaluateInlineExpression('@prev * 3', emptyScope, defaultFormat, noPreProcessors, r1.raw);
-			const r3 = evaluateInlineExpression('@prev + 5', emptyScope, defaultFormat, noPreProcessors, r2.raw);
-			expect(r3.formatted).toBe('35');
+			const r1 = evaluateInlineExpression('10', emptyScope, noPreProcessors);
+			const r2 = evaluateInlineExpression('@prev * 3', emptyScope, noPreProcessors, r1.raw);
+			const r3 = evaluateInlineExpression('@prev + 5', emptyScope, noPreProcessors, r2.raw);
+			expect(r3.raw).toBe(35);
 		});
 	});
 
@@ -569,27 +587,26 @@ describe('evaluateInlineExpression — @prev directive', () => {
 		it('should work alongside scope variables', () => {
 			const scope = new NumeralsScope();
 			scope.set('tax', 0.08);
-			const result = evaluateInlineExpression('@prev * tax', scope, defaultFormat, noPreProcessors, 100);
-			expect(result.formatted).toBe('8');
+			const result = evaluateInlineExpression('@prev * tax', scope, noPreProcessors, 100);
+			expect(result.raw).toBe(8);
 		});
 
 		it('should work with preprocessors (currency)', () => {
-			const result = evaluateInlineExpression('$50 + @prev', emptyScope, defaultFormat, preProcessors, math.evaluate('50 USD'));
-			expect(result.formatted).toContain('100');
-			expect(result.formatted).toContain('USD');
+			const result = evaluateInlineExpression('$50 + @prev', emptyScope, preProcessors, math.evaluate('50 USD'));
+			expect(formattedText(result)).toContain('100');
+			expect(formattedText(result)).toContain('USD');
 		});
 	});
 
 	describe('backward compatibility', () => {
 		it('should work without prevResult argument (existing behavior)', () => {
-			const result = evaluateInlineExpression('3 + 2', emptyScope, defaultFormat, noPreProcessors);
-			expect(result.formatted).toBe('5');
+			const result = evaluateInlineExpression('3 + 2', emptyScope, noPreProcessors);
 			expect(result.raw).toBe(5);
 		});
 
 		it('expressions without @prev should not be affected by prevResult', () => {
-			const result = evaluateInlineExpression('7 * 6', emptyScope, defaultFormat, noPreProcessors, 999);
-			expect(result.formatted).toBe('42');
+			const result = evaluateInlineExpression('7 * 6', emptyScope, noPreProcessors, 999);
+			expect(result.raw).toBe(42);
 		});
 	});
 });
@@ -599,31 +616,30 @@ describe('evaluateInlineExpression — @prev directive', () => {
 // ---------------------------------------------------------------------------
 describe('evaluateInlineExpression — note-global extraction', () => {
 	const emptyScope = new NumeralsScope();
-	const defaultFormat: mathjsFormat = undefined;
 	const noPreProcessors: StringReplaceMap[] = [];
 
 	describe('$-prefixed assignments are extracted', () => {
 		it('should return $x in globals when expression is "$x = 10"', () => {
-			const result = evaluateInlineExpression('$x = 10', emptyScope, defaultFormat, noPreProcessors);
+			const result = evaluateInlineExpression('$x = 10', emptyScope, noPreProcessors);
 			expect(result.globals.size).toBe(1);
 			expect(result.globals.get('$x')).toBe(10);
 		});
 
 		it('should return $price with units', () => {
-			const result = evaluateInlineExpression('$price = 50 kg', emptyScope, defaultFormat, noPreProcessors);
+			const result = evaluateInlineExpression('$price = 50 kg', emptyScope, noPreProcessors);
 			expect(result.globals.size).toBe(1);
 			expect(result.globals.has('$price')).toBe(true);
 		});
 
 		it('should return $price with currency', () => {
-			const result = evaluateInlineExpression('$price = $100', emptyScope, defaultFormat, preProcessors);
+			const result = evaluateInlineExpression('$price = $100', emptyScope, preProcessors);
 			expect(result.globals.has('$price')).toBe(true);
 		});
 
 		it('should return multiple globals from compound expression', () => {
 			// mathjs supports semicolons for multiple statements, but inline is single-expression.
 			// This test verifies only one global from a single assignment.
-			const result = evaluateInlineExpression('$y = 42', emptyScope, defaultFormat, noPreProcessors);
+			const result = evaluateInlineExpression('$y = 42', emptyScope, noPreProcessors);
 			expect(result.globals.size).toBe(1);
 			expect(result.globals.get('$y')).toBe(42);
 		});
@@ -631,21 +647,21 @@ describe('evaluateInlineExpression — note-global extraction', () => {
 
 	describe('non-$ assignments are NOT extracted', () => {
 		it('should return empty globals for "y = 10"', () => {
-			const result = evaluateInlineExpression('y = 10', emptyScope, defaultFormat, noPreProcessors);
+			const result = evaluateInlineExpression('y = 10', emptyScope, noPreProcessors);
 			expect(result.globals.size).toBe(0);
 		});
 
 		it('should return empty globals for simple arithmetic', () => {
-			const result = evaluateInlineExpression('3 + 2', emptyScope, defaultFormat, noPreProcessors);
+			const result = evaluateInlineExpression('3 + 2', emptyScope, noPreProcessors);
 			expect(result.globals.size).toBe(0);
 		});
 	});
 
 	describe('globals with @prev', () => {
 		it('should extract $total when using @prev', () => {
-			const result = evaluateInlineExpression('$total = @prev * 2', emptyScope, defaultFormat, noPreProcessors, 50);
+			const result = evaluateInlineExpression('$total = @prev * 2', emptyScope, noPreProcessors, 50);
 			expect(result.globals.get('$total')).toBe(100);
-			expect(result.formatted).toBe('100');
+			expect(result.raw).toBe(100);
 		});
 	});
 
@@ -654,15 +670,15 @@ describe('evaluateInlineExpression — note-global extraction', () => {
 			const scope = new NumeralsScope();
 			scope.set('$x', 10);
 			// Expression that reads $x but doesn't reassign it
-			const result = evaluateInlineExpression('$x + 5', scope, defaultFormat, noPreProcessors);
+			const result = evaluateInlineExpression('$x + 5', scope, noPreProcessors);
 			expect(result.globals.size).toBe(0);
-			expect(result.formatted).toBe('15');
+			expect(result.raw).toBe(15);
 		});
 
 		it('should report $x if it was reassigned to a different value', () => {
 			const scope = new NumeralsScope();
 			scope.set('$x', 10);
-			const result = evaluateInlineExpression('$x = 20', scope, defaultFormat, noPreProcessors);
+			const result = evaluateInlineExpression('$x = 20', scope, noPreProcessors);
 			expect(result.globals.size).toBe(1);
 			expect(result.globals.get('$x')).toBe(20);
 		});

--- a/tests/inlineLivePreview.test.ts
+++ b/tests/inlineLivePreview.test.ts
@@ -27,12 +27,21 @@ import {
 	selectionOverlapsRange,
 } from '../src/inline/inlineLivePreview';
 import { InlineNumeralsMode, NumeralsRenderStyle } from '../src/numerals.types';
+import type { FormattedResult } from '../src/formatting';
 import { EditorSelection } from '@codemirror/state';
 import { renderMath } from 'obsidian';
 
 beforeAll(() => {
 	(globalThis as { activeDocument?: Document }).activeDocument = document;
 });
+
+function formatted(
+	text: string,
+	tex: string = text,
+	canonical: string = text,
+): FormattedResult {
+	return { text, tex, canonical };
+}
 
 // ---------------------------------------------------------------------------
 // getFormattingClasses
@@ -125,7 +134,7 @@ describe('InlineNumeralsWidget', () => {
 	describe('toDOM', () => {
 		it('should render result-only mode with value span', () => {
 			const widget = new InlineNumeralsWidget(
-				'36 in', InlineNumeralsMode.ResultOnly, '3ft in inches', ' = ', false
+				formatted('36 in'), InlineNumeralsMode.ResultOnly, '3ft in inches', ' = ', false
 			);
 			const el = widget.toDOM();
 
@@ -140,8 +149,8 @@ describe('InlineNumeralsWidget', () => {
 
 		it('should render result-only TeX mode with MathJax inside the value span', async () => {
 			const widget = new InlineNumeralsWidget(
-				'36', InlineNumeralsMode.ResultOnly, '3ft in inches', ' = ', false,
-				[], NumeralsRenderStyle.TeX, 36, '3 ft in inches', []
+				formatted('36', '36'), InlineNumeralsMode.ResultOnly, '3ft in inches', ' = ', false,
+				[], NumeralsRenderStyle.TeX, '3 ft in inches'
 			);
 			const el = widget.toDOM();
 			await Promise.resolve();
@@ -152,7 +161,7 @@ describe('InlineNumeralsWidget', () => {
 
 		it('should render equation mode with input, separator, and value spans', () => {
 			const widget = new InlineNumeralsWidget(
-				'5 ft', InlineNumeralsMode.Equation, '3ft + 2ft', ' = ', false
+				formatted('5 ft'), InlineNumeralsMode.Equation, '3ft + 2ft', ' = ', false
 			);
 			const el = widget.toDOM();
 
@@ -169,8 +178,8 @@ describe('InlineNumeralsWidget', () => {
 				throw new Error('MathJax unavailable');
 			});
 			const widget = new InlineNumeralsWidget(
-				'36', InlineNumeralsMode.ResultOnly, '3ft in inches', ' = ', false,
-				[], NumeralsRenderStyle.TeX, 36, '3 ft in inches', []
+				formatted('36', '36'), InlineNumeralsMode.ResultOnly, '3ft in inches', ' = ', false,
+				[], NumeralsRenderStyle.TeX, '3 ft in inches'
 			);
 			const el = widget.toDOM();
 			await Promise.resolve();
@@ -180,8 +189,8 @@ describe('InlineNumeralsWidget', () => {
 
 		it('should render equation TeX mode with MathJax input and value spans', async () => {
 			const widget = new InlineNumeralsWidget(
-				'12', InlineNumeralsMode.Equation, 'sqrt(144)', ' = ', false,
-				[], NumeralsRenderStyle.TeX, 12, 'sqrt(144)', []
+				formatted('12', '12'), InlineNumeralsMode.Equation, 'sqrt(144)', ' = ', false,
+				[], NumeralsRenderStyle.TeX, 'sqrt(144)'
 			);
 			const el = widget.toDOM();
 			await Promise.resolve();
@@ -195,7 +204,7 @@ describe('InlineNumeralsWidget', () => {
 			const editorDocument = document.implementation.createHTMLDocument('editor');
 			const editorDom = editorDocument.createElement('div');
 			const widget = new InlineNumeralsWidget(
-				'5 ft', InlineNumeralsMode.Equation, '3ft + 2ft', ' = ', false
+				formatted('5 ft'), InlineNumeralsMode.Equation, '3ft + 2ft', ' = ', false
 			);
 
 			const el = widget.toDOM({ dom: editorDom } as unknown as Parameters<InlineNumeralsWidget['toDOM']>[0]);
@@ -208,7 +217,7 @@ describe('InlineNumeralsWidget', () => {
 
 		it('should render error mode with raw expression', () => {
 			const widget = new InlineNumeralsWidget(
-				'', InlineNumeralsMode.ResultOnly, 'bad expression', ' = ', true
+				formatted(''), InlineNumeralsMode.ResultOnly, 'bad expression', ' = ', true
 			);
 			const el = widget.toDOM();
 
@@ -219,7 +228,7 @@ describe('InlineNumeralsWidget', () => {
 
 		it('should apply formatting classes (bold)', () => {
 			const widget = new InlineNumeralsWidget(
-				'5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong']
+				formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong']
 			);
 			const el = widget.toDOM();
 
@@ -229,7 +238,7 @@ describe('InlineNumeralsWidget', () => {
 
 		it('should apply multiple formatting classes', () => {
 			const widget = new InlineNumeralsWidget(
-				'5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false,
+				formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false,
 				['cm-strong', 'cm-em', 'cm-highlight']
 			);
 			const el = widget.toDOM();
@@ -241,7 +250,7 @@ describe('InlineNumeralsWidget', () => {
 
 		it('should apply formatting classes even on error widgets', () => {
 			const widget = new InlineNumeralsWidget(
-				'', InlineNumeralsMode.ResultOnly, 'bad', ' = ', true, ['cm-em']
+				formatted(''), InlineNumeralsMode.ResultOnly, 'bad', ' = ', true, ['cm-em']
 			);
 			const el = widget.toDOM();
 
@@ -252,76 +261,75 @@ describe('InlineNumeralsWidget', () => {
 
 	describe('eq', () => {
 		it('should return true for identical widgets', () => {
-			const a = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false);
-			const b = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false);
+			const a = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false);
+			const b = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false);
 			expect(a.eq(b)).toBe(true);
 		});
 
 		it('should return false when result differs', () => {
-			const a = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false);
-			const b = new InlineNumeralsWidget('6', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false);
+			const a = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false);
+			const b = new InlineNumeralsWidget(formatted('6'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false);
 			expect(a.eq(b)).toBe(false);
 		});
 
 		it('should return false when mode differs', () => {
-			const a = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false);
-			const b = new InlineNumeralsWidget('5', InlineNumeralsMode.Equation, '3+2', ' = ', false);
+			const a = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false);
+			const b = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.Equation, '3+2', ' = ', false);
 			expect(a.eq(b)).toBe(false);
 		});
 
 		it('should return false when expression differs', () => {
-			const a = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false);
-			const b = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '2+3', ' = ', false);
+			const a = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false);
+			const b = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.ResultOnly, '2+3', ' = ', false);
 			expect(a.eq(b)).toBe(false);
 		});
 
 		it('should return false when error state differs', () => {
-			const a = new InlineNumeralsWidget('', InlineNumeralsMode.ResultOnly, 'x', ' = ', false);
-			const b = new InlineNumeralsWidget('', InlineNumeralsMode.ResultOnly, 'x', ' = ', true);
+			const a = new InlineNumeralsWidget(formatted(''), InlineNumeralsMode.ResultOnly, 'x', ' = ', false);
+			const b = new InlineNumeralsWidget(formatted(''), InlineNumeralsMode.ResultOnly, 'x', ' = ', true);
 			expect(a.eq(b)).toBe(false);
 		});
 
 		it('should return false when separator differs', () => {
-			const a = new InlineNumeralsWidget('5', InlineNumeralsMode.Equation, '3+2', ' = ', false);
-			const b = new InlineNumeralsWidget('5', InlineNumeralsMode.Equation, '3+2', ' \u2192 ', false);
+			const a = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.Equation, '3+2', ' = ', false);
+			const b = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.Equation, '3+2', ' \u2192 ', false);
 			expect(a.eq(b)).toBe(false);
 		});
 
 		it('should return false when formatting classes differ', () => {
-			const a = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong']);
-			const b = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, []);
+			const a = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong']);
+			const b = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, []);
 			expect(a.eq(b)).toBe(false);
 		});
 
 		it('should return true when formatting classes match', () => {
-			const a = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong', 'cm-em']);
-			const b = new InlineNumeralsWidget('5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong', 'cm-em']);
+			const a = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong', 'cm-em']);
+			const b = new InlineNumeralsWidget(formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false, ['cm-strong', 'cm-em']);
 			expect(a.eq(b)).toBe(true);
 		});
 
-		it('should return true when only the rawResult object identity differs', () => {
-			// mathjs results (e.g. Unit objects) are fresh instances on every
-			// evaluation pass; comparing them by reference would force a DOM
-			// rebuild (and MathJax re-render) on every cursor move.
+		it('should return true for distinct but equivalent formatted result objects', () => {
 			const a = new InlineNumeralsWidget(
-				'5 m', InlineNumeralsMode.ResultOnly, '2m+3m', ' = ', false,
-				[], NumeralsRenderStyle.TeX, { value: 5 }, '2m+3m', []
+				formatted('5 m', '5~\\mathrm{m}', '5 m'),
+				InlineNumeralsMode.ResultOnly, '2m+3m', ' = ', false,
+				[], NumeralsRenderStyle.TeX, '2m+3m'
 			);
 			const b = new InlineNumeralsWidget(
-				'5 m', InlineNumeralsMode.ResultOnly, '2m+3m', ' = ', false,
-				[], NumeralsRenderStyle.TeX, { value: 5 }, '2m+3m', []
+				formatted('5 m', '5~\\mathrm{m}', '5 m'),
+				InlineNumeralsMode.ResultOnly, '2m+3m', ' = ', false,
+				[], NumeralsRenderStyle.TeX, '2m+3m'
 			);
 			expect(a.eq(b)).toBe(true);
 		});
 
 		it('should return false when render style differs', () => {
 			const plain = new InlineNumeralsWidget(
-				'5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false,
-				[], NumeralsRenderStyle.Plain, 5, '3+2', []
+				formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false,
+				[], NumeralsRenderStyle.Plain, '3+2'
 			);
 			const tex = new InlineNumeralsWidget(
-				'5', InlineNumeralsMode.ResultOnly, '3+2', ' = ', false,
-				[], NumeralsRenderStyle.TeX, 5, '3+2', []
+				formatted('5'), InlineNumeralsMode.ResultOnly, '3+2', ' = ', false,
+				[], NumeralsRenderStyle.TeX, '3+2'
 			);
 
 			expect(plain.eq(tex)).toBe(false);

--- a/tests/inlineLivePreview.test.ts
+++ b/tests/inlineLivePreview.test.ts
@@ -35,6 +35,10 @@ beforeAll(() => {
 	(globalThis as { activeDocument?: Document }).activeDocument = document;
 });
 
+beforeEach(() => {
+	jest.clearAllMocks();
+});
+
 function formatted(
 	text: string,
 	tex: string = text,
@@ -157,6 +161,7 @@ describe('InlineNumeralsWidget', () => {
 
 			expect(el.classList.contains('numerals-inline-result')).toBe(true);
 			expect(el.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:36');
+			expect(renderMath).toHaveBeenCalledWith('36', false);
 		});
 
 		it('should render equation mode with input, separator, and value spans', () => {
@@ -198,6 +203,8 @@ describe('InlineNumeralsWidget', () => {
 			expect(el.querySelector('.numerals-inline-input .numerals-tex')?.textContent).toBe('TeX:\\sqrt{144}');
 			expect(el.querySelector('.numerals-inline-separator')?.textContent).toBe(' = ');
 			expect(el.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:12');
+			expect(renderMath).toHaveBeenNthCalledWith(1, '\\sqrt{144}', false);
+			expect(renderMath).toHaveBeenNthCalledWith(2, '12', false);
 		});
 
 		it('should create widget nodes from the editor ownerDocument', () => {

--- a/tests/inlinePostProcessor.test.ts
+++ b/tests/inlinePostProcessor.test.ts
@@ -25,6 +25,7 @@ jest.mock(
 );
 
 import * as math from 'mathjs';
+import { renderMath } from 'obsidian';
 import { defaultCurrencyMap } from '../src/rendering/displayUtils';
 import {
 	NumeralsSettings,
@@ -72,6 +73,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+	jest.clearAllMocks();
 	mockRegisteredEvents.length = 0;
 });
 
@@ -212,6 +214,7 @@ describe('inline numerals integration', () => {
 			const texValue = code.querySelector('.numerals-inline-value .numerals-tex');
 			expect(texValue).not.toBeNull();
 			expect(texValue?.textContent).toBe('TeX:36~\\mathrm{inches}');
+			expect(renderMath).toHaveBeenCalledWith('36~\\mathrm{inches}', false);
 		});
 
 		it('renders "#=$:" equation input and result with MathJax in Reading mode', async () => {
@@ -222,6 +225,8 @@ describe('inline numerals integration', () => {
 			expect(code.querySelector('.numerals-inline-input .numerals-tex')?.textContent).toBe('TeX:\\sqrt{144}');
 			expect(code.querySelector('.numerals-inline-separator')?.textContent).toBe(' = ');
 			expect(code.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:12');
+			expect(renderMath).toHaveBeenNthCalledWith(1, '\\sqrt{144}', false);
+			expect(renderMath).toHaveBeenNthCalledWith(2, '12', false);
 		});
 
 		it('renders plain "#:" results as text, without any MathJax span', () => {

--- a/tests/inlinePostProcessor.test.ts
+++ b/tests/inlinePostProcessor.test.ts
@@ -30,11 +30,17 @@ import {
 	NumeralsSettings,
 	NumeralsScope,
 	DEFAULT_SETTINGS,
+	NumeralsNumberFormat,
 	StringReplaceMap,
 } from '../src/numerals.types';
 import { parseInlineExpression } from '../src/inline/inlineParser';
 import { evaluateInlineExpression } from '../src/inline/inlineEvaluator';
 import { createInlineNumeralsPostProcessor } from '../src/inline/inlinePostProcessor';
+import {
+	createNumberFormatProfile,
+	createResultFormatter,
+	type ResultFormatter,
+} from '../src/formatting';
 
 const mockRegisteredEvents: unknown[] = [];
 
@@ -92,6 +98,15 @@ for (const moneyType of defaultCurrencyMap) {
 	}
 }
 
+function testFormatter(
+	processors: StringReplaceMap[] = preProcessors,
+): ResultFormatter {
+	return createResultFormatter({
+		profile: createNumberFormatProfile(NumeralsNumberFormat.System, 'en-US'),
+		preProcessors: processors,
+	});
+}
+
 // ---------------------------------------------------------------------------
 // Helper: simulate the full inline pipeline (parse → evaluate → format)
 // ---------------------------------------------------------------------------
@@ -108,14 +123,17 @@ function simulateInlinePipeline(
 	});
 	if (!parsed) return null;
 
-	const { formatted } = evaluateInlineExpression(
+	const result = evaluateInlineExpression(
 		parsed.expression,
 		scope,
-		undefined,
 		preProcessors
 	);
 
-	return { mode: parsed.mode, expression: parsed.expression, result: formatted };
+	return {
+		mode: parsed.mode,
+		expression: parsed.expression,
+		result: testFormatter().format(result.raw).text,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -171,7 +189,7 @@ describe('inline numerals integration', () => {
 			return createInlineNumeralsPostProcessor(
 				app as any,
 				() => DEFAULT_SETTINGS,
-				() => undefined,
+				() => testFormatter(preProcessors),
 				() => preProcessors,
 				new Map(),
 			);
@@ -271,7 +289,7 @@ describe('inline numerals integration', () => {
 			});
 			expect(parsed).not.toBeNull();
 			expect(() => {
-				evaluateInlineExpression(parsed!.expression, new NumeralsScope(), undefined, []);
+				evaluateInlineExpression(parsed!.expression, new NumeralsScope(), []);
 			}).toThrow();
 		});
 	});
@@ -315,7 +333,7 @@ describe('inline post-processor cross-note references', () => {
 		const postProcessor = createInlineNumeralsPostProcessor(
 			app as any,
 			() => DEFAULT_SETTINGS,
-			() => undefined,
+			() => testFormatter([]),
 			() => [],
 			new Map(),
 		);
@@ -340,13 +358,13 @@ describe('inline note-global ($) variable chaining', () => {
 
 	describe('globals extracted from inline evaluation', () => {
 		it('should return $x in globals when assigning $x = 10', () => {
-			const result = evaluateInlineExpression('$x = 10', new NumeralsScope(), undefined, []);
+			const result = evaluateInlineExpression('$x = 10', new NumeralsScope(), []);
 			expect(result.globals.size).toBe(1);
 			expect(result.globals.get('$x')).toBe(10);
 		});
 
 		it('should return no globals for non-$ assignment', () => {
-			const result = evaluateInlineExpression('y = 10', new NumeralsScope(), undefined, []);
+			const result = evaluateInlineExpression('y = 10', new NumeralsScope(), []);
 			expect(result.globals.size).toBe(0);
 		});
 	});
@@ -357,26 +375,26 @@ describe('inline note-global ($) variable chaining', () => {
 			const scope = new NumeralsScope();
 
 			// First expression defines $apples
-			const r1 = evaluateInlineExpression('$apples = 100', scope, undefined, []);
+			const r1 = evaluateInlineExpression('$apples = 100', scope, []);
 			// Post-processor would inject globals into shared scope
 			for (const [k, v] of r1.globals) { scope.set(k, v); }
 
 			// Second expression uses $apples
-			const r2 = evaluateInlineExpression('$apples * 2', scope, undefined, []);
-			expect(r2.formatted).toBe('200');
+			const r2 = evaluateInlineExpression('$apples * 2', scope, []);
+			expect(r2.raw).toBe(200);
 		});
 
 		it('should chain three globals sequentially', () => {
 			const scope = new NumeralsScope();
 
-			const r1 = evaluateInlineExpression('$a = 10', scope, undefined, []);
+			const r1 = evaluateInlineExpression('$a = 10', scope, []);
 			for (const [k, v] of r1.globals) { scope.set(k, v); }
 
-			const r2 = evaluateInlineExpression('$b = $a * 3', scope, undefined, []);
+			const r2 = evaluateInlineExpression('$b = $a * 3', scope, []);
 			for (const [k, v] of r2.globals) { scope.set(k, v); }
 
-			const r3 = evaluateInlineExpression('$a + $b', scope, undefined, []);
-			expect(r3.formatted).toBe('40');
+			const r3 = evaluateInlineExpression('$a + $b', scope, []);
+			expect(r3.raw).toBe(40);
 		});
 	});
 
@@ -385,7 +403,7 @@ describe('inline note-global ($) variable chaining', () => {
 			const scopeCache = new Map<string, NumeralsScope>();
 			const scope = new NumeralsScope();
 
-			const result = evaluateInlineExpression('$price = 42', scope, undefined, []);
+			const result = evaluateInlineExpression('$price = 42', scope, []);
 			
 			// Simulate what the post-processor does after evaluation
 			if (result.globals.size > 0) {
@@ -409,12 +427,12 @@ describe('inline note-global ($) variable chaining', () => {
 		it('should support $total = @prev pattern', () => {
 			const scope = new NumeralsScope();
 
-			const r1 = evaluateInlineExpression('100 * 1.2', scope, undefined, []);
-			const r2 = evaluateInlineExpression('$total = @prev * 1.08', scope, undefined, [], r1.raw);
+			const r1 = evaluateInlineExpression('100 * 1.2', scope, []);
+			const r2 = evaluateInlineExpression('$total = @prev * 1.08', scope, [], r1.raw);
 			
 			expect(r2.globals.has('$total')).toBe(true);
 			// 100 * 1.2 * 1.08 = 129.6
-			expect(r2.formatted).toContain('129.6');
+			expect(testFormatter([]).format(r2.raw).text).toContain('129.6');
 		});
 	});
 });

--- a/tests/numberFormat.test.ts
+++ b/tests/numberFormat.test.ts
@@ -1,0 +1,195 @@
+jest.mock('obsidian', () => ({
+	finishRenderMath: jest.fn().mockResolvedValue(undefined),
+	renderMath: jest.fn(),
+	sanitizeHTMLToDom: jest.fn(),
+}));
+
+import * as math from 'mathjs';
+import { NumeralsNumberFormat } from '../src/numerals.types';
+import {
+	createNumberFormatProfile,
+	formatNumberWithProfile,
+	formatWithNumberFormatProfile,
+	isValidDecimalPlaces,
+	resolveNumberFormatProfile,
+} from '../src/formatting/numberFormat';
+
+describe('number format profiles', () => {
+	it('preserves legacy output when no explicit decimal override is present', () => {
+		const value = 123456.789;
+		const formats = Object.values(NumeralsNumberFormat);
+
+		for (const format of formats) {
+			const profile = createNumberFormatProfile(format, 'en-US');
+			expect(formatWithNumberFormatProfile(value, profile)).toBe(
+				math.format(value, profile.mathjsFormat)
+			);
+		}
+	});
+
+	it('retains both active locale identity and the system locale', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.Format_PeriodThousands_CommaDecimal,
+			'en-GB'
+		);
+
+		expect(profile.locale).toBe('de-DE');
+		expect(profile.systemLocale).toBe('en-GB');
+
+		const systemOverride = resolveNumberFormatProfile(profile, {
+			numberFormat: NumeralsNumberFormat.System,
+		});
+		expect(systemOverride.locale).toBe('en-GB');
+		expect(systemOverride.systemLocale).toBe('en-GB');
+	});
+
+	it.each([
+		[
+			NumeralsNumberFormat.Format_CommaThousands_PeriodDecimal,
+			'1,234.50',
+		],
+		[
+			NumeralsNumberFormat.Format_PeriodThousands_CommaDecimal,
+			'1.234,50',
+		],
+		[
+			NumeralsNumberFormat.Format_SpaceThousands_CommaDecimal,
+			'1\u202f234,50',
+		],
+		[NumeralsNumberFormat.Format_Indian, '1,234.50'],
+		[NumeralsNumberFormat.Fixed, '1234.50'],
+	])('formats exact decimal places without losing profile identity for %s', (
+		format,
+		expected
+	) => {
+		const profile = createNumberFormatProfile(format, 'en-US');
+		expect(formatWithNumberFormatProfile(1234.5, profile, 2)).toBe(expected);
+	});
+
+	it('keeps exponential notation while applying exact coefficient decimals', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.Exponential,
+			'en-US'
+		);
+
+		expect(formatNumberWithProfile(1234.5, profile, 2)).toBe('1.23e+3');
+		expect(formatWithNumberFormatProfile(1234.5, profile, 2)).toBe('1.23e+3');
+	});
+
+	it('keeps engineering notation while applying exact coefficient decimals', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.Engineering,
+			'en-US'
+		);
+
+		expect(formatNumberWithProfile(123456, profile, 2)).toBe('123.46e+3');
+		expect(formatNumberWithProfile(0, profile, 2)).toBe('0.00e+0');
+		expect(formatNumberWithProfile(999.999, profile, 2)).toBe('1.00e+3');
+	});
+
+	it.each([
+		[NumeralsNumberFormat.Fixed, '1.01'],
+		[NumeralsNumberFormat.Exponential, '1.01e+0'],
+		[NumeralsNumberFormat.Engineering, '1.01e+0'],
+	])('rounds decimal midpoints consistently for %s notation', (
+		format,
+		expected
+	) => {
+		const profile = createNumberFormatProfile(format, 'en-US');
+
+		expect(formatNumberWithProfile(1.005, profile, 2)).toBe(expected);
+		expect(formatWithNumberFormatProfile(1.005, profile, 2)).toBe(expected);
+	});
+
+	it('rounds negative decimal midpoints consistently', () => {
+		const fixed = createNumberFormatProfile(
+			NumeralsNumberFormat.Fixed,
+			'en-US'
+		);
+		const exponential = createNumberFormatProfile(
+			NumeralsNumberFormat.Exponential,
+			'en-US'
+		);
+
+		expect(formatNumberWithProfile(-1.255, fixed, 2)).toBe('-1.26');
+		expect(formatNumberWithProfile(-1.255, exponential, 2)).toBe('-1.26e+0');
+	});
+
+	it('supports the documented 20-place limit', () => {
+		const fixed = createNumberFormatProfile(
+			NumeralsNumberFormat.Fixed,
+			'en-US'
+		);
+
+		expect(formatNumberWithProfile(1.005, fixed, 20)).toBe(
+			'1.00500000000000000000'
+		);
+	});
+
+	it('formats subnormal numbers without exponent underflow', () => {
+		const exponential = createNumberFormatProfile(
+			NumeralsNumberFormat.Exponential,
+			'en-US'
+		);
+		const engineering = createNumberFormatProfile(
+			NumeralsNumberFormat.Engineering,
+			'en-US'
+		);
+
+		expect(formatNumberWithProfile(Number.MIN_VALUE, exponential, 2)).toBe(
+			'5.00e-324'
+		);
+		expect(formatNumberWithProfile(Number.MIN_VALUE, engineering, 2)).toBe(
+			'5.00e-324'
+		);
+	});
+
+	it('applies exact decimals and locale profiles to BigNumber values', () => {
+		const localized = createNumberFormatProfile(
+			NumeralsNumberFormat.Format_PeriodThousands_CommaDecimal,
+			'en-US'
+		);
+		const exponential = createNumberFormatProfile(
+			NumeralsNumberFormat.Exponential,
+			'en-US'
+		);
+		const value = math.bignumber('1234.505');
+
+		expect(formatWithNumberFormatProfile(value, localized, 2)).toBe('1.234,51');
+		expect(formatWithNumberFormatProfile(value, exponential, 2)).toBe('1.23e+3');
+	});
+
+	it('preserves locale-specific sign and bidi parts for BigNumber values', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.System,
+			'ar-EG'
+		);
+		const value = math.bignumber('-1234.5');
+		const expected = new Intl.NumberFormat('ar-EG', {
+			useGrouping: true,
+			minimumFractionDigits: 2,
+			maximumFractionDigits: 2,
+		}).format(-1234.5);
+
+		expect(formatWithNumberFormatProfile(value, profile, 2)).toBe(expected);
+	});
+
+	it('applies decimal overrides to Fraction values', () => {
+		const fixed = createNumberFormatProfile(
+			NumeralsNumberFormat.Fixed,
+			'en-US'
+		);
+
+		expect(formatWithNumberFormatProfile(math.fraction(1, 3), fixed, 2)).toBe(
+			'0.33'
+		);
+	});
+
+	it('accepts only the supported decimal-place range', () => {
+		expect(isValidDecimalPlaces(0)).toBe(true);
+		expect(isValidDecimalPlaces(20)).toBe(true);
+		expect(isValidDecimalPlaces(-1)).toBe(false);
+		expect(isValidDecimalPlaces(1.5)).toBe(false);
+		expect(isValidDecimalPlaces(21)).toBe(false);
+	});
+});

--- a/tests/numeralsUtilities.test.ts
+++ b/tests/numeralsUtilities.test.ts
@@ -16,7 +16,8 @@ const mockApp = {
 				getLine: jest.fn(),
 				setLine: jest.fn()
 			}
-		}))
+		})),
+		iterateAllLeaves: jest.fn(),
 	}
 } as any;
 
@@ -36,11 +37,16 @@ import {
 	NumeralsSettings,
 	NumeralsRenderStyle,
 	NumeralsLayout,
+	NumeralsNumberFormat,
 	NumeralsScope,
-	mathjsFormat,
 	StringReplaceMap,
 	DEFAULT_SETTINGS,
 } from "../src/numerals.types";
+import {
+	createNumberFormatProfile,
+	createResultFormatter,
+	ResultFormatter,
+} from '../src/formatting';
 
 // jest.mock('obsidian-dataview');
 
@@ -256,6 +262,39 @@ b = 3
 		expect(result.processedSource).toEqual("# Simple math\n1 + 1\n2 * 2");
 		expect(result.blockInfo.emitter_lines).toEqual([]);
 		expect(result.blockInfo.insertion_lines).toEqual([]);
+	});
+
+	it("collects block formatting overrides without changing source indexes", () => {
+		const sampleBlock = `value = 1
+@format scientific
+@decimalPlaces 2
+value = 2`;
+
+		const result = preProcessBlockForNumeralsDirectives(sampleBlock, undefined);
+
+		expect(result.processedSource).toBe("value = 1\n\n\nvalue = 2");
+		expect(result.blockInfo.hidden_lines).toEqual([1, 2]);
+		expect(result.formatOverrides).toEqual({
+			numberFormat: NumeralsNumberFormat.Exponential,
+			decimalPlaces: 2,
+		});
+		expect(result.invalidFormatDirectives).toEqual([]);
+	});
+
+	it("returns structured invalid formatting directives", () => {
+		const result = preProcessBlockForNumeralsDirectives(
+			"@decimalPlaces 21\nvalue = 1",
+			undefined
+		);
+
+		expect(result.invalidFormatDirectives).toHaveLength(1);
+		expect(result.invalidFormatDirectives[0]).toMatchObject({
+			kind: 'decimalPlaces',
+			lineIndex: 0,
+			source: '@decimalPlaces 21',
+			value: '21',
+			reason: 'out-of-range',
+		});
 	});
 
 	it("Correctly processes block with @prev directive", () => {
@@ -886,7 +925,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
     let metadata: { [key: string]: unknown };
     let type: NumeralsRenderStyle;
     let settings: NumeralsSettings;
-    let numberFormat: mathjsFormat;
+    let formatter: ResultFormatter;
 
     beforeEach(() => {
         el = document.createElement("div");
@@ -938,14 +977,17 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
         metadata = {};
         type = NumeralsRenderStyle.Plain;
         settings = { ...DEFAULT_SETTINGS };
-        numberFormat = getLocaleFormatter();
+		formatter = createResultFormatter({
+			profile: createNumberFormatProfile(settings.numberFormat),
+			preProcessors,
+		});
     });
 
 	const resultSeparator = DEFAULT_SETTINGS.resultSeparator;
 
     it("renders a simple math block correctly", () => {
         source = "1 + 1\n2 * 2";
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 
         const lines = el.querySelectorAll(".numerals-line");
         expect(lines.length).toBe(2);
@@ -953,9 +995,54 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
         expect(lines[1].textContent).toContain(`2 * 2${resultSeparator}4`);
     });
 
+	it("applies @format to a block and hides the directive row", () => {
+		source = "@format exponential\n1234";
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
+
+		const lines = el.querySelectorAll<HTMLElement>(".numerals-line");
+		expect(lines).toHaveLength(1);
+		expect(lines[0].dataset.sourceLine).toBe('1');
+		expect(lines[0].textContent).toContain(`${resultSeparator}1.234e+3`);
+		expect(el.textContent).not.toContain('@format');
+	});
+
+	it("applies @decimalPlaces without changing the value held in scope", () => {
+		source = "@decimalPlaces 2\nvalue = 1 / 3\nvalue";
+		const result = processAndRenderNumeralsBlockFromSource(
+			el,
+			source,
+			ctx,
+			metadata,
+			type,
+			settings,
+			formatter,
+			preProcessors,
+			mockApp
+		);
+
+		const lines = el.querySelectorAll<HTMLElement>(".numerals-line");
+		expect(lines).toHaveLength(2);
+		expect(lines[0].textContent).toContain(`${resultSeparator}0.33`);
+		expect(lines[1].textContent).toContain(`${resultSeparator}0.33`);
+		expect(result.scope.get('value')).toBeCloseTo(1 / 3);
+	});
+
+	it("renders a dedicated error for an invalid formatting directive", () => {
+		source = "@format hexadecimal\n1 + 1";
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
+
+		const errorLine = el.querySelector(".numerals-error-line");
+		expect(errorLine).not.toBeNull();
+		expect(errorLine?.querySelector('.numerals-input')?.textContent).toBe('@format hexadecimal');
+		expect(errorLine?.querySelector('.numerals-error-name')?.textContent).toBe('Formatting Directive Error:');
+		expect(errorLine?.querySelector('.numerals-error-message')?.textContent).toBe(
+			'Unknown @format value: hexadecimal.'
+		);
+	});
+
     it("renders a block with emitter lines correctly", () => {
         source = "1 + 1 =>\n2 * 2 =>";
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 
         const emitterLines = el.querySelectorAll(".numerals-emitter");
         expect(emitterLines.length).toBe(2);
@@ -966,7 +1053,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
     it("renders a block with insertion directives correctly", () => {
 		metadata = { numerals: "all", result1: 1, result2: 2, result3: 3 };
         source = "@[result1]\n@[result2::2]\n@[result3::4]";
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 
         const insertionLines = el.querySelectorAll(".numerals-line");
         // const children = Array.from(el.children);
@@ -978,7 +1065,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 
     it("applies preProcessors correctly", () => {
         source = "$100 + $1,000";
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 
         const lines = el.querySelectorAll(".numerals-line");
         expect(lines.length).toBe(1);
@@ -987,7 +1074,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 
     it("handles errors in math expressions gracefully", () => {
         source = "1 +\n2 * 2";
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 
         const errorLine = el.querySelector(".numerals-error-line");
         expect(errorLine).not.toBeNull();
@@ -996,7 +1083,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 
     it("calculates with variables correctly", () => {
         source = "lemons = 20\napples = 10\nfruit = lemons + apples";
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 
         const lines = el.querySelectorAll(".numerals-line");
         expect(lines.length).toBe(3);
@@ -1007,7 +1094,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 
 	it('simple math block with currency and emitter with snapshot', () => {
 		source = "amount = 100 USD + $1,000\ntax = 10% * amount =>";
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 		const lines = el.querySelectorAll(".numerals-line");
 		expect(lines.length).toBe(2);
 		expect(lines[0].textContent).toContain(`amount = 100 USD + $1,000${resultSeparator}1,100 USD`);
@@ -1027,7 +1114,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 		tuesday = $20
 		wednesday = $30
 		profit = @total`;
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 		const lines = el.querySelectorAll(".numerals-line");
 		expect(lines.length).toBe(10);	
 		expect(lines[0].textContent).toContain(`# Fruit`);
@@ -1049,7 +1136,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
         2 + 3 =>
         @[$result::5]`;
         
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 
         const lines = el.querySelectorAll(".numerals-line");
         // expect(lines.length).toBe(3); // Only 3 lines should be rendered
@@ -1062,7 +1149,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
         2 + 3 =>
         @[$result::5]`;
         
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 
         const lines = el.querySelectorAll(".numerals-line");
         expect(lines.length).toBe(4); // All 4 lines should be rendered
@@ -1078,7 +1165,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 		distance = 100 m
 		time = distance / speed =>
 		@[time]`;
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});	
 	
@@ -1089,7 +1176,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 		lambda=780.246021 nanometer
 		nu=speedOfLight/lambda
 		pi+1`;
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});		
 	
@@ -1157,26 +1244,26 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 	it('Extended Snapshot 1: Default Settings', () => {
 		source = extendedSource;
 		settings = { ...DEFAULT_SETTINGS };
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});
 
 	it('Extended Snapshot 2: Answer Right', () => {
 		source = extendedSource;
 		settings = { ...DEFAULT_SETTINGS, layoutStyle: NumeralsLayout.AnswerRight };
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});	
 	it('Extended Snapshot 3: Answer Below', () => {
 		source = extendedSource;
 		settings = { ...DEFAULT_SETTINGS, layoutStyle: NumeralsLayout.AnswerBelow };
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});		
 	it('Extended Snapshot 4: Answer Inline', () => {
 		source = extendedSource;
 		settings = { ...DEFAULT_SETTINGS, layoutStyle: NumeralsLayout.AnswerInline };
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});			
 	it('Extended Snapshot 5: Mixed Settings', () => {
@@ -1188,7 +1275,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 			layoutStyle: NumeralsLayout.AnswerRight,
 			hideEmitterMarkupInInput: false
 		};
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, formatter, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});		
 });

--- a/tests/numeralsUtilities.test.ts
+++ b/tests/numeralsUtilities.test.ts
@@ -273,6 +273,7 @@ value = 2`;
 		const result = preProcessBlockForNumeralsDirectives(sampleBlock, undefined);
 
 		expect(result.processedSource).toBe("value = 1\n\n\nvalue = 2");
+		expect(result.transparentLineIndexes).toEqual([1, 2]);
 		expect(result.blockInfo.hidden_lines).toEqual([1, 2]);
 		expect(result.formatOverrides).toEqual({
 			numberFormat: NumeralsNumberFormat.Exponential,
@@ -852,6 +853,38 @@ result = __prev + 5`;
 		const { results, inputs } = evaluateMathFromSourceStrings(processedSource, scope);
 		expect(results).toEqual([10, 20, 30, 35]);
 		expect(inputs).toEqual(["value = 10", "doubled = __prev * 2", "tripled = __prev * 1.5", "result = __prev + 5"]);
+	});
+
+	it("should keep formatting directives transparent to @prev", () => {
+		const processedBlock = preProcessBlockForNumeralsDirectives(
+			"value = 10\n@format fixed\ndoubled = @prev * 2",
+			undefined
+		);
+
+		const { results, errorMsg } = evaluateMathFromSourceStrings(
+			processedBlock.processedSource,
+			scope,
+			processedBlock.transparentLineIndexes
+		);
+
+		expect(errorMsg).toBeNull();
+		expect(results).toEqual([10, undefined, 20]);
+	});
+
+	it("should keep formatting directives transparent to @total", () => {
+		const processedBlock = preProcessBlockForNumeralsDirectives(
+			"1\n2\n@decimalPlaces 2\n@total",
+			undefined
+		);
+
+		const { results, errorMsg } = evaluateMathFromSourceStrings(
+			processedBlock.processedSource,
+			scope,
+			processedBlock.transparentLineIndexes
+		);
+
+		expect(errorMsg).toBeNull();
+		expect(results).toEqual([1, 2, undefined, 3]);
 	});
 	
 	it("should handle error when @prev is used on the first line", () => {

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -98,6 +98,7 @@ describe('renderNumeralsBlock', () => {
 		processedBlock = {
 			rawRows: ['1 + 1', '2 + 2', '3 + 3'],
 			processedSource: '1 + 1\n2 + 2\n3 + 3',
+			transparentLineIndexes: [],
 			blockInfo,
 			formatOverrides: {},
 			invalidFormatDirectives: [],

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -1,6 +1,6 @@
 import { renderError, renderNumeralsBlock } from '../src/numeralsUtilities';
-import { EvaluationResult, ProcessedBlock, RenderContext, NumeralsRenderStyle, NumeralsSettings, numeralsBlockInfo } from '../src/numerals.types';
-import * as math from 'mathjs';
+import { EvaluationResult, ProcessedBlock, RenderContext, NumeralsRenderStyle, NumeralsNumberFormat, NumeralsSettings, numeralsBlockInfo } from '../src/numerals.types';
+import { createNumberFormatProfile, createResultFormatter } from '../src/formatting';
 
 // Mock Obsidian functions before importing renderers
 jest.mock('obsidian', () => ({
@@ -98,7 +98,9 @@ describe('renderNumeralsBlock', () => {
 		processedBlock = {
 			rawRows: ['1 + 1', '2 + 2', '3 + 3'],
 			processedSource: '1 + 1\n2 + 2\n3 + 3',
-			blockInfo
+			blockInfo,
+			formatOverrides: {},
+			invalidFormatDirectives: [],
 		};
 
 		settings = {
@@ -109,7 +111,10 @@ describe('renderNumeralsBlock', () => {
 		context = {
 			renderStyle: NumeralsRenderStyle.Plain,
 			settings,
-			numberFormat: math.format,
+			formatter: createResultFormatter({
+				profile: createNumberFormatProfile(NumeralsNumberFormat.System, 'en-US'),
+			}),
+			formatOverrides: {},
 			preProcessors: []
 		};
 	});

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -31,10 +31,11 @@ import {
 	LineRenderData,
 	RenderContext,
 	NumeralsRenderStyle,
+	NumeralsNumberFormat,
 	DEFAULT_SETTINGS,
 } from '../src/numerals.types';
 import { expressionToTeX, resultToTeX } from '../src/rendering/texRendering';
-import { getLocaleFormatter } from '../src/numeralsUtilities';
+import { createNumberFormatProfile, createResultFormatter } from '../src/formatting';
 
 // Mock Obsidian DOM methods
 beforeAll(() => {
@@ -82,7 +83,10 @@ describe('Renderer Implementations', () => {
 		context = {
 			renderStyle: NumeralsRenderStyle.Plain,
 			settings: DEFAULT_SETTINGS,
-			numberFormat: getLocaleFormatter(),
+			formatter: createResultFormatter({
+				profile: createNumberFormatProfile(NumeralsNumberFormat.System),
+			}),
+			formatOverrides: {},
 			preProcessors: [],
 		};
 	});

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -26,6 +26,7 @@ import {
 	SyntaxHighlightRenderer,
 	RendererFactory,
 } from '../src/renderers';
+import { renderMath } from 'obsidian';
 import * as math from 'mathjs';
 import {
 	LineRenderData,
@@ -318,6 +319,7 @@ describe('Renderer Implementations', () => {
 		let renderer: TeXRenderer;
 
 		beforeEach(() => {
+			jest.clearAllMocks();
 			renderer = new TeXRenderer();
 		});
 
@@ -358,6 +360,8 @@ describe('Renderer Implementations', () => {
 			expect(texSpans.length).toBe(2); // input and result
 			expect(input?.textContent).toContain('TeX:2+2');
 			expect(result?.textContent).toContain('TeX:4');
+			expect(renderMath).toHaveBeenNthCalledWith(1, '2+2', true);
+			expect(renderMath).toHaveBeenNthCalledWith(2, '4', true);
 		});
 
 		it('should render empty line', () => {

--- a/tests/resultFormatter.test.ts
+++ b/tests/resultFormatter.test.ts
@@ -1,0 +1,167 @@
+jest.mock('obsidian', () => ({
+	finishRenderMath: jest.fn().mockResolvedValue(undefined),
+	renderMath: jest.fn(),
+	sanitizeHTMLToDom: jest.fn(),
+}));
+
+import * as math from 'mathjs';
+import { NumeralsNumberFormat } from '../src/numerals.types';
+import {
+	createNumberFormatProfile,
+	createResultFormatter,
+} from '../src/formatting';
+import { resultToTeX } from '../src/rendering/texRendering';
+
+describe('ResultFormatter', () => {
+	it('preserves the legacy text, TeX, and canonical contracts by default', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.Format_CommaThousands_PeriodDecimal,
+			'en-US'
+		);
+		const formatter = createResultFormatter({ profile, preProcessors: [] });
+		const value = 1234.5;
+
+		const formatted = formatter.format(value);
+
+		expect(formatted.text).toBe(math.format(value, profile.mathjsFormat));
+		expect(formatted.tex).toBe(resultToTeX(value, []));
+		expect(formatted.canonical).toBe(formatted.text);
+	});
+
+	it('formats localized text but raw-value TeX for an exact decimal override', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.Format_PeriodThousands_CommaDecimal,
+			'en-US'
+		);
+		const formatter = createResultFormatter({ profile });
+
+		const formatted = formatter.format(1234.5, { decimalPlaces: 2 });
+
+		expect(formatted.text).toBe('1.234,50');
+		expect(formatted.tex).toBe('1234.50');
+		expect(formatted.canonical).toBe('1.234,50');
+	});
+
+	it('applies number-format and decimal overrides together', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.System,
+			'en-US'
+		);
+		const formatter = createResultFormatter({ profile });
+
+		const exponential = formatter.format(1234.5, {
+			numberFormat: NumeralsNumberFormat.Exponential,
+			decimalPlaces: 2,
+		});
+		const engineering = formatter.format(123456, {
+			numberFormat: NumeralsNumberFormat.Engineering,
+			decimalPlaces: 2,
+		});
+
+		expect(exponential.text).toBe('1.23e+3');
+		expect(exponential.tex).toBe('1.23 \\times 10^{3}');
+		expect(engineering.text).toBe('123.46e+3');
+		expect(engineering.tex).toBe('123.46 \\times 10^{3}');
+	});
+
+	it('preserves exact decimal digits in Unit text and TeX', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.Fixed,
+			'en-US'
+		);
+		const formatter = createResultFormatter({ profile });
+		const value = math.unit(2, 'm');
+
+		const formatted = formatter.format(value, { decimalPlaces: 2 });
+
+		expect(formatted.text).toBe('2.00 m');
+		expect(formatted.tex).toBe('2.00~\\mathrm{m}');
+		expect(formatted.canonical).toBe('2.00 m');
+	});
+
+	it('does not mutate or computationally round a raw Unit value', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.Fixed,
+			'en-US'
+		);
+		const formatter = createResultFormatter({ profile });
+		const value = math.unit(1 / 3, 'm');
+		const beforeText = value.toString();
+		const beforeNumber = value.toNumber('m');
+
+		const formatted = formatter.format(value, { decimalPlaces: 2 });
+
+		expect(formatted.text).toBe('0.33 m');
+		expect(value.toString()).toBe(beforeText);
+		expect(value.toNumber('m')).toBe(beforeNumber);
+		expect(value.toNumber('m')).not.toBe(0.33);
+	});
+
+	it('preserves decimal padding in collection and complex TeX', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.Fixed,
+			'en-US'
+		);
+		const formatter = createResultFormatter({ profile });
+
+		const matrix = formatter.format(math.matrix([[1, 2], [3, 4]]), {
+			decimalPlaces: 2,
+		});
+		const complex = formatter.format(math.complex(1, -2), {
+			decimalPlaces: 2,
+		});
+
+		expect(matrix.text).toBe('[[1.00, 2.00], [3.00, 4.00]]');
+		expect(matrix.tex).toBe(
+			'\\begin{bmatrix}1.00&2.00\\\\3.00&4.00\\end{bmatrix}'
+		);
+		expect(complex.text).toBe('1.00 - 2.00i');
+		expect(complex.tex).toBe('1.00 - 2.00~ i');
+	});
+
+	it.each([
+		[Number.POSITIVE_INFINITY, '\\infty'],
+		[Number.NEGATIVE_INFINITY, '-\\infty'],
+		[Number.NaN, '\\mathrm{NaN}'],
+	])('renders non-finite override value %s as TeX', (value, expected) => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.Fixed,
+			'en-US'
+		);
+		const formatter = createResultFormatter({ profile });
+
+		expect(formatter.format(value, { decimalPlaces: 2 }).tex).toBe(expected);
+	});
+
+	it('preserves exact TeX digits for BigNumber and Fraction values', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.Fixed,
+			'en-US'
+		);
+		const formatter = createResultFormatter({ profile });
+
+		expect(formatter.format(math.bignumber(2), { decimalPlaces: 2 }).tex)
+			.toBe('2.00');
+		expect(formatter.format(math.fraction(1, 2), { decimalPlaces: 2 }).tex)
+			.toBe('0.50');
+		expect(formatter.format(math.bignumber(Number.NaN), {
+			decimalPlaces: 2,
+		}).tex).toBe('\\mathrm{NaN}');
+	});
+
+	it('preserves decimal padding in ragged and nested collection TeX', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.Fixed,
+			'en-US'
+		);
+		const formatter = createResultFormatter({ profile });
+		const value = [[[1], [2]], [[3, 4]]];
+
+		const formatted = formatter.format(value, { decimalPlaces: 2 });
+
+		expect(formatted.tex).toContain('1.00');
+		expect(formatted.tex).toContain('2.00');
+		expect(formatted.tex).toContain('3.00');
+		expect(formatted.tex).toContain('4.00');
+	});
+});

--- a/tests/resultFormatter.test.ts
+++ b/tests/resultFormatter.test.ts
@@ -97,6 +97,21 @@ describe('ResultFormatter', () => {
 		expect(value.toNumber('m')).not.toBe(0.33);
 	});
 
+	it('preserves arbitrary-precision Unit values in TeX', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.Fixed,
+			'en-US'
+		);
+		const formatter = createResultFormatter({ profile });
+		const numericValue = math.bignumber('1e400');
+		const value = math.unit(numericValue, 'm');
+
+		const formatted = formatter.format(value, { decimalPlaces: 2 });
+
+		expect(formatted.tex).toBe(`${numericValue.toFixed(2)}~\\mathrm{m}`);
+		expect(formatted.tex).not.toContain('infty');
+	});
+
 	it('preserves decimal padding in collection and complex TeX', () => {
 		const profile = createNumberFormatProfile(
 			NumeralsNumberFormat.Fixed,

--- a/tests/resultInsertion.test.ts
+++ b/tests/resultInsertion.test.ts
@@ -4,7 +4,12 @@
  */
 
 import { handleResultInsertions } from '../src/numeralsUtilities';
-import { getLocaleFormatter } from '../src/numeralsUtilities';
+import {
+	createNumberFormatProfile,
+	createResultFormatter,
+	ResultFormatter,
+} from '../src/formatting';
+import { NumeralsNumberFormat } from '../src/numerals.types';
 import { App, MarkdownPostProcessorContext, MarkdownView } from 'obsidian';
 
 // Mock Obsidian types
@@ -23,7 +28,7 @@ describe('handleResultInsertions', () => {
 	let mockApp: Partial<App>;
 	let mockCtx: MockContext;
 	let mockEl: HTMLElement;
-	let numberFormat: any;
+	let formatter: ResultFormatter;
 
 	beforeEach(() => {
 		// Mock editor
@@ -55,8 +60,9 @@ describe('handleResultInsertions', () => {
 		// Mock element
 		mockEl = document.createElement('div');
 
-		// Number format
-		numberFormat = getLocaleFormatter();
+		formatter = createResultFormatter({
+			profile: createNumberFormatProfile(NumeralsNumberFormat.System),
+		});
 
 		// Clear setTimeout mock
 		jest.useFakeTimers();
@@ -76,7 +82,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -101,7 +108,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -127,7 +135,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -150,7 +159,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -171,7 +181,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -193,7 +204,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -213,7 +225,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -233,7 +246,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -255,7 +269,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -275,7 +290,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -296,7 +312,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -310,6 +327,31 @@ describe('handleResultInsertions', () => {
 		expect(call[1]).toMatch(/@\[value::\d+/);
 	});
 
+	it('should apply block format overrides to inserted results', () => {
+		const results = [1.2];
+		const insertionLines = [0];
+
+		mockCtx.getSectionInfo.mockReturnValue({ lineStart: 0 });
+		mockEditor.getLine.mockReturnValue('@[value]');
+
+		handleResultInsertions(
+			results,
+			insertionLines,
+			formatter,
+			{
+				numberFormat: NumeralsNumberFormat.Fixed,
+				decimalPlaces: 2,
+			},
+			mockCtx as unknown as MarkdownPostProcessorContext,
+			mockApp as App,
+			mockEl
+		);
+
+		jest.runAllTimers();
+
+		expect(mockEditor.setLine).toHaveBeenCalledWith(1, '@[value::1.20]');
+	});
+
 	it('should preserve text after insertion directive', () => {
 		const results = [99];
 		const insertionLines = [0];
@@ -320,7 +362,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -344,7 +387,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -376,7 +420,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -403,7 +448,8 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			formatter,
+			{},
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -30,6 +30,7 @@ describe('Rendering Pipeline Types', () => {
 			const processedBlock: ProcessedBlock = {
 				rawRows: ['line1', 'line2'],
 				processedSource: 'processed\nsource',
+				transparentLineIndexes: [],
 				blockInfo: {
 					emitter_lines: [1],
 					insertion_lines: [],
@@ -49,6 +50,7 @@ describe('Rendering Pipeline Types', () => {
 			const processedBlock: ProcessedBlock = {
 				rawRows: [],
 				processedSource: '',
+				transparentLineIndexes: [],
 				blockInfo: {
 					emitter_lines: [],
 					insertion_lines: [],
@@ -270,6 +272,7 @@ describe('Type Compatibility', () => {
 		const processedBlock: ProcessedBlock = {
 			rawRows,
 			processedSource,
+			transparentLineIndexes: [],
 			blockInfo,
 			formatOverrides: {},
 			invalidFormatDirectives: [],

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -10,11 +10,19 @@ import {
 	RenderContext,
 	StringReplaceMap,
 	NumeralsRenderStyle,
+	NumeralsNumberFormat,
 	NumeralsSettings,
 	DEFAULT_SETTINGS,
-	mathjsFormat,
 	numeralsBlockInfo,
 } from '../src/numerals.types';
+import {
+	createNumberFormatProfile,
+	createResultFormatter,
+} from '../src/formatting';
+
+const formatter = createResultFormatter({
+	profile: createNumberFormatProfile(NumeralsNumberFormat.System, 'en-US'),
+});
 
 describe('Rendering Pipeline Types', () => {
 	describe('ProcessedBlock', () => {
@@ -28,6 +36,8 @@ describe('Rendering Pipeline Types', () => {
 					hidden_lines: [],
 					shouldHideNonEmitterLines: false,
 				},
+				formatOverrides: {},
+				invalidFormatDirectives: [],
 			};
 
 			expect(processedBlock.rawRows).toHaveLength(2);
@@ -45,6 +55,8 @@ describe('Rendering Pipeline Types', () => {
 					hidden_lines: [],
 					shouldHideNonEmitterLines: false,
 				},
+				formatOverrides: {},
+				invalidFormatDirectives: [],
 			};
 
 			expect(processedBlock.rawRows).toHaveLength(0);
@@ -178,7 +190,8 @@ describe('Rendering Pipeline Types', () => {
 			const context: RenderContext = {
 				renderStyle: NumeralsRenderStyle.Plain,
 				settings: DEFAULT_SETTINGS,
-				numberFormat: undefined,
+				formatter,
+				formatOverrides: {},
 				preProcessors: [],
 			};
 
@@ -190,12 +203,13 @@ describe('Rendering Pipeline Types', () => {
 			const context: RenderContext = {
 				renderStyle: NumeralsRenderStyle.TeX,
 				settings: DEFAULT_SETTINGS,
-				numberFormat: { notation: 'fixed' },
+				formatter,
+				formatOverrides: { numberFormat: NumeralsNumberFormat.Fixed },
 				preProcessors: [],
 			};
 
 			expect(context.renderStyle).toBe(NumeralsRenderStyle.TeX);
-			expect(context.numberFormat).toHaveProperty('notation', 'fixed');
+			expect(context.formatOverrides.numberFormat).toBe(NumeralsNumberFormat.Fixed);
 		});
 
 		it('should accept valid RenderContext with preProcessors', () => {
@@ -207,7 +221,8 @@ describe('Rendering Pipeline Types', () => {
 			const context: RenderContext = {
 				renderStyle: NumeralsRenderStyle.SyntaxHighlight,
 				settings: DEFAULT_SETTINGS,
-				numberFormat: undefined,
+				formatter,
+				formatOverrides: {},
 				preProcessors,
 			};
 
@@ -256,6 +271,8 @@ describe('Type Compatibility', () => {
 			rawRows,
 			processedSource,
 			blockInfo,
+			formatOverrides: {},
+			invalidFormatDirectives: [],
 		};
 
 		expect(processedBlock).toBeDefined();


### PR DESCRIPTION
## Summary

- introduce a single `ResultFormatter` boundary for block, inline, TeX, and result-insertion output
- keep evaluated mathjs values raw so display precision never changes scope, `@prev`, `@sum`, variables, or globals
- add block-local `@format` and `@decimalPlaces` directives with structured validation
- render inline TeX triggers with MathJax inline mode in both Reading mode and Live Preview while preserving display math for TeX blocks
- preserve default text, TeX, canonical insertion, settings, and snapshots byte-for-byte
- add the implementation/architecture spec for this PR and the stacked currency-formatting PR

## Architecture

Evaluation now returns raw values. A normalized number-format profile and one formatter produce text, TeX, and canonical output for every rendering surface. Locale-aware text and non-localized structured TeX are generated from the raw value rather than reparsing localized display strings.

The formatter handles Number, BigNumber, Fraction, Complex, Unit, and nested collection results. Decimal overrides support 0–20 places, preserve notation, and affect presentation only.

The shared MathJax helper accepts Obsidian's display-mode flag. Block TeX keeps display mode as the default, while inline result and equation triggers explicitly request inline mode and retain their asynchronous plain-text fallback.

## Adversarial review hardening

- formatting-directive rows retain source alignment but are evaluation-transparent, so placing them between calculations cannot break `@prev` or reset `@total`
- Unit TeX formatting uses mathjs's precision-preserving numeric API, avoiding overflow of BigNumber-backed Units through JavaScript `number`

## Validation

- `npm test -- --runInBand`: 18 suites, 487 tests, 8 snapshots
- `npm run lint`
- `npm run build`
- `npx tsc --noEmit`
- `git diff --check`
- legacy snapshot SHA-256 unchanged

Closes #75
Closes #140

## Stack

PR #166 is intentionally stacked on this PR and adds currency-standard precision, configured-symbol display, custom-currency precision, settings migration, and locale coverage for #160.
