### PR TITLE
feat: add currency-aware result formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 - Per-expression TeX rendering for Inline Numerals via the new `#$:` (result only) and `#=$:` (equation) trigger prefixes, which render with MathJax in both Live Preview and Reading mode. Both prefixes are configurable in settings. (Closes #161)
 - Block-level `@format` and `@decimalPlaces` directives for overriding result presentation without changing calculated values. (Closes #75, #140)
-- Opt-in currency-standard decimal places and configured-symbol display for pure currency results, including derived currency values. Compatibility defaults preserve existing number formatting and currency codes. (Closes #160)
+- Currency-standard decimal places by default and optional configured-symbol display for pure currency results, including derived currency values. Currency-code display remains the default. (Closes #160)
 
 ### Changed
 - Centralized block, inline, TeX, and result-insertion formatting behind one result-formatting pipeline so evaluation always retains raw mathjs values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 - Per-expression TeX rendering for Inline Numerals via the new `#$:` (result only) and `#=$:` (equation) trigger prefixes, which render with MathJax in both Live Preview and Reading mode. Both prefixes are configurable in settings. (Closes #161)
 - Block-level `@format` and `@decimalPlaces` directives for overriding result presentation without changing calculated values. (Closes #75, #140)
+- Opt-in currency-standard decimal places and configured-symbol display for pure currency results, including derived currency values. Compatibility defaults preserve existing number formatting and currency codes. (Closes #160)
 
 ### Changed
 - Centralized block, inline, TeX, and result-insertion formatting behind one result-formatting pipeline so evaluation always retains raw mathjs values.
+- Result insertion continues to persist currency codes even when configured-symbol display is enabled.
 
 ## [1.10.2] - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 | Show-your-work equations | `` `#=: 2 * (3ft + 4ft)` `` -> `2 * (3 ft + 4 ft) = 14 ft` |
 | Full math blocks | <code>```math<br>20 mi / 4 hr to m/s<br>```</code> -> `2.235 m / s` |
 | Units and conversions | `100 km/hr in mi/hr` -> `62.137 mi / hr` |
-| Currency math | `$100/hr * 3 days` -> `7,200 USD` |
+| Currency math | `$100/hr * 3 days` -> `7,200.00 USD` |
 | Note-wide variables | `$rate = $150/hr`, then `` `#: $rate * 40hr` `` |
 | Cross-note references | `[[Client Settings]].rates.hourly * 8hr` |
-| Result insertion | `@[profit] = revenue - expenses` writes `@[profit::10 USD]` |
+| Result insertion | `@[profit] = revenue - expenses` writes `@[profit::10.00 USD]` |
 
 ## Quick Start
 
@@ -88,8 +88,8 @@ Numerals uses [mathjs](https://mathjs.org/) for calculations and adds Obsidian-f
 | --- | --- |
 | Units | `1ft + 12in` -> `2 ft` |
 | Conversions | `72 degF to degC` -> `22.222 degC` |
-| Currency | `$1,000 * 2` -> `2,000 USD` |
-| Rates | `$100/hr * 3 days` -> `7,200 USD` |
+| Currency | `$1,000 * 2` -> `2,000.00 USD` |
+| Rates | `$100/hr * 3 days` -> `7,200.00 USD` |
 | Functions | `sqrt(144)`, `sin(pi/2)`, `log(1000, 10)` |
 | Bases | `0xff + 0b100` -> `259` |
 | Fractions | `fraction(1/3) + fraction(1/4)` -> `7/12` |
@@ -197,7 +197,7 @@ Use `@[label]` to write a result back into the raw note as Dataview-style inline
 Numerals updates the source text to:
 
 ```markdown
-@[profit::1,550 USD]
+@[profit::1550.00 USD]
 ```
 
 ### Auto-Complete

--- a/README.md
+++ b/README.md
@@ -269,6 +269,24 @@ third = 1 / 3
 
 These directives change displayed and inserted results, not values in calculation scope. For computational rounding, use mathjs directly: `round(value, 2)` for numbers or `round(amount, 2, GBP)` for currency Units.
 
+### Currency Formatting
+
+Currency formatting is opt-in so existing notes keep their current output. The compatibility defaults are **Use rendered number format** and **Currency code**, which preserve results such as `120 GBP`.
+
+To use conventional currency precision, choose **Use currency standard** in Numerals settings. Pure currency results then use the standard number of decimal places for their currency:
+
+- GBP and USD use 2 places: `120.00 GBP`
+- JPY uses 0 places: `120 JPY`
+- KWD uses 3 places: `120.000 KWD`
+
+A custom currency mapping uses the configured **Custom currency decimal places** value, from 0 through 20. This setting is enabled when currency-standard precision is selected.
+
+Choose **Configured symbol** to display the symbol from Numerals' active currency mapping instead of its code. Symbol order, spacing, digits, and signs follow the selected locale, while the configured symbol itself is preserved. For example, a `$` mapping to CAD still uses `$`, rather than substituting `CA$`.
+
+Currency presentation applies to pure currency results, including derived values such as `remaining / 8`. Compound rates such as `GBP / hour` retain the general number format and code. A block-level `@decimalPlaces` directive takes precedence over currency-standard digits.
+
+Result insertion always writes the currency code, never a display symbol. For example, a result displayed as `£12.50` is inserted as `12.50 GBP`.
+
 ## Installation
 
 Install **Numerals** from Obsidian's Community Plugins browser.

--- a/README.md
+++ b/README.md
@@ -271,15 +271,17 @@ These directives change displayed and inserted results, not values in calculatio
 
 ### Currency Formatting
 
-Currency formatting is opt-in so existing notes keep their current output. The compatibility defaults are **Use rendered number format** and **Currency code**, which preserve results such as `120 GBP`.
+Currency results use **Currency standard** precision and **Currency code** display by default. Pure currency values therefore render with the conventional number of decimal places for their currency while keeping an unambiguous unit code.
 
-To use conventional currency precision, choose **Use currency standard** in Numerals settings. Pure currency results then use the standard number of decimal places for their currency:
+Examples of the default precision are:
 
 - GBP and USD use 2 places: `120.00 GBP`
 - JPY uses 0 places: `120 JPY`
 - KWD uses 3 places: `120.000 KWD`
 
 A custom currency mapping uses the configured **Custom currency decimal places** value, from 0 through 20. This setting is enabled when currency-standard precision is selected.
+
+Choose **Use rendered number format** when currency values should instead follow the general number-format behavior used by other Units.
 
 Choose **Configured symbol** to display the symbol from Numerals' active currency mapping instead of its code. Symbol order, spacing, digits, and signs follow the selected locale, while the configured symbol itself is preserved. For example, a `$` mapping to CAD still uses `$`, rather than substituting `CA$`.
 

--- a/docs/result-formatting.md
+++ b/docs/result-formatting.md
@@ -137,9 +137,14 @@ A result is pure currency when its dimensions equal one active currency unit. Th
 
 Mathjs cannot remove registered units. Rebuilding the immutable registry changes which units receive currency presentation, even though stale mathjs unit definitions may remain until Obsidian reloads.
 
-## Currency presentation (PR 2)
+## Currency presentation
 
-PR 2 adds two independent settings:
+Currency presentation uses two independent, opt-in settings. Their persisted values are intentionally explicit:
+
+- `currencyPrecisionMode`: `follow-number-format` or `currency-standard`.
+- `currencyDisplayMode`: `code` or `symbol`.
+
+Older settings files omit these keys and inherit the compatibility defaults without being rewritten on load. Present but invalid values are repaired to the compatibility defaults. The custom decimal-place value must be an integer from 0 through 20; invalid persisted values are repaired to 2.
 
 ### Currency decimal places
 
@@ -152,7 +157,7 @@ Examples of standard digits:
 - JPY: 0
 - KWD: 3
 
-Custom/non-ISO currencies default to 2 and expose a validated custom decimal-place setting from 0 through 20.
+Custom currencies default to 2 and expose a validated custom decimal-place setting from 0 through 20. The custom value is only relevant when currency-standard precision is active.
 
 ### Currency display
 
@@ -170,6 +175,8 @@ Symbol placement comes from `Intl.NumberFormat.formatToParts()`. The formatter r
 - Result insertion continues using an ISO/custom unit code, never a display symbol.
 
 Compatibility defaults mean users see no currency presentation change until they opt in.
+
+Changing a currency presentation setting rebuilds the immutable registry and formatter immediately. The settings tab continues to use its imperative implementation so Numerals can retain its existing minimum Obsidian version.
 
 ## Rounding versus display formatting
 
@@ -209,7 +216,7 @@ PR 1 requirements:
 - No mathjs formatter or Unit internal is patched for presentation.
 - Only explicit block directives change output.
 
-PR 2 requirements:
+Currency-policy requirements:
 
 - Currency code and current number-format behavior remain the defaults.
 - Automatic currency digits and configured symbols are opt-in.

--- a/docs/result-formatting.md
+++ b/docs/result-formatting.md
@@ -10,7 +10,7 @@ This architecture addresses three related requests:
 - Currency-aware precision, symbols, and derived currency values (#160).
 - Consistent result presentation in blocks, inline Numerals, TeX, and result insertion.
 
-The work is split into two stacked pull requests. PR 1 introduces the shared formatting boundary and block directives. PR 2 adds opt-in currency presentation policies.
+The work is split into two stacked pull requests. PR 1 introduces the shared formatting boundary and block directives. PR 2 adds currency presentation policies.
 
 ## Formatting boundary
 
@@ -139,17 +139,17 @@ Mathjs cannot remove registered units. Rebuilding the immutable registry changes
 
 ## Currency presentation
 
-Currency presentation uses two independent, opt-in settings. Their persisted values are intentionally explicit:
+Currency presentation uses two independent settings. Their persisted values are intentionally explicit:
 
 - `currencyPrecisionMode`: `follow-number-format` or `currency-standard`.
 - `currencyDisplayMode`: `code` or `symbol`.
 
-Older settings files omit these keys and inherit the compatibility defaults without being rewritten on load. Present but invalid values are repaired to the compatibility defaults. The custom decimal-place value must be an integer from 0 through 20; invalid persisted values are repaired to 2.
+Older settings files omit these keys and inherit the current defaults without being rewritten on load. Present but invalid values are repaired to the current defaults. The custom decimal-place value must be an integer from 0 through 20; invalid persisted values are repaired to 2.
 
 ### Currency decimal places
 
-- `Use rendered number format` is the compatibility default.
-- `Use currency standard` uses ISO 4217 minor units obtained from `Intl.NumberFormat.resolvedOptions()`.
+- `Use currency standard` is the default and uses ISO 4217 minor units obtained from `Intl.NumberFormat.resolvedOptions()`.
+- `Use rendered number format` applies the general number-format behavior to currency values.
 
 Examples of standard digits:
 
@@ -161,7 +161,7 @@ Custom currencies default to 2 and expose a validated custom decimal-place setti
 
 ### Currency display
 
-- `ISO code` is the compatibility default, such as `12.50 GBP`.
+- `ISO code` remains the default, such as `12.50 GBP`.
 - `Configured symbol` uses the symbol in Numerals' active currency map.
 
 Symbol placement comes from `Intl.NumberFormat.formatToParts()`. The formatter replaces only the `currency` part with the configured symbol. This preserves locale order, spacing, digits, signs, and bidirectional marks without accepting Intl's choice of symbol. For example, a `$` mapping to CAD continues to display the configured `$`, not an automatically selected `CA$`.
@@ -174,7 +174,7 @@ Symbol placement comes from `Intl.NumberFormat.formatToParts()`. The formatter r
 - TeX uses the same rounding decision, with a period decimal and no locale grouping.
 - Result insertion continues using an ISO/custom unit code, never a display symbol.
 
-Compatibility defaults mean users see no currency presentation change until they opt in.
+Currency-standard precision applies by default. Configured-symbol display remains opt-in; currency codes are displayed and inserted unless the user selects symbols for display.
 
 Changing a currency presentation setting rebuilds the immutable registry and formatter immediately. The settings tab continues to use its imperative implementation so Numerals can retain its existing minimum Obsidian version.
 
@@ -218,8 +218,8 @@ PR 1 requirements:
 
 Currency-policy requirements:
 
-- Currency code and current number-format behavior remain the defaults.
-- Automatic currency digits and configured symbols are opt-in.
+- Currency-standard precision and currency-code display are the defaults.
+- Configured symbols are opt-in, and users can select rendered-number precision when desired.
 - The settings tab stays on the imperative API because `minAppVersion` remains below Obsidian 1.13.0.
 - Symbol/unit remapping retains the existing reload requirement where mathjs aliases cannot be removed safely.
 

--- a/src/formatting/currencyRegistry.ts
+++ b/src/formatting/currencyRegistry.ts
@@ -6,6 +6,8 @@ import type {
 } from './types';
 
 const DEFAULT_CURRENCY_FRACTION_DIGITS = 2;
+const MIN_CURRENCY_FRACTION_DIGITS = 0;
+const MAX_CURRENCY_FRACTION_DIGITS = 20;
 
 export interface CurrencyRegistryOptions {
 	locale?: string;
@@ -52,14 +54,17 @@ export class CurrencyRegistry {
 			}
 
 			const configuredDigits = options.fractionDigitsByCode?.get(code);
-			const fractionDigits = configuredDigits ??
+			const fractionDigits = isValidFractionDigits(configuredDigits)
+				? configuredDigits
+				: undefined;
+			const resolvedFractionDigits = fractionDigits ??
 				getCurrencyFractionDigits(code, options.locale);
 
 			definitionsByCode.set(code, {
 				code,
 				symbol: entry.symbol,
 				texCommand: `\\${entry.name}`,
-				fractionDigits,
+				fractionDigits: resolvedFractionDigits,
 				unit,
 			});
 		}
@@ -96,6 +101,13 @@ export class CurrencyRegistry {
 
 		return undefined;
 	}
+}
+
+function isValidFractionDigits(value: number | undefined): value is number {
+	return value !== undefined &&
+		Number.isInteger(value) &&
+		value >= MIN_CURRENCY_FRACTION_DIGITS &&
+		value <= MAX_CURRENCY_FRACTION_DIGITS;
 }
 
 function getCurrencyFractionDigits(code: string, locale?: string): number {

--- a/src/formatting/resultFormatter.ts
+++ b/src/formatting/resultFormatter.ts
@@ -1,4 +1,8 @@
 import * as math from 'mathjs';
+import {
+	CurrencyDisplayMode,
+	CurrencyPrecisionMode,
+} from '../numerals.types';
 import type { StringReplaceMap } from '../numerals.types';
 import {
 	getLocaleFormatter,
@@ -13,6 +17,7 @@ import {
 } from './numberFormat';
 import type {
 	FormattedResult,
+	CurrencyMatch,
 	NumberFormatProfile,
 	ResultFormatOverrides,
 	ResultFormatter,
@@ -20,8 +25,12 @@ import type {
 
 export interface ResultFormatterConfig {
 	profile: NumberFormatProfile;
-	/** Wired in PR 1 so PR 2 can add policy without changing call sites. */
+	/** Active currency definitions created by Numerals. */
 	currencies?: CurrencyRegistry;
+	/** Whether pure currency values follow the number format or ISO minor units. */
+	currencyPrecisionMode?: CurrencyPrecisionMode;
+	/** Whether pure currency values display their unit code or configured symbol. */
+	currencyDisplayMode?: CurrencyDisplayMode;
 	/** Legacy TeX conversion applies these source preprocessing rules. */
 	preProcessors?: StringReplaceMap[];
 }
@@ -36,17 +45,57 @@ export function createResultFormatter(
 class DefaultResultFormatter implements ResultFormatter {
 	private readonly profile: NumberFormatProfile;
 	private readonly preProcessors: StringReplaceMap[];
+	private readonly currencies: CurrencyRegistry | undefined;
+	private readonly currencyPrecisionMode: CurrencyPrecisionMode;
+	private readonly currencyDisplayMode: CurrencyDisplayMode;
 
 	constructor(config: ResultFormatterConfig) {
 		this.profile = config.profile;
 		this.preProcessors = [...(config.preProcessors ?? [])];
-		// Retain the registry in the public construction contract for PR 2.
-		// PR 1 intentionally applies no currency-special presentation policy.
-		void config.currencies;
+		this.currencies = config.currencies;
+		this.currencyPrecisionMode = config.currencyPrecisionMode ??
+			CurrencyPrecisionMode.FollowNumberFormat;
+		this.currencyDisplayMode = config.currencyDisplayMode ??
+			CurrencyDisplayMode.Code;
 	}
 
 	format(value: unknown, overrides?: ResultFormatOverrides): FormattedResult {
 		const profile = resolveNumberFormatProfile(this.profile, overrides);
+		const currency = this.currencies?.match(value);
+		if (currency) {
+			if (this.usesCurrencyPresentation(overrides)) {
+				return this.formatCurrency(currency, profile, overrides);
+			}
+
+			const legacy = this.formatGeneral(value, profile, overrides);
+			return {
+				...legacy,
+				// Preserve legacy display while ensuring persisted currency never
+				// depends on the alias used to construct the mathjs Unit.
+				canonical: `${formatCurrencyNumber(
+					currency.amount,
+					profile,
+					undefined
+				)} ${currency.definition.code}`,
+			};
+		}
+
+		return this.formatGeneral(value, profile, overrides);
+	}
+
+	private usesCurrencyPresentation(
+		overrides?: ResultFormatOverrides
+	): boolean {
+		return overrides?.decimalPlaces !== undefined ||
+			this.currencyPrecisionMode === CurrencyPrecisionMode.CurrencyStandard ||
+			this.currencyDisplayMode === CurrencyDisplayMode.Symbol;
+	}
+
+	private formatGeneral(
+		value: unknown,
+		profile: NumberFormatProfile,
+		overrides?: ResultFormatOverrides
+	): FormattedResult {
 		const text = formatWithNumberFormatProfile(
 			value,
 			profile,
@@ -66,10 +115,151 @@ class DefaultResultFormatter implements ResultFormatter {
 		return {
 			text,
 			tex,
-			// PR 1 preserves the result-insertion contract byte-for-byte.
+			// Compatibility path: preserve the PR 1 insertion contract.
 			canonical: text,
 		};
 	}
+
+	private formatCurrency(
+		currency: CurrencyMatch,
+		profile: NumberFormatProfile,
+		overrides?: ResultFormatOverrides
+	): FormattedResult {
+		const decimalPlaces = overrides?.decimalPlaces ??
+			(this.currencyPrecisionMode === CurrencyPrecisionMode.CurrencyStandard
+				? currency.definition.fractionDigits
+				: undefined);
+		const numericText = formatCurrencyNumber(
+			currency.amount,
+			profile,
+			decimalPlaces
+		);
+		const text = this.currencyDisplayMode === CurrencyDisplayMode.Symbol
+			? placeConfiguredCurrencySymbol(
+				currency,
+				profile,
+				decimalPlaces
+			)
+			: `${numericText} ${currency.definition.code}`;
+
+		const nonLocalizedProfile = nonLocalizedNumberProfile(profile);
+		const canonicalNumber = formatCurrencyNumber(
+			currency.amount,
+			nonLocalizedProfile,
+			decimalPlaces
+		);
+		const canonical = `${canonicalNumber} ${currency.definition.code}`;
+		const tex = formatCurrencyTeX(
+			currency,
+			nonLocalizedProfile,
+			decimalPlaces,
+			this.currencyDisplayMode
+		);
+
+		return { text, tex, canonical };
+	}
+}
+
+function formatCurrencyNumber(
+	value: number,
+	profile: NumberFormatProfile,
+	decimalPlaces: number | undefined
+): string {
+	return decimalPlaces === undefined
+		? formatWithNumberFormatProfile(value, profile)
+		: formatNumberWithProfile(value, profile, decimalPlaces);
+}
+
+function placeConfiguredCurrencySymbol(
+	currency: CurrencyMatch,
+	profile: NumberFormatProfile,
+	decimalPlaces: number | undefined
+): string {
+	const negative = currency.amount < 0 || Object.is(currency.amount, -0);
+	const numericText = formatCurrencyNumber(
+		Math.abs(currency.amount),
+		profile,
+		decimalPlaces
+	);
+	const locale = profile.locale ?? profile.systemLocale;
+	const templateCurrency = /^[A-Za-z]{3}$/u.test(currency.definition.code)
+		? currency.definition.code.toUpperCase()
+		: 'USD';
+	const parts = new Intl.NumberFormat(locale, {
+		style: 'currency',
+		currency: templateCurrency,
+		currencyDisplay: 'symbol',
+		useGrouping: false,
+		minimumFractionDigits: 0,
+		maximumFractionDigits: 0,
+	}).formatToParts(negative ? -1 : 1);
+
+	let insertedNumber = false;
+	return parts.map((part) => {
+		if (part.type === 'currency') {
+			return currency.definition.symbol;
+		}
+		if (isNumericFormatPart(part.type)) {
+			if (insertedNumber) {
+				return '';
+			}
+			insertedNumber = true;
+			return numericText;
+		}
+		return part.value;
+	}).join('');
+}
+
+function isNumericFormatPart(type: Intl.NumberFormatPartTypes): boolean {
+	return type === 'integer' ||
+		type === 'group' ||
+		type === 'decimal' ||
+		type === 'fraction' ||
+		type === 'nan' ||
+		type === 'infinity' ||
+		type === 'compact' ||
+		type === 'exponentInteger' ||
+		type === 'exponentMinusSign' ||
+		type === 'exponentSeparator';
+}
+
+function nonLocalizedNumberProfile(
+	profile: NumberFormatProfile
+): NumberFormatProfile {
+	if (profile.notation !== 'standard') {
+		return profile;
+	}
+
+	return {
+		...profile,
+		locale: 'en-US',
+		useGrouping: false,
+		mathjsFormat: getLocaleFormatter('en-US', { useGrouping: false }),
+	};
+}
+
+function formatCurrencyTeX(
+	currency: CurrencyMatch,
+	profile: NumberFormatProfile,
+	decimalPlaces: number | undefined,
+	displayMode: CurrencyDisplayMode
+): string {
+	if (displayMode === CurrencyDisplayMode.Symbol) {
+		const negative = currency.amount < 0 || Object.is(currency.amount, -0);
+		const numberTex = numberToTeX(
+			Math.abs(currency.amount),
+			profile,
+			decimalPlaces
+		);
+		return `${negative ? '-' : ''}${currency.definition.texCommand} ${numberTex}`;
+	}
+
+	const numberTex = numberToTeX(currency.amount, profile, decimalPlaces);
+	return `${numberTex}~\\mathrm{${escapeTexRoman(currency.definition.code)}}`;
+}
+
+function escapeTexRoman(value: string): string {
+	return value.replace(/([{}#$%&_])/gu, '\\$1');
 }
 
 function legacyResultToTeX(

--- a/src/formatting/resultFormatter.ts
+++ b/src/formatting/resultFormatter.ts
@@ -54,7 +54,7 @@ class DefaultResultFormatter implements ResultFormatter {
 		this.preProcessors = [...(config.preProcessors ?? [])];
 		this.currencies = config.currencies;
 		this.currencyPrecisionMode = config.currencyPrecisionMode ??
-			CurrencyPrecisionMode.FollowNumberFormat;
+			CurrencyPrecisionMode.CurrencyStandard;
 		this.currencyDisplayMode = config.currencyDisplayMode ??
 			CurrencyDisplayMode.Code;
 	}

--- a/src/formatting/types.ts
+++ b/src/formatting/types.ts
@@ -40,7 +40,7 @@ export interface FormattedResult {
 	text: string;
 	/** MathJax-ready TeX source. */
 	tex: string;
-	/** Persistable output. PR 1 intentionally preserves legacy text here. */
+	/** Persistable output; currency symbols are normalized to active unit codes. */
 	canonical: string;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -363,7 +363,7 @@ export default class NumeralsPlugin extends Plugin {
 			currencies: this.currencyRegistry,
 			preProcessors: this.preProcessors,
 			currencyPrecisionMode: this.settings.currencyPrecisionMode ??
-				CurrencyPrecisionMode.FollowNumberFormat,
+				CurrencyPrecisionMode.CurrencyStandard,
 			currencyDisplayMode: this.settings.currencyDisplayMode ??
 				CurrencyDisplayMode.Code,
 		});

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,12 +12,15 @@ import { getMetadataForFileAtPath, addGlobalsFromScopeToPageCache } from "./proc
 import { createInlineNumeralsPostProcessor, createInlineLivePreviewExtension } from "./inline";
 import {
 	CurrencyType,
+	CurrencyDisplayMode,
+	CurrencyPrecisionMode,
 	NumeralsLayout,
 	NumeralsRenderStyle,
 	NumeralsSettings,
 	DEFAULT_SETTINGS,
 	NumeralsScope,
 	StringReplaceMap,
+	normalizeCurrencyFormattingSettings,
 } from "./numerals.types";
 import {
 	NumeralsSettingTab,
@@ -292,7 +295,13 @@ export default class NumeralsPlugin extends Plugin {
 
 	async loadSettings() {
 		const loadData = await this.loadData() as Partial<NumeralsSettings> & Record<string, unknown> | undefined;
+		let shouldSaveSettings = false;
 		if (loadData) {
+			if (normalizeCurrencyFormattingSettings(loadData)) {
+				console.warn('Numerals: Repaired invalid currency formatting settings');
+				shouldSaveSettings = true;
+			}
+
 			// Check for signature of old setting format, then port to new setting format
 			if (loadData.layoutStyle == undefined) {
 				const oldRenderStyleMap: Record<number, NumeralsLayout> = {
@@ -304,8 +313,7 @@ export default class NumeralsPlugin extends Plugin {
 				loadData.layoutStyle = oldRenderStyleMap[loadData['renderStyle'] as number];
 				if (loadData.layoutStyle) {
 					delete loadData['renderStyle'];
-					this.settings = loadData as NumeralsSettings;
-					void this.saveSettings();
+					shouldSaveSettings = true;
 				} else {
 					console.warn("Numerals: Error porting old layout style");
 				}
@@ -321,8 +329,7 @@ export default class NumeralsPlugin extends Plugin {
 
 				loadData.layoutStyle = oldLayoutStyleMap[loadData.layoutStyle as unknown as number];
 				if (loadData.layoutStyle) {
-					this.settings = loadData as NumeralsSettings;
-					void this.saveSettings();
+					shouldSaveSettings = true;
 				} else {
 					console.warn("Numerals: Error porting old layout style");
 				}
@@ -330,6 +337,9 @@ export default class NumeralsPlugin extends Plugin {
 		}
 
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, loadData);
+		if (shouldSaveSettings) {
+			await this.saveSettings();
+		}
 	}
 
 	async saveSettings() {
@@ -340,12 +350,22 @@ export default class NumeralsPlugin extends Plugin {
 		this.updateFormatting();
 	}
 
-	private updateFormatting(): void {
-		this.currencyRegistry = CurrencyRegistry.create(this.currencyMap);
+	updateFormatting(): void {
+		const customCurrencyCode = this.settings.customCurrencySymbol?.currency.trim();
+		const fractionDigitsByCode = customCurrencyCode
+			? new Map([[customCurrencyCode, this.settings.customCurrencyDecimalPlaces]])
+			: undefined;
+		this.currencyRegistry = CurrencyRegistry.create(this.currencyMap, {
+			fractionDigitsByCode,
+		});
 		this.resultFormatter = createResultFormatter({
 			profile: createNumberFormatProfile(this.settings.numberFormat),
 			currencies: this.currencyRegistry,
 			preProcessors: this.preProcessors,
+			currencyPrecisionMode: this.settings.currencyPrecisionMode ??
+				CurrencyPrecisionMode.FollowNumberFormat,
+			currencyDisplayMode: this.settings.currencyDisplayMode ??
+				CurrencyDisplayMode.Code,
 		});
 	}
 }

--- a/src/numerals.types.ts
+++ b/src/numerals.types.ts
@@ -111,7 +111,7 @@ export const DEFAULT_SETTINGS: NumeralsSettings = {
 	provideSuggestions: 				true,
 	suggestionsIncludeMathjsSymbols: 	false,
 	numberFormat: 						NumeralsNumberFormat.System,
-	currencyPrecisionMode: 			CurrencyPrecisionMode.FollowNumberFormat,
+	currencyPrecisionMode: 			CurrencyPrecisionMode.CurrencyStandard,
 	currencyDisplayMode: 			CurrencyDisplayMode.Code,
 	customCurrencyDecimalPlaces: 	2,
 	forceProcessAllFrontmatter: 		false,
@@ -132,7 +132,7 @@ export const DEFAULT_SETTINGS: NumeralsSettings = {
 /**
  * Repair invalid persisted currency-formatting settings in place.
  * Missing properties are left untouched so older settings files can inherit
- * compatibility defaults without being rewritten merely by loading Numerals.
+ * current defaults without being rewritten merely by loading Numerals.
  *
  * @returns Whether any present property was repaired.
  */

--- a/src/numerals.types.ts
+++ b/src/numerals.types.ts
@@ -50,6 +50,19 @@ export enum NumeralsNumberFormat {
 	Format_Indian = "Format_Indian"
 }
 
+export enum CurrencyPrecisionMode {
+	FollowNumberFormat = 'follow-number-format',
+	CurrencyStandard = 'currency-standard',
+}
+
+export enum CurrencyDisplayMode {
+	Code = 'code',
+	Symbol = 'symbol',
+}
+
+export const MIN_CURRENCY_DECIMAL_PLACES = 0;
+export const MAX_CURRENCY_DECIMAL_PLACES = 20;
+
 interface CurrencySymbolMapping {
 	symbol: string;
 	currency: string; // ISO 4217 Currency Code
@@ -67,6 +80,9 @@ export interface NumeralsSettings {
 	provideSuggestions: boolean;
 	suggestionsIncludeMathjsSymbols: boolean;
 	numberFormat: NumeralsNumberFormat;
+	currencyPrecisionMode: CurrencyPrecisionMode;
+	currencyDisplayMode: CurrencyDisplayMode;
+	customCurrencyDecimalPlaces: number;
 	forceProcessAllFrontmatter: boolean;
 	customCurrencySymbol: CurrencyType | null;
 	enableGreekAutoComplete: boolean;
@@ -95,6 +111,9 @@ export const DEFAULT_SETTINGS: NumeralsSettings = {
 	provideSuggestions: 				true,
 	suggestionsIncludeMathjsSymbols: 	false,
 	numberFormat: 						NumeralsNumberFormat.System,
+	currencyPrecisionMode: 			CurrencyPrecisionMode.FollowNumberFormat,
+	currencyDisplayMode: 			CurrencyDisplayMode.Code,
+	customCurrencyDecimalPlaces: 	2,
 	forceProcessAllFrontmatter: 		false,
 	customCurrencySymbol: 				null,
 	enableGreekAutoComplete: 			true,
@@ -108,6 +127,53 @@ export const DEFAULT_SETTINGS: NumeralsSettings = {
 	provideInlineSuggestions:			true,
 	// Cross-note reference settings
 	enableCrossNoteReferences:			true,
+}
+
+/**
+ * Repair invalid persisted currency-formatting settings in place.
+ * Missing properties are left untouched so older settings files can inherit
+ * compatibility defaults without being rewritten merely by loading Numerals.
+ *
+ * @returns Whether any present property was repaired.
+ */
+export function normalizeCurrencyFormattingSettings(
+	data: Record<string, unknown>
+): boolean {
+	let changed = false;
+	const hasOwn = (key: string): boolean => Object.prototype.hasOwnProperty.call(data, key);
+
+	if (
+		hasOwn('currencyPrecisionMode') &&
+		data['currencyPrecisionMode'] !== CurrencyPrecisionMode.FollowNumberFormat &&
+		data['currencyPrecisionMode'] !== CurrencyPrecisionMode.CurrencyStandard
+	) {
+		data['currencyPrecisionMode'] = DEFAULT_SETTINGS.currencyPrecisionMode;
+		changed = true;
+	}
+
+	if (
+		hasOwn('currencyDisplayMode') &&
+		data['currencyDisplayMode'] !== CurrencyDisplayMode.Code &&
+		data['currencyDisplayMode'] !== CurrencyDisplayMode.Symbol
+	) {
+		data['currencyDisplayMode'] = DEFAULT_SETTINGS.currencyDisplayMode;
+		changed = true;
+	}
+
+	if (hasOwn('customCurrencyDecimalPlaces')) {
+		const decimalPlaces = data['customCurrencyDecimalPlaces'];
+		if (
+			typeof decimalPlaces !== 'number' ||
+			!Number.isInteger(decimalPlaces) ||
+			decimalPlaces < MIN_CURRENCY_DECIMAL_PLACES ||
+			decimalPlaces > MAX_CURRENCY_DECIMAL_PLACES
+		) {
+			data['customCurrencyDecimalPlaces'] = DEFAULT_SETTINGS.customCurrencyDecimalPlaces;
+			changed = true;
+		}
+	}
+
+	return changed;
 }
 
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,13 +5,21 @@
 import NumeralsPlugin from "./main";
 import { NumeralsSuggestor } from "./NumeralsSuggestor";
 import { htmlToElements } from "./rendering/displayUtils";
-import { NumeralsRenderStyle, NumeralsNumberFormat, NumeralsLayout } from "./numerals.types";
+import {
+	CurrencyDisplayMode,
+	CurrencyPrecisionMode,
+	MAX_CURRENCY_DECIMAL_PLACES,
+	MIN_CURRENCY_DECIMAL_PLACES,
+	NumeralsRenderStyle,
+	NumeralsNumberFormat,
+	NumeralsLayout,
+} from "./numerals.types";
 
 import {
-    PluginSettingTab,
-    App,
-    Setting,
-	ButtonComponent, TextComponent
+	PluginSettingTab,
+	App,
+	Setting,
+	ButtonComponent, DropdownComponent, TextComponent
  } from "obsidian";
 
 ///////////////////////////////////////////
@@ -231,6 +239,7 @@ export class NumeralsSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setHeading()
 			.setName("Number and currency formatting");
+		let customCurrencyDecimalPlacesDropDown: DropdownComponent | null = null;
 
 		new Setting(containerEl)
 			.setName('Rendered number format')
@@ -255,6 +264,68 @@ export class NumeralsSettingTab extends PluginSettingTab {
 					this.plugin.updateLocale();
 				});
 			})
+
+		new Setting(containerEl)
+			.setName('Currency precision')
+			.setDesc('Choose whether pure currency results follow the rendered number format or use standard currency decimal places, such as 2 for GBP and 0 for JPY.') // eslint-disable-line obsidianmd/ui/sentence-case
+			.addDropdown(dropDown => {
+				dropDown.addOption(
+					CurrencyPrecisionMode.FollowNumberFormat,
+					'Use rendered number format'
+				);
+				dropDown.addOption(
+					CurrencyPrecisionMode.CurrencyStandard,
+					'Use currency standard'
+				);
+				dropDown.setValue(this.plugin.settings.currencyPrecisionMode);
+				dropDown.onChange(async (value) => {
+					const precisionMode = value as CurrencyPrecisionMode;
+					this.plugin.settings.currencyPrecisionMode = precisionMode;
+					await this.plugin.saveSettings();
+					this.plugin.updateFormatting();
+					customCurrencyDecimalPlacesDropDown?.setDisabled(
+						precisionMode !== CurrencyPrecisionMode.CurrencyStandard
+					);
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('Currency display')
+			.setDesc('Choose whether pure currency results use their unit code or the symbol configured in Numerals. Compound units continue to use codes.') // eslint-disable-line obsidianmd/ui/sentence-case
+			.addDropdown(dropDown => {
+				dropDown.addOption(CurrencyDisplayMode.Code, 'Currency code (GBP)'); // eslint-disable-line obsidianmd/ui/sentence-case
+				dropDown.addOption(CurrencyDisplayMode.Symbol, 'Configured symbol (£)');
+				dropDown.setValue(this.plugin.settings.currencyDisplayMode);
+				dropDown.onChange(async (value) => {
+					this.plugin.settings.currencyDisplayMode = value as CurrencyDisplayMode;
+					await this.plugin.saveSettings();
+					this.plugin.updateFormatting();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('Custom currency decimal places')
+			.setDesc('Decimal places to use for a custom currency mapping. Standard currencies use their own currency-standard value.')
+			.addDropdown(dropDown => {
+				for (
+					let decimalPlaces = MIN_CURRENCY_DECIMAL_PLACES;
+					decimalPlaces <= MAX_CURRENCY_DECIMAL_PLACES;
+					decimalPlaces++
+				) {
+					const value = String(decimalPlaces);
+					dropDown.addOption(value, value);
+				}
+				dropDown.setValue(String(this.plugin.settings.customCurrencyDecimalPlaces));
+				dropDown.setDisabled(
+					this.plugin.settings.currencyPrecisionMode !== CurrencyPrecisionMode.CurrencyStandard
+				);
+				dropDown.onChange(async (value) => {
+					this.plugin.settings.customCurrencyDecimalPlaces = Number(value);
+					await this.plugin.saveSettings();
+					this.plugin.updateFormatting();
+				});
+				customCurrencyDecimalPlacesDropDown = dropDown;
+			});
 
 		new Setting(containerEl)
 			.setName('`$` symbol currency mapping')

--- a/tests/currencyFormattingIntegration.test.ts
+++ b/tests/currencyFormattingIntegration.test.ts
@@ -33,7 +33,6 @@ import {
 	type ResultFormatter,
 } from '../src/formatting';
 import { PlainRenderer, TeXRenderer } from '../src/renderers';
-import { resultToTeX } from '../src/rendering/texRendering';
 
 const activeCurrencies: CurrencyType[] = [
 	{ symbol: '$', unicode: 'x024', name: 'dollar', currency: 'USD' },
@@ -132,12 +131,7 @@ beforeAll(() => {
 });
 
 describe('currency formatting compatibility matrix', () => {
-	it.each([
-		['GBP', 120],
-		['USD', 120.1],
-		['JPY', 120.5],
-		['KWD', 120.1234],
-	])('keeps default settings byte-compatible for %s', (code, amount) => {
+	it('uses currency-standard precision and code display by default', () => {
 		const profile = createNumberFormatProfile(
 			NumeralsNumberFormat.System,
 			'en-US',
@@ -147,21 +141,16 @@ describe('currency formatting compatibility matrix', () => {
 			currencies: CurrencyRegistry.create(activeCurrencies, {
 				locale: 'en-US',
 			}),
-			currencyPrecisionMode: DEFAULT_SETTINGS.currencyPrecisionMode,
-			currencyDisplayMode: DEFAULT_SETTINGS.currencyDisplayMode,
 		});
-		const value = currency(amount, code);
-		const formatted = formatter.format(value);
-		const legacyText = math.format(value, profile.mathjsFormat);
 
 		expect(DEFAULT_SETTINGS.currencyPrecisionMode).toBe(
-			CurrencyPrecisionMode.FollowNumberFormat,
+			CurrencyPrecisionMode.CurrencyStandard,
 		);
 		expect(DEFAULT_SETTINGS.currencyDisplayMode).toBe(CurrencyDisplayMode.Code);
-		expect(formatted).toEqual({
-			text: legacyText,
-			tex: resultToTeX(value, []),
-			canonical: legacyText,
+		expect(formatter.format(currency(120, 'GBP'))).toEqual({
+			text: '120.00 GBP',
+			tex: '120.00~\\mathrm{GBP}',
+			canonical: '120.00 GBP',
 		});
 	});
 

--- a/tests/currencyFormattingIntegration.test.ts
+++ b/tests/currencyFormattingIntegration.test.ts
@@ -1,0 +1,369 @@
+jest.mock('obsidian', () => ({
+	finishRenderMath: jest.fn().mockResolvedValue(undefined),
+	renderMath: jest.fn((tex: string) => {
+		const span = document.createElement('span');
+		span.textContent = `TeX:${tex}`;
+		return span;
+	}),
+	sanitizeHTMLToDom: jest.fn((html: string) => {
+		const fragment = document.createDocumentFragment();
+		const div = document.createElement('div');
+		div.innerHTML = html;
+		fragment.appendChild(div);
+		return fragment;
+	}),
+}), { virtual: true });
+
+import * as math from 'mathjs';
+import {
+	CurrencyDisplayMode,
+	CurrencyPrecisionMode,
+	DEFAULT_SETTINGS,
+	NumeralsNumberFormat,
+	NumeralsRenderStyle,
+	type CurrencyType,
+	type LineRenderData,
+	type RenderContext,
+} from '../src/numerals.types';
+import {
+	createNumberFormatProfile,
+	createResultFormatter,
+	CurrencyRegistry,
+	type ResultFormatOverrides,
+	type ResultFormatter,
+} from '../src/formatting';
+import { PlainRenderer, TeXRenderer } from '../src/renderers';
+import { resultToTeX } from '../src/rendering/texRendering';
+
+const activeCurrencies: CurrencyType[] = [
+	{ symbol: '$', unicode: 'x024', name: 'dollar', currency: 'USD' },
+	{ symbol: '£', unicode: 'x00A3', name: 'pound', currency: 'GBP' },
+	{ symbol: '¥', unicode: 'x00A5', name: 'yen', currency: 'JPY' },
+	{ symbol: 'د.ك', unicode: 'x0000', name: 'dinar', currency: 'KWD' },
+	{ symbol: '¤', unicode: 'x00A4', name: 'custom', currency: 'XCU' },
+];
+
+interface FormatterOptions {
+	locale?: string;
+	format?: NumeralsNumberFormat;
+	precisionMode?: CurrencyPrecisionMode;
+	displayMode?: CurrencyDisplayMode;
+	currencyMap?: CurrencyType[];
+	customDigits?: number;
+}
+
+function ensureCurrencyUnit(code: string): void {
+	try {
+		math.createUnit(code, { aliases: [code.toLowerCase()] });
+	} catch {
+		// mathjs Unit registration is process-global across the Jest worker.
+	}
+}
+
+function createFormatter(options: FormatterOptions = {}): ResultFormatter {
+	const locale = options.locale ?? 'en-US';
+	const currencyMap = options.currencyMap ?? activeCurrencies;
+	const fractionDigitsByCode = new Map<string, number>();
+	if (options.customDigits !== undefined) {
+		fractionDigitsByCode.set('XCU', options.customDigits);
+	}
+
+	return createResultFormatter({
+		profile: createNumberFormatProfile(
+			options.format ?? NumeralsNumberFormat.System,
+			locale,
+		),
+		currencies: CurrencyRegistry.create(currencyMap, {
+			locale,
+			fractionDigitsByCode,
+		}),
+		currencyPrecisionMode: options.precisionMode ??
+			DEFAULT_SETTINGS.currencyPrecisionMode,
+		currencyDisplayMode: options.displayMode ??
+			DEFAULT_SETTINGS.currencyDisplayMode,
+	});
+}
+
+function currency(value: number, code: string): math.Unit {
+	return math.unit(value, code);
+}
+
+beforeAll(() => {
+	for (const { currency: code } of activeCurrencies) {
+		ensureCurrencyUnit(code);
+	}
+	ensureCurrencyUnit('CAD');
+
+	Object.defineProperty(HTMLElement.prototype, 'createEl', {
+		configurable: true,
+		value: function(
+			this: HTMLElement,
+			tag: string,
+			options?: { cls?: string | string[]; text?: string },
+		): HTMLElement {
+			const element = document.createElement(tag);
+			if (options?.cls) {
+				const classes = Array.isArray(options.cls)
+					? options.cls
+					: [options.cls];
+				element.classList.add(...classes);
+			}
+			if (options?.text !== undefined) {
+				element.textContent = options.text;
+			}
+			this.appendChild(element);
+			return element;
+		},
+	});
+
+	Object.defineProperty(HTMLElement.prototype, 'toggleClass', {
+		configurable: true,
+		value: function(this: HTMLElement, className: string, enabled: boolean) {
+			this.classList.toggle(className, enabled);
+		},
+	});
+
+	Object.defineProperty(HTMLElement.prototype, 'setText', {
+		configurable: true,
+		value: function(this: HTMLElement, text: string) {
+			this.textContent = text;
+		},
+	});
+});
+
+describe('currency formatting compatibility matrix', () => {
+	it.each([
+		['GBP', 120],
+		['USD', 120.1],
+		['JPY', 120.5],
+		['KWD', 120.1234],
+	])('keeps default settings byte-compatible for %s', (code, amount) => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.System,
+			'en-US',
+		);
+		const formatter = createResultFormatter({
+			profile,
+			currencies: CurrencyRegistry.create(activeCurrencies, {
+				locale: 'en-US',
+			}),
+			currencyPrecisionMode: DEFAULT_SETTINGS.currencyPrecisionMode,
+			currencyDisplayMode: DEFAULT_SETTINGS.currencyDisplayMode,
+		});
+		const value = currency(amount, code);
+		const formatted = formatter.format(value);
+		const legacyText = math.format(value, profile.mathjsFormat);
+
+		expect(DEFAULT_SETTINGS.currencyPrecisionMode).toBe(
+			CurrencyPrecisionMode.FollowNumberFormat,
+		);
+		expect(DEFAULT_SETTINGS.currencyDisplayMode).toBe(CurrencyDisplayMode.Code);
+		expect(formatted).toEqual({
+			text: legacyText,
+			tex: resultToTeX(value, []),
+			canonical: legacyText,
+		});
+	});
+
+	it.each([
+		['GBP', 1234.5, '1,234.50 GBP', '1234.50~\\mathrm{GBP}', '1234.50 GBP'],
+		['USD', 1234.5, '1,234.50 USD', '1234.50~\\mathrm{USD}', '1234.50 USD'],
+		['JPY', 1234.5, '1,235 JPY', '1235~\\mathrm{JPY}', '1235 JPY'],
+		['KWD', 1234.5, '1,234.500 KWD', '1234.500~\\mathrm{KWD}', '1234.500 KWD'],
+	])(
+		'uses currency-standard precision across all output forms for %s',
+		(code, amount, text, tex, canonical) => {
+			const formatter = createFormatter({
+				precisionMode: CurrencyPrecisionMode.CurrencyStandard,
+				displayMode: CurrencyDisplayMode.Code,
+			});
+
+			expect(formatter.format(currency(amount, code))).toEqual({
+				text,
+				tex,
+				canonical,
+			});
+		},
+	);
+
+	it('threads the custom-currency decimal setting through the registry', () => {
+		const settings = {
+			...DEFAULT_SETTINGS,
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			customCurrencyDecimalPlaces: 4,
+		};
+		const formatter = createFormatter({
+			precisionMode: settings.currencyPrecisionMode,
+			customDigits: settings.customCurrencyDecimalPlaces,
+		});
+
+		expect(formatter.format(currency(1.2, 'XCU'))).toEqual({
+			text: '1.2000 XCU',
+			tex: '1.2000~\\mathrm{XCU}',
+			canonical: '1.2000 XCU',
+		});
+	});
+
+	it('uses the configured symbol for a remapped dollar without changing canonical code', () => {
+		const remappedDollar: CurrencyType[] = [{
+			symbol: '$',
+			unicode: 'x024',
+			name: 'dollar',
+			currency: 'CAD',
+		}];
+		const formatter = createFormatter({
+			precisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			displayMode: CurrencyDisplayMode.Symbol,
+			currencyMap: remappedDollar,
+		});
+		const formatted = formatter.format(currency(1234.5, 'CAD'));
+
+		expect(formatted.text).toBe('$1,234.50');
+		expect(formatted.text).not.toContain('CA$');
+		expect(formatted.tex).toBe('\\dollar 1234.50');
+		expect(formatted.canonical).toBe('1234.50 CAD');
+	});
+});
+
+describe('currency formatting policy precedence', () => {
+	it('gives an explicit decimal override precedence over JPY standard digits', () => {
+		const formatter = createFormatter({
+			precisionMode: CurrencyPrecisionMode.CurrencyStandard,
+		});
+
+		expect(formatter.format(currency(1234.5, 'JPY'), {
+			decimalPlaces: 3,
+		})).toEqual({
+			text: '1,234.500 JPY',
+			tex: '1234.500~\\mathrm{JPY}',
+			canonical: '1234.500 JPY',
+		});
+	});
+
+	it('composes @format locale selection with standard currency precision', () => {
+		const formatter = createFormatter({
+			precisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			displayMode: CurrencyDisplayMode.Symbol,
+		});
+		const overrides: ResultFormatOverrides = {
+			numberFormat: NumeralsNumberFormat.Format_PeriodThousands_CommaDecimal,
+		};
+		const formatted = formatter.format(currency(1234.5, 'GBP'), overrides);
+
+		expect(formatted.text).toBe('1.234,50\u00a0£');
+		expect(formatted.tex).toBe('\\pound 1234.50');
+		expect(formatted.canonical).toBe('1234.50 GBP');
+	});
+
+	it('preserves @format notation while currency precision controls coefficient digits', () => {
+		const formatter = createFormatter({
+			precisionMode: CurrencyPrecisionMode.CurrencyStandard,
+		});
+		const formatted = formatter.format(currency(1250, 'GBP'), {
+			numberFormat: NumeralsNumberFormat.Exponential,
+		});
+
+		expect(formatted.text).toBe('1.25e+3 GBP');
+		expect(formatted.tex).toBe('1.25 \\times 10^{3}~\\mathrm{GBP}');
+		expect(formatted.canonical).toBe('1.25e+3 GBP');
+	});
+
+	it('formats pure derived currency but leaves compound currency on the profile', () => {
+		const formatter = createFormatter({
+			precisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			displayMode: CurrencyDisplayMode.Symbol,
+		});
+		const remaining = currency(80, 'GBP');
+		const derived = math.divide(remaining, 8) as math.Unit;
+		const compound = math.divide(
+			currency(0.00416, 'GBP'),
+			math.unit(1, 'hour'),
+		) as math.Unit;
+
+		expect(formatter.format(derived)).toEqual({
+			text: '£10.00',
+			tex: '\\pound 10.00',
+			canonical: '10.00 GBP',
+		});
+		expect(formatter.format(compound).text).toBe('0.004 GBP / hour');
+		expect(formatter.format(compound).text).not.toContain('£');
+		expect(derived.toNumber('GBP')).toBe(10);
+	});
+
+	it('rounds a negative midpoint consistently without mutating the Unit', () => {
+		const formatter = createFormatter({
+			precisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			displayMode: CurrencyDisplayMode.Symbol,
+		});
+		const value = currency(-1.255, 'GBP');
+		const before = value.toNumber('GBP');
+
+		expect(formatter.format(value)).toEqual({
+			text: '-£1.26',
+			tex: '-\\pound 1.26',
+			canonical: '-1.26 GBP',
+		});
+		expect(value.toNumber('GBP')).toBe(before);
+	});
+});
+
+describe('localized currency text with stable TeX and canonical output', () => {
+	it.each([
+		['en-US', '£1,234.50'],
+		['fr-FR', '1\u202f234,50\u00a0£'],
+		['ar-EG', '\u200f١٬٢٣٤٫٥٠\u00a0£'],
+	])('preserves locale digits, spacing, and bidi marks for %s', (locale, expectedText) => {
+		const formatter = createFormatter({
+			locale,
+			precisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			displayMode: CurrencyDisplayMode.Symbol,
+		});
+		const formatted = formatter.format(currency(1234.5, 'GBP'));
+
+		expect(formatted.text).toBe(expectedText);
+		expect(formatted.tex).toBe('\\pound 1234.50');
+		expect(formatted.canonical).toBe('1234.50 GBP');
+	});
+});
+
+describe('formatter consumers', () => {
+	it('keeps Plain and TeX block consumers on the same formatted result', async () => {
+		const formatter = createFormatter({
+			precisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			displayMode: CurrencyDisplayMode.Symbol,
+		});
+		const value = currency(1234.5, 'GBP');
+		const formatted = formatter.format(value);
+		const lineData: LineRenderData = {
+			index: 0,
+			rawInput: 'total = 1234.5 GBP',
+			processedInput: 'total = 1234.5 GBP',
+			result: value,
+			isEmpty: false,
+			isEmitter: false,
+			isHidden: false,
+			comment: null,
+		};
+		const context: RenderContext = {
+			renderStyle: NumeralsRenderStyle.Plain,
+			settings: DEFAULT_SETTINGS,
+			formatter,
+			formatOverrides: {},
+			preProcessors: [],
+		};
+		const plainContainer = document.createElement('div');
+		const texContainer = document.createElement('div');
+
+		new PlainRenderer().renderLine(plainContainer, lineData, context);
+		new TeXRenderer().renderLine(texContainer, lineData, {
+			...context,
+			renderStyle: NumeralsRenderStyle.TeX,
+		});
+		await Promise.resolve();
+
+		expect(plainContainer.querySelector('.numerals-result')?.textContent)
+			.toBe(`${DEFAULT_SETTINGS.resultSeparator}${formatted.text}`);
+		expect(texContainer.querySelector('.numerals-result')?.textContent)
+			.toBe(`TeX:${formatted.tex}`);
+	});
+});

--- a/tests/currencyRegistry.test.ts
+++ b/tests/currencyRegistry.test.ts
@@ -47,6 +47,18 @@ describe('CurrencyRegistry', () => {
 		expect(registry.get('KWD')?.fractionDigits).toBe(3);
 	});
 
+	it.each([-1, 1.5, 21])(
+		'ignores invalid configured fraction digit value %s',
+		(configuredDigits) => {
+			const registry = CurrencyRegistry.create(currencyMap, {
+				locale: 'en-US',
+				fractionDigitsByCode: new Map([['GBP', configuredDigits]]),
+			});
+
+			expect(registry.get('GBP')?.fractionDigits).toBe(2);
+		}
+	);
+
 	it('matches scalar-derived currency through public Unit APIs', () => {
 		const registry = CurrencyRegistry.create(currencyMap);
 		const remaining = math.unit(80, 'GBP');

--- a/tests/resultFormatter.test.ts
+++ b/tests/resultFormatter.test.ts
@@ -5,11 +5,17 @@ jest.mock('obsidian', () => ({
 }));
 
 import * as math from 'mathjs';
-import { NumeralsNumberFormat } from '../src/numerals.types';
+import {
+	CurrencyDisplayMode,
+	CurrencyPrecisionMode,
+	NumeralsNumberFormat,
+} from '../src/numerals.types';
 import {
 	createNumberFormatProfile,
 	createResultFormatter,
+	CurrencyRegistry,
 } from '../src/formatting';
+import type { CurrencyType } from '../src/numerals.types';
 import { resultToTeX } from '../src/rendering/texRendering';
 
 describe('ResultFormatter', () => {
@@ -163,5 +169,231 @@ describe('ResultFormatter', () => {
 		expect(formatted.tex).toContain('2.00');
 		expect(formatted.tex).toContain('3.00');
 		expect(formatted.tex).toContain('4.00');
+	});
+});
+
+const activeCurrencies: CurrencyType[] = [
+	{ symbol: '$', unicode: 'x024', name: 'dollar', currency: 'USD' },
+	{ symbol: '£', unicode: 'x00A3', name: 'pound', currency: 'GBP' },
+	{ symbol: '¥', unicode: 'x00A5', name: 'yen', currency: 'JPY' },
+	{ symbol: 'د.ك', unicode: 'x0000', name: 'dinar', currency: 'KWD' },
+	{ symbol: '¤', unicode: 'x00A4', name: 'custom', currency: 'XCU' },
+];
+
+function ensureCurrencyUnit(code: string): void {
+	try {
+		math.createUnit(code, { aliases: [code.toLowerCase()] });
+	} catch {
+		// mathjs units are global and another suite may already have created it.
+	}
+}
+
+describe('ResultFormatter currency presentation', () => {
+	beforeAll(() => {
+		for (const { currency } of activeCurrencies) {
+			ensureCurrencyUnit(currency);
+		}
+		ensureCurrencyUnit('CAD');
+	});
+
+	function registry(
+		currencyMap: CurrencyType[] = activeCurrencies,
+		fractionDigitsByCode: ReadonlyMap<string, number> = new Map([
+			['XCU', 4],
+		])
+	): CurrencyRegistry {
+		return CurrencyRegistry.create(currencyMap, {
+			locale: 'en-US',
+			fractionDigitsByCode,
+		});
+	}
+
+	it('preserves legacy output under the compatibility policies', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.System,
+			'en-US'
+		);
+		const formatter = createResultFormatter({
+			profile,
+			currencies: registry(),
+		});
+		const value = math.unit(1234.5, 'GBP');
+
+		const formatted = formatter.format(value);
+
+		expect(formatted.text).toBe(math.format(value, profile.mathjsFormat));
+		expect(formatted.tex).toBe(resultToTeX(value, []));
+		expect(formatted.canonical).toBe(formatted.text);
+	});
+
+	it('normalizes a pure currency alias to its code in canonical output', () => {
+		const profile = createNumberFormatProfile(
+			NumeralsNumberFormat.System,
+			'en-US'
+		);
+		const formatter = createResultFormatter({
+			profile,
+			currencies: registry(),
+		});
+		const formatted = formatter.format(math.unit(12, 'gbp'));
+
+		expect(formatted.text).toBe('12 gbp');
+		expect(formatted.canonical).toBe('12 GBP');
+	});
+
+	it('uses standard currency digits with code-suffix text and canonical output', () => {
+		const formatter = createResultFormatter({
+			profile: createNumberFormatProfile(NumeralsNumberFormat.System, 'en-US'),
+			currencies: registry(),
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			currencyDisplayMode: CurrencyDisplayMode.Code,
+		});
+
+		const formatted = formatter.format(math.unit(1234.5, 'GBP'));
+
+		expect(formatted.text).toBe('1,234.50 GBP');
+		expect(formatted.tex).toBe('1234.50~\\mathrm{GBP}');
+		expect(formatted.canonical).toBe('1234.50 GBP');
+	});
+
+	it.each([
+		['USD', 1234.5, '1,234.50 USD'],
+		['JPY', 1234.5, '1,235 JPY'],
+		['KWD', 1.2345, '1.235 KWD'],
+		['XCU', 1.23454, '1.2345 XCU'],
+	])('uses registered standard/custom digits for %s', (code, value, expected) => {
+		const formatter = createResultFormatter({
+			profile: createNumberFormatProfile(NumeralsNumberFormat.System, 'en-US'),
+			currencies: registry(),
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
+		});
+
+		expect(formatter.format(math.unit(value, code)).text).toBe(expected);
+	});
+
+	it('gives @decimalPlaces precedence over currency-standard digits', () => {
+		const formatter = createResultFormatter({
+			profile: createNumberFormatProfile(NumeralsNumberFormat.System, 'en-US'),
+			currencies: registry(),
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
+		});
+
+		const formatted = formatter.format(math.unit(1.2345, 'GBP'), {
+			decimalPlaces: 3,
+		});
+
+		expect(formatted.text).toBe('1.235 GBP');
+		expect(formatted.tex).toBe('1.235~\\mathrm{GBP}');
+		expect(formatted.canonical).toBe('1.235 GBP');
+	});
+
+	it('places the configured symbol by locale and keeps canonical code output', () => {
+		const formatter = createResultFormatter({
+			profile: createNumberFormatProfile(NumeralsNumberFormat.System, 'en-US'),
+			currencies: registry(),
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			currencyDisplayMode: CurrencyDisplayMode.Symbol,
+		});
+
+		const formatted = formatter.format(math.unit(1234.5, 'GBP'));
+
+		expect(formatted.text).toBe('£1,234.50');
+		expect(formatted.tex).toBe('\\pound 1234.50');
+		expect(formatted.canonical).toBe('1234.50 GBP');
+	});
+
+	it('uses locale suffix placement and locale digits without replacing the configured symbol', () => {
+		const frenchFormatter = createResultFormatter({
+			profile: createNumberFormatProfile(
+				NumeralsNumberFormat.Format_SpaceThousands_CommaDecimal,
+				'en-US'
+			),
+			currencies: registry(),
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			currencyDisplayMode: CurrencyDisplayMode.Symbol,
+		});
+		const arabicProfile = createNumberFormatProfile(
+			NumeralsNumberFormat.System,
+			'ar-EG'
+		);
+		const arabicFormatter = createResultFormatter({
+			profile: arabicProfile,
+			currencies: registry(),
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			currencyDisplayMode: CurrencyDisplayMode.Symbol,
+		});
+
+		expect(frenchFormatter.format(math.unit(1234.5, 'GBP')).text).toBe(
+			'1\u202f234,50\u00a0£'
+		);
+
+		const arabic = arabicFormatter.format(math.unit(-1234.5, 'GBP')).text;
+		const expectedArabic = new Intl.NumberFormat('ar-EG', {
+			style: 'currency',
+			currency: 'GBP',
+			currencyDisplay: 'symbol',
+			minimumFractionDigits: 2,
+			maximumFractionDigits: 2,
+		}).formatToParts(-1234.5).map((part) =>
+			part.type === 'currency' ? '£' : part.value
+		).join('');
+		expect(arabic).toBe(expectedArabic);
+	});
+
+	it('rounds negative midpoints consistently across symbol, TeX, and canonical output', () => {
+		const formatter = createResultFormatter({
+			profile: createNumberFormatProfile(NumeralsNumberFormat.System, 'en-US'),
+			currencies: registry(),
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			currencyDisplayMode: CurrencyDisplayMode.Symbol,
+		});
+
+		const formatted = formatter.format(math.unit(-1.255, 'GBP'));
+
+		expect(formatted.text).toBe('-£1.26');
+		expect(formatted.tex).toBe('-\\pound 1.26');
+		expect(formatted.canonical).toBe('-1.26 GBP');
+	});
+
+	it('uses the configured remapped symbol instead of the Intl-selected symbol', () => {
+		const remappedMap: CurrencyType[] = [{
+			symbol: '$',
+			unicode: 'x024',
+			name: 'dollar',
+			currency: 'CAD',
+		}];
+		const formatter = createResultFormatter({
+			profile: createNumberFormatProfile(NumeralsNumberFormat.System, 'en-US'),
+			currencies: registry(remappedMap),
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			currencyDisplayMode: CurrencyDisplayMode.Symbol,
+		});
+
+		const formatted = formatter.format(math.unit(12.5, 'CAD'));
+
+		expect(formatted.text).toBe('$12.50');
+		expect(formatted.text).not.toContain('CA$');
+		expect(formatted.canonical).toBe('12.50 CAD');
+	});
+
+	it('formats scalar-derived currency but leaves compound currency Units general', () => {
+		const profile = createNumberFormatProfile(NumeralsNumberFormat.System, 'en-US');
+		const formatter = createResultFormatter({
+			profile,
+			currencies: registry(),
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			currencyDisplayMode: CurrencyDisplayMode.Symbol,
+		});
+		const derived = math.divide(math.unit(10, 'GBP'), 8) as math.Unit;
+		const compound = math.divide(
+			math.unit(1.234, 'GBP'),
+			math.unit(1, 'hour')
+		) as math.Unit;
+
+		expect(formatter.format(derived).text).toBe('£1.25');
+		expect(formatter.format(compound).text).toBe(
+			math.format(compound, profile.mathjsFormat)
+		);
+		expect(formatter.format(compound).text).toContain('GBP / hour');
 	});
 });

--- a/tests/resultFormatter.test.ts
+++ b/tests/resultFormatter.test.ts
@@ -208,7 +208,7 @@ describe('ResultFormatter currency presentation', () => {
 		});
 	}
 
-	it('preserves legacy output under the compatibility policies', () => {
+	it('supports rendered-number precision as an explicit compatibility policy', () => {
 		const profile = createNumberFormatProfile(
 			NumeralsNumberFormat.System,
 			'en-US'
@@ -216,6 +216,7 @@ describe('ResultFormatter currency presentation', () => {
 		const formatter = createResultFormatter({
 			profile,
 			currencies: registry(),
+			currencyPrecisionMode: CurrencyPrecisionMode.FollowNumberFormat,
 		});
 		const value = math.unit(1234.5, 'GBP');
 
@@ -226,7 +227,7 @@ describe('ResultFormatter currency presentation', () => {
 		expect(formatted.canonical).toBe(formatted.text);
 	});
 
-	it('normalizes a pure currency alias to its code in canonical output', () => {
+	it('normalizes a pure currency alias under the default currency policy', () => {
 		const profile = createNumberFormatProfile(
 			NumeralsNumberFormat.System,
 			'en-US'
@@ -237,8 +238,8 @@ describe('ResultFormatter currency presentation', () => {
 		});
 		const formatted = formatter.format(math.unit(12, 'gbp'));
 
-		expect(formatted.text).toBe('12 gbp');
-		expect(formatted.canonical).toBe('12 GBP');
+		expect(formatted.text).toBe('12.00 GBP');
+		expect(formatted.canonical).toBe('12.00 GBP');
 	});
 
 	it('uses standard currency digits with code-suffix text and canonical output', () => {

--- a/tests/settingsCurrencyFormatting.test.ts
+++ b/tests/settingsCurrencyFormatting.test.ts
@@ -8,9 +8,9 @@ import {
 } from '../src/numerals.types';
 
 describe('currency formatting settings', () => {
-	it('uses compatibility-safe defaults', () => {
+	it('uses currency-standard precision and code display by default', () => {
 		expect(DEFAULT_SETTINGS.currencyPrecisionMode).toBe(
-			CurrencyPrecisionMode.FollowNumberFormat
+			CurrencyPrecisionMode.CurrencyStandard
 		);
 		expect(DEFAULT_SETTINGS.currencyDisplayMode).toBe(CurrencyDisplayMode.Code);
 		expect(DEFAULT_SETTINGS.customCurrencyDecimalPlaces).toBe(2);
@@ -21,6 +21,9 @@ describe('currency formatting settings', () => {
 
 		expect(normalizeCurrencyFormattingSettings(data)).toBe(false);
 		expect(data).toEqual({ numberFormat: 'System' });
+		expect({ ...DEFAULT_SETTINGS, ...data }.currencyPrecisionMode).toBe(
+			CurrencyPrecisionMode.CurrencyStandard
+		);
 	});
 
 	it('leaves valid persisted settings unchanged', () => {
@@ -68,7 +71,7 @@ describe('currency formatting settings', () => {
 
 		expect(normalizeCurrencyFormattingSettings(data)).toBe(true);
 		expect(data).toEqual({
-			currencyPrecisionMode: CurrencyPrecisionMode.FollowNumberFormat,
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
 			currencyDisplayMode: CurrencyDisplayMode.Code,
 			customCurrencyDecimalPlaces: 4,
 			unrelated: true,

--- a/tests/settingsCurrencyFormatting.test.ts
+++ b/tests/settingsCurrencyFormatting.test.ts
@@ -1,0 +1,77 @@
+import {
+	CurrencyDisplayMode,
+	CurrencyPrecisionMode,
+	DEFAULT_SETTINGS,
+	MAX_CURRENCY_DECIMAL_PLACES,
+	MIN_CURRENCY_DECIMAL_PLACES,
+	normalizeCurrencyFormattingSettings,
+} from '../src/numerals.types';
+
+describe('currency formatting settings', () => {
+	it('uses compatibility-safe defaults', () => {
+		expect(DEFAULT_SETTINGS.currencyPrecisionMode).toBe(
+			CurrencyPrecisionMode.FollowNumberFormat
+		);
+		expect(DEFAULT_SETTINGS.currencyDisplayMode).toBe(CurrencyDisplayMode.Code);
+		expect(DEFAULT_SETTINGS.customCurrencyDecimalPlaces).toBe(2);
+	});
+
+	it('does not rewrite an older settings object with missing properties', () => {
+		const data: Record<string, unknown> = { numberFormat: 'System' };
+
+		expect(normalizeCurrencyFormattingSettings(data)).toBe(false);
+		expect(data).toEqual({ numberFormat: 'System' });
+	});
+
+	it('leaves valid persisted settings unchanged', () => {
+		const data: Record<string, unknown> = {
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			currencyDisplayMode: CurrencyDisplayMode.Symbol,
+			customCurrencyDecimalPlaces: 3,
+		};
+
+		expect(normalizeCurrencyFormattingSettings(data)).toBe(false);
+		expect(data).toEqual({
+			currencyPrecisionMode: CurrencyPrecisionMode.CurrencyStandard,
+			currencyDisplayMode: CurrencyDisplayMode.Symbol,
+			customCurrencyDecimalPlaces: 3,
+		});
+	});
+
+	it.each([MIN_CURRENCY_DECIMAL_PLACES, MAX_CURRENCY_DECIMAL_PLACES])(
+		'accepts the inclusive custom decimal-place boundary %i',
+		(customCurrencyDecimalPlaces) => {
+			const data: Record<string, unknown> = { customCurrencyDecimalPlaces };
+
+			expect(normalizeCurrencyFormattingSettings(data)).toBe(false);
+			expect(data['customCurrencyDecimalPlaces']).toBe(customCurrencyDecimalPlaces);
+		}
+	);
+
+	it.each([-1, 21, 1.5, Number.NaN, Number.POSITIVE_INFINITY, '2', null])(
+		'repairs invalid custom decimal places %p',
+		(customCurrencyDecimalPlaces) => {
+			const data: Record<string, unknown> = { customCurrencyDecimalPlaces };
+
+			expect(normalizeCurrencyFormattingSettings(data)).toBe(true);
+			expect(data['customCurrencyDecimalPlaces']).toBe(2);
+		}
+	);
+
+	it('repairs invalid modes without changing other properties', () => {
+		const data: Record<string, unknown> = {
+			currencyPrecisionMode: 'automatic',
+			currencyDisplayMode: 'narrow-symbol',
+			customCurrencyDecimalPlaces: 4,
+			unrelated: true,
+		};
+
+		expect(normalizeCurrencyFormattingSettings(data)).toBe(true);
+		expect(data).toEqual({
+			currencyPrecisionMode: CurrencyPrecisionMode.FollowNumberFormat,
+			currencyDisplayMode: CurrencyDisplayMode.Code,
+			customCurrencyDecimalPlaces: 4,
+			unrelated: true,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- use currency-standard precision by default for pure currency results
- keep currency-code display as the default and offer configured-symbol display with locale-aware order, spacing, digits, signs, and bidi marks
- use ISO minor digits for standard currencies and validated 0–20 digits for custom mappings
- retain **Use rendered number format** as an explicit compatibility option
- keep result insertion code-based even when display uses a symbol
- apply currency policy to scalar-derived currency while leaving compound rates on general Unit formatting
- add settings migration, UI controls, documentation, and a cross-policy integration matrix

## Policy

Precedence is:

`@decimalPlaces` > currency-standard digits > block `@format` profile > global number format

Formatting remains presentation-only. Raw Unit values stay in scope, so derived calculations do not inherit display rounding.

## Defaults and migration

The defaults are:

- precision: **Use currency standard**
- display: **Currency code**
- custom currency digits: **2**

Older settings files inherit those defaults without being rewritten. Present invalid values are repaired and persisted. Users who prefer the former general Unit presentation can select **Use rendered number format**.

## Adversarial review

The currency policy, registry, settings migration, locale behavior, insertion contract, derived/compound Unit handling, and compatibility matrix were independently reviewed with no additional actionable findings. This branch includes the reviewed #165 hardening.

## Validation

- `npm test -- --runInBand`: 20 suites, 532 tests, 8 snapshots
- `npm run lint`
- `npm run build`
- `npx tsc --noEmit`
- `git diff --check`
- legacy snapshot SHA-256 unchanged

Closes #160

## Stack

This PR is intentionally based on #165. Merge #165 first, then retarget this PR to `master`.
