### PR TITLE
feat: currency-aware display formatting with symbol restoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Added
 - Per-expression TeX rendering for Inline Numerals via the new `#$:` (result only) and `#=$:` (equation) trigger prefixes, which render with MathJax in both Live Preview and Reading mode. Both prefixes are configurable in settings. (Closes #161)
+- New **Currency result display** setting to choose between the currency symbol form (`$12.50`, default) and the ISO currency-code form (`12.50 USD`). (Closes #160, #75)
+
+### Changed
+- Pure currency results now display with their currency symbol and conventional decimal places by default (e.g. `$100/hr * 3 days` → `$7,200.00`, `1234 JPY` → `¥1,234`, `100 GBP / 3` → `£33.33`). Decimal conventions come from each currency's ISO minor units (JPY uses 0 decimals). Formatting is consistent across math blocks, Inline Numerals, TeX rendering, and result insertion. Compound units such as `$/hr` are unaffected. Inserted results (`@[name::value]`) always use the ISO-code form so stored values round-trip cleanly.
 
 ## [1.10.2] - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 | Show-your-work equations | `` `#=: 2 * (3ft + 4ft)` `` -> `2 * (3 ft + 4 ft) = 14 ft` |
 | Full math blocks | <code>```math<br>20 mi / 4 hr to m/s<br>```</code> -> `2.235 m / s` |
 | Units and conversions | `100 km/hr in mi/hr` -> `62.137 mi / hr` |
-| Currency math | `$100/hr * 3 days` -> `7,200 USD` |
+| Currency math | `$100/hr * 3 days` -> `$7,200.00` |
 | Note-wide variables | `$rate = $150/hr`, then `` `#: $rate * 40hr` `` |
 | Cross-note references | `[[Client Settings]].rates.hourly * 8hr` |
-| Result insertion | `@[profit] = revenue - expenses` writes `@[profit::10 USD]` |
+| Result insertion | `@[profit] = revenue - expenses` writes `@[profit::10.00 USD]` |
 
 ## Quick Start
 
@@ -88,13 +88,13 @@ Numerals uses [mathjs](https://mathjs.org/) for calculations and adds Obsidian-f
 | --- | --- |
 | Units | `1ft + 12in` -> `2 ft` |
 | Conversions | `72 degF to degC` -> `22.222 degC` |
-| Currency | `$1,000 * 2` -> `2,000 USD` |
-| Rates | `$100/hr * 3 days` -> `7,200 USD` |
+| Currency | `$1,000 * 2` -> `$2,000.00` |
+| Rates | `$100/hr * 3 days` -> `$7,200.00` |
 | Functions | `sqrt(144)`, `sin(pi/2)`, `log(1000, 10)` |
 | Bases | `0xff + 0b100` -> `259` |
 | Fractions | `fraction(1/3) + fraction(1/4)` -> `7/12` |
 
-Currency symbols can be customized in settings.
+Currency results are shown with their currency symbol and conventional decimal places by default (`$2,000.00`, `¥1,234`, `£33.33`). Set **Currency result display** to *Currency code* if you prefer the ISO-code form (`2,000.00 USD`). Compound rates such as `$/hr` keep their existing formatting, and inserted results (`@[name::value]`) always use the ISO-code form. Currency symbols and their mapped codes can be customized in settings.
 
 ### Note-Wide Variables
 
@@ -197,8 +197,10 @@ Use `@[label]` to write a result back into the raw note as Dataview-style inline
 Numerals updates the source text to:
 
 ```markdown
-@[profit::1,550 USD]
+@[profit::1,550.00 USD]
 ```
+
+Inserted results always use the ISO currency-code form (with conventional decimal places) so stored values round-trip cleanly, even when currency results are shown with their symbol elsewhere.
 
 ### Auto-Complete
 

--- a/docs/currency-display-formatting.md
+++ b/docs/currency-display-formatting.md
@@ -1,0 +1,114 @@
+# Currency Display Formatting
+
+## Goal
+
+Pure currency results should read like money: shown with the currency symbol and
+the currency's conventional number of decimal places, without changing how
+Numerals evaluates expressions. Examples (default settings):
+
+- `$120` displays as `$120.00`
+- `$120.1` displays as `$120.10`
+- `$120.3499` displays as `$120.35`
+- `100 GBP / 3` displays as `£33.33` (negative: `-£33.33`)
+- `1234 JPY` displays as `¥1,234` (JPY has no minor units)
+
+This is result-formatting behavior only. Numerals still uses mathjs for
+evaluation and still creates mathjs units for configured currency codes. No
+mathjs internals are monkey-patched for display.
+
+## Display Context
+
+All result formatting flows through a single `NumeralsDisplayContext`, built once
+per render in `NumeralsPlugin.getDisplayContext()` and threaded through every
+rendering surface:
+
+```ts
+interface NumeralsDisplayContext {
+    numberFormat: mathjsFormat;        // resolved global number format
+    hasExplicitFormat?: boolean;       // set by a future @format directive
+    currencies: ReadonlyArray<CurrencyType>;  // active symbol ↔ code map
+    currencyDisplay: CurrencyResultDisplay;   // Symbol (default) or CurrencyCode
+}
+```
+
+`formatNumeralsResult(value, ctx)` is the single result → string chokepoint.
+
+## Detection
+
+Currency display formatting applies only when the evaluated value is a mathjs
+`Unit` that is a pure configured currency (`getPureCurrencyInfo`):
+
+- The result is a mathjs Unit.
+- The Unit has exactly one unit component.
+- The component power is `1`.
+- The Unit's numeric value is a finite number (a valueless unit such as bare
+  `USD` is skipped).
+- The component unit name is one of the active currency codes Numerals created
+  from the currency map.
+
+Currency codes come from the active Numerals currency configuration, including
+`$` and `¥` remappings and custom currency mappings — nothing is hard-coded to
+USD.
+
+## Minor Units
+
+The conventional number of decimal places (minor units) for a currency is
+resolved from the platform via `Intl.NumberFormat` and cached per code:
+
+```ts
+new Intl.NumberFormat('en-US', { style: 'currency', currency: code })
+    .resolvedOptions().maximumFractionDigits
+```
+
+USD/GBP/EUR/INR resolve to 2, JPY resolves to 0. Codes that `Intl` cannot
+resolve (e.g. custom non-ISO codes) fall back to 2.
+
+## Display Modes
+
+The **Currency result display** setting selects between two modes:
+
+- **Currency symbol** (default): `$12.50`, `€120,00`, `¥1,234`. The symbol is
+  prefixed and any negative sign stays outside it (`-£12.50`).
+- **Currency code**: `12.50 USD` — the pre-existing ISO-code form.
+
+The numeric part respects the selected number format's locale, so grouping and
+decimal separators follow the locale (e.g. de-DE renders `€120,00`). Values are
+rounded and padded to exactly the currency's minor-unit count.
+
+## Compound Units
+
+Compound currency units keep their existing number-format behavior — no symbol
+restoration and no forced decimals. Examples:
+
+- `$100/hr`
+- `$0.042/floz`
+- `USD / m^2`
+
+These often represent rates where money-display precision would destroy
+information, so they are left on the selected Numerals number format.
+
+## Rendering Surfaces
+
+The same context and helper are used everywhere Numerals displays or writes
+results:
+
+- **Block Plain / Syntax-highlight** rendering via the shared base renderer.
+- **Inline Numerals** in Reading mode and Live Preview via inline evaluation.
+- **TeX** result rendering. Pure currency bypasses the `math.parse(...).toTex()`
+  reconstruction and is built directly: symbol mode → `\pound 12.50`
+  (negative `-\pound 12.50`), code mode → `12.50~\mathrm{GBP}`. The numeric part
+  uses an en-US, no-grouping formatter (a constraint of the TeX path) with the
+  currency's conventional decimals.
+- **Result insertion** via `@[name::value]`. Inserted text is a storage/data
+  surface (round-tripped by Numerals and read by tools like Dataview), so it
+  **always uses the ISO-code form** (`@[total::120.10 USD]`) regardless of the
+  display setting. This keeps stored values unambiguous and avoids `$`
+  replacement-pattern hazards in the write-back. Conventional decimals still
+  apply.
+
+## Explicit Format Override
+
+`hasExplicitFormat` (reserved for a future block `@format` directive) suppresses
+the currency-convention decimals while keeping symbol/code display. For example,
+an explicit `fixed 4` format renders `100 USD / 3` as `$33.3333` — the directive
+wins on precision, but the currency is still shown with its symbol.

--- a/src/inline/inlineEvaluator.ts
+++ b/src/inline/inlineEvaluator.ts
@@ -1,8 +1,9 @@
 import * as math from 'mathjs';
 import { App } from 'obsidian';
-import { NumeralsScope, NumeralsSettings, mathjsFormat, StringReplaceMap, InlineEvaluationResult } from '../numerals.types';
+import { NumeralsScope, NumeralsSettings, NumeralsDisplayContext, StringReplaceMap, InlineEvaluationResult } from '../numerals.types';
 import { replaceStringsInTextFromMap } from '../processing/preprocessor';
 import { resolveCrossNoteReferences } from '../processing/crossNoteResolver';
+import { formatNumeralsResult } from '../rendering/displayUtils';
 
 /**
  * Evaluate a single inline expression against a scope.
@@ -14,7 +15,7 @@ import { resolveCrossNoteReferences } from '../processing/crossNoteResolver';
  *
  * @param expression - The math expression to evaluate (trigger prefix already stripped)
  * @param scope - Variable scope (note-globals + frontmatter)
- * @param numberFormat - mathjs format options for result display
+ * @param displayContext - Number format + currency-display configuration for the result
  * @param preProcessors - String replacement rules (currency, thousands, etc.)
  * @param prevResult - The raw result of the previous inline expression (for @prev support).
  *                     Pass `undefined` when there is no previous result.
@@ -27,7 +28,7 @@ import { resolveCrossNoteReferences } from '../processing/crossNoteResolver';
 export function evaluateInlineExpression(
 	expression: string,
 	scope: NumeralsScope,
-	numberFormat: mathjsFormat,
+	displayContext: NumeralsDisplayContext,
 	preProcessors: StringReplaceMap[],
 	prevResult?: unknown,
 	app?: App,
@@ -76,9 +77,7 @@ export function evaluateInlineExpression(
 		throw new Error('Expression produced no result');
 	}
 
-	const formatted = numberFormat !== undefined
-		? math.format(result, numberFormat)
-		: math.format(result);
+	const formatted = formatNumeralsResult(result, displayContext);
 
 	// Extract note-global ($-prefixed) variable assignments.
 	// Compare the local scope against the original to find new or changed $-keys.

--- a/src/inline/inlineLivePreview.ts
+++ b/src/inline/inlineLivePreview.ts
@@ -39,7 +39,8 @@ import { editorInfoField, editorLivePreviewField } from 'obsidian';
 import {
 	NumeralsSettings,
 	NumeralsScope,
-	mathjsFormat,
+	NumeralsDisplayContext,
+	CurrencyResultDisplay,
 	StringReplaceMap,
 	InlineNumeralsMode,
 	NumeralsRenderStyle,
@@ -49,11 +50,22 @@ import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing
 import { getActiveInlineTriggers, getInlineTriggers, parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
 import { getDataviewApi } from '../dataview';
+import { defaultCurrencyMap } from '../rendering/displayUtils';
 import {
 	preProcessorsEqual,
 	renderInlineInputContent,
 	renderInlineValueContent,
 } from './inlineRenderer';
+
+/**
+ * Fallback display context for widgets constructed without one (defensive; the
+ * decoration builder always supplies a real context).
+ */
+const FALLBACK_DISPLAY_CONTEXT: NumeralsDisplayContext = {
+	numberFormat: undefined,
+	currencies: defaultCurrencyMap,
+	currencyDisplay: CurrencyResultDisplay.Symbol,
+};
 
 /****************************************************
  * Formatting context helpers
@@ -147,6 +159,7 @@ export class InlineNumeralsWidget extends WidgetType {
 		private readonly rawResult: unknown = resultText,
 		private readonly processedExpression: string = rawExpression,
 		private readonly preProcessors: StringReplaceMap[] = [],
+		private readonly displayContext?: NumeralsDisplayContext,
 	) {
 		super();
 	}
@@ -217,7 +230,8 @@ export class InlineNumeralsWidget extends WidgetType {
 				this.resultText,
 				this.rawResult,
 				this.renderStyle,
-				this.preProcessors
+				this.preProcessors,
+				this.displayContext ?? FALLBACK_DISPLAY_CONTEXT
 			);
 
 			span.appendChild(inputEl);
@@ -234,7 +248,8 @@ export class InlineNumeralsWidget extends WidgetType {
 				this.resultText,
 				this.rawResult,
 				this.renderStyle,
-				this.preProcessors
+				this.preProcessors,
+				this.displayContext ?? FALLBACK_DISPLAY_CONTEXT
 			);
 
 			span.appendChild(valueEl);
@@ -260,7 +275,7 @@ interface PrevResultRef {
 interface DecorationContext {
 	settings: NumeralsSettings;
 	triggers: InlineTriggerSettings;
-	numberFormat: mathjsFormat | undefined;
+	displayContext: NumeralsDisplayContext;
 	preProcessors: StringReplaceMap[];
 	getScope: () => NumeralsScope;
 	scopeCache: Map<string, NumeralsScope>;
@@ -275,7 +290,7 @@ interface DecorationContext {
  */
 function createDecorationContext(
 	getSettings: () => NumeralsSettings,
-	getNumberFormat: () => mathjsFormat | undefined,
+	getDisplayContext: () => NumeralsDisplayContext,
 	preProcessors: StringReplaceMap[],
 	scopeCache: Map<string, NumeralsScope>,
 	app: App,
@@ -313,7 +328,7 @@ function createDecorationContext(
 	return {
 		settings,
 		triggers,
-		numberFormat: getNumberFormat(),
+		displayContext: getDisplayContext(),
 		preProcessors,
 		getScope,
 		scopeCache,
@@ -369,7 +384,7 @@ function tryBuildNodeDecoration(
 		const result = evaluateInlineExpression(
 			parsed.expression,
 			scope,
-			ctx.numberFormat,
+			ctx.displayContext,
 			ctx.preProcessors,
 			prevResultRef.value,
 			ctx.app,
@@ -423,6 +438,7 @@ function tryBuildNodeDecoration(
 		rawResult,
 		processedExpression,
 		ctx.preProcessors,
+		ctx.displayContext,
 	);
 
 	return Decoration.replace({ widget }).range(spanFrom, spanTo);
@@ -557,7 +573,7 @@ function updateDecorations(
  * as evaluated widgets in Obsidian's Live Preview mode.
  *
  * @param getSettings     - Returns current plugin settings (called on each update for hot-reload)
- * @param getNumberFormat - Returns the active mathjs number format
+ * @param getDisplayContext - Returns the active number-format + currency-display configuration
  * @param getPreProcessors - Returns current string replacement preprocessors (currency symbols, etc.)
  * @param scopeCache        - Shared cache of per-file variable scopes
  * @param app               - The Obsidian App instance
@@ -565,7 +581,7 @@ function updateDecorations(
  */
 export function createInlineLivePreviewExtension(
 	getSettings: () => NumeralsSettings,
-	getNumberFormat: () => mathjsFormat | undefined,
+	getDisplayContext: () => NumeralsDisplayContext,
 	getPreProcessors: () => StringReplaceMap[],
 	scopeCache: Map<string, NumeralsScope>,
 	app: App,
@@ -680,7 +696,7 @@ export function createInlineLivePreviewExtension(
 
 				return createDecorationContext(
 					getSettings,
-					getNumberFormat,
+					getDisplayContext,
 					getPreProcessors(),
 					scopeCache,
 					app,

--- a/src/inline/inlinePostProcessor.ts
+++ b/src/inline/inlinePostProcessor.ts
@@ -1,5 +1,5 @@
 import { App, MarkdownPostProcessorContext, MarkdownRenderChild } from 'obsidian';
-import { NumeralsSettings, NumeralsScope, mathjsFormat, StringReplaceMap, InlineNumeralsMode, InlineEvaluationResult, NumeralsRenderStyle } from '../numerals.types';
+import { NumeralsSettings, NumeralsScope, NumeralsDisplayContext, StringReplaceMap, InlineNumeralsMode, InlineEvaluationResult, NumeralsRenderStyle } from '../numerals.types';
 import { getMetadataForFileAtPath, getScopeFromFrontmatter } from '../processing/scope';
 import { getActiveInlineTriggers, getInlineTriggers, parseInlineExpression } from './inlineParser';
 import { evaluateInlineExpression } from './inlineEvaluator';
@@ -46,7 +46,8 @@ function renderInlineResult(
 	renderStyle: NumeralsRenderStyle,
 	result: InlineEvaluationResult,
 	settings: NumeralsSettings,
-	preProcessors: StringReplaceMap[]
+	preProcessors: StringReplaceMap[],
+	displayContext: NumeralsDisplayContext
 ): void {
 	codeEl.empty();
 	codeEl.addClass('numerals-inline');
@@ -72,7 +73,8 @@ function renderInlineResult(
 			result.formatted,
 			result.raw,
 			renderStyle,
-			preProcessors
+			preProcessors,
+			displayContext
 		);
 	} else {
 		codeEl.addClass('numerals-inline-result');
@@ -82,7 +84,8 @@ function renderInlineResult(
 			result.formatted,
 			result.raw,
 			renderStyle,
-			preProcessors
+			preProcessors,
+			displayContext
 		);
 	}
 }
@@ -137,7 +140,7 @@ function processInlineCodeElement(
 	codeEl: HTMLElement,
 	scope: NumeralsScope,
 	settings: NumeralsSettings,
-	numberFormat: mathjsFormat,
+	displayContext: NumeralsDisplayContext,
 	preProcessors: StringReplaceMap[],
 	prevResultRef: PrevResultRef,
 	scopeCache: Map<string, NumeralsScope>,
@@ -156,7 +159,7 @@ function processInlineCodeElement(
 		const result = evaluateInlineExpression(
 			parsed.expression,
 			scope,
-			numberFormat,
+			displayContext,
 			preProcessors,
 			prevResultRef.value,
 			app,
@@ -175,7 +178,7 @@ function processInlineCodeElement(
 			addGlobalsToScopeCache(scopeCache, sourcePath, result.globals);
 		}
 
-		renderInlineResult(codeEl, parsed.expression, parsed.mode, parsed.renderStyle, result, settings, preProcessors);
+		renderInlineResult(codeEl, parsed.expression, parsed.mode, parsed.renderStyle, result, settings, preProcessors, displayContext);
 		return { referencedPaths: result.referencedPaths };
 	} catch {
 		prevResultRef.value = undefined;
@@ -197,8 +200,8 @@ function processInlineCodeElement(
  * - Post-processors only fire on render, not on scroll
  *
  * @param app - The Obsidian App instance
- * @param settings - Plugin settings (read at call time for hot-reload)
- * @param numberFormat - Number formatting configuration
+ * @param getSettings - Returns current plugin settings (read at call time for hot-reload)
+ * @param getDisplayContext - Returns the active number-format + currency-display configuration
  * @param getPreProcessors - Returns current preprocessing rules (currency, thousands, etc.)
  * @param scopeCache - Shared scope cache for note-global variables
  * @returns The post-processor function (for registration with Plugin.registerMarkdownPostProcessor)
@@ -206,7 +209,7 @@ function processInlineCodeElement(
 export function createInlineNumeralsPostProcessor(
 	app: App,
 	getSettings: () => NumeralsSettings,
-	getNumberFormat: () => mathjsFormat,
+	getDisplayContext: () => NumeralsDisplayContext,
 	getPreProcessors: () => StringReplaceMap[],
 	scopeCache: Map<string, NumeralsScope>
 ): (el: HTMLElement, ctx: MarkdownPostProcessorContext) => void {
@@ -245,7 +248,7 @@ export function createInlineNumeralsPostProcessor(
 				preProcessors
 			);
 
-			const numberFormat = getNumberFormat();
+			const displayContext = getDisplayContext();
 
 			// Track previous result for @prev support.
 			// Resets per section (post-processor call), so @prev only chains
@@ -259,7 +262,7 @@ export function createInlineNumeralsPostProcessor(
 					codeEl,
 					scope,
 					currentSettings,
-					numberFormat,
+					displayContext,
 					preProcessors,
 					prevResultRef,
 					scopeCache,

--- a/src/inline/inlineRenderer.ts
+++ b/src/inline/inlineRenderer.ts
@@ -1,4 +1,4 @@
-import { NumeralsRenderStyle, StringReplaceMap } from '../numerals.types';
+import { NumeralsDisplayContext, NumeralsRenderStyle, StringReplaceMap } from '../numerals.types';
 import { mathjaxLoop } from '../rendering/displayUtils';
 import { expressionToTeX, resultToTeX } from '../rendering/texRendering';
 
@@ -52,13 +52,14 @@ export function renderInlineValueContent(
 	formattedResult: string,
 	rawResult: unknown,
 	renderStyle: NumeralsRenderStyle,
-	preProcessors: StringReplaceMap[]
+	preProcessors: StringReplaceMap[],
+	displayContext: NumeralsDisplayContext
 ): void {
 	renderTexOrText(
 		container,
 		formattedResult,
 		renderStyle,
-		() => resultToTeX(rawResult, preProcessors)
+		() => resultToTeX(rawResult, preProcessors, displayContext)
 	);
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
 	NumeralsRenderStyle,
 	NumeralsNumberFormat,
 	NumeralsSettings,
+	NumeralsDisplayContext,
 	mathjsFormat,
 	DEFAULT_SETTINGS,
 	NumeralsScope,
@@ -121,7 +122,7 @@ export default class NumeralsPlugin extends Plugin {
 			metadata,
 			type,
 			this.settings,
-			this.numberFormat,
+			this.getDisplayContext(),
 			this.preProcessors,
 			this.app
 		);
@@ -158,7 +159,7 @@ export default class NumeralsPlugin extends Plugin {
 				metadata,
 				type,
 				this.settings,
-				this.numberFormat,
+				this.getDisplayContext(),
 				this.preProcessors,
 				this.app
 			);
@@ -278,7 +279,7 @@ export default class NumeralsPlugin extends Plugin {
 			createInlineNumeralsPostProcessor(
 				this.app,
 				() => this.settings,
-				() => this.numberFormat,
+				() => this.getDisplayContext(),
 				() => this.preProcessors,
 				this.scopeCache
 			)
@@ -288,7 +289,7 @@ export default class NumeralsPlugin extends Plugin {
 		this.registerEditorExtension(
 			createInlineLivePreviewExtension(
 				() => this.settings,
-				() => this.numberFormat,
+				() => this.getDisplayContext(),
 				() => this.preProcessors,
 				this.scopeCache,
 				this.app
@@ -355,5 +356,18 @@ export default class NumeralsPlugin extends Plugin {
 
 	updateLocale(): void {
 		this.numberFormat = getMathjsFormat(this.settings.numberFormat);
+	}
+
+	/**
+	 * Build the display context threaded through every rendering surface.
+	 * Read live at render time so number-format and currency settings changes
+	 * take effect without re-registering processors.
+	 */
+	private getDisplayContext(): NumeralsDisplayContext {
+		return {
+			numberFormat: this.numberFormat,
+			currencies: this.currencyMap,
+			currencyDisplay: this.settings.currencyResultDisplay,
+		};
 	}
 }

--- a/src/numerals.types.ts
+++ b/src/numerals.types.ts
@@ -34,13 +34,26 @@ export enum NumeralsRenderStyle {
 
 export enum NumeralsNumberFormat {
 	System = "System",
-	Fixed = "Fixed",	
+	Fixed = "Fixed",
 	Exponential = "Exponential",
 	Engineering = "Engineering",
 	Format_CommaThousands_PeriodDecimal = "Format_CommaThousands_PeriodDecimal",
 	Format_PeriodThousands_CommaDecimal = "Format_PeriodThousands_CommaDecimal",
 	Format_SpaceThousands_CommaDecimal = "Format_SpaceThousands_CommaDecimal",
 	Format_Indian = "Format_Indian"
+}
+
+/**
+ * How a pure currency result is displayed.
+ *
+ * Applies only to results that are a single currency unit (e.g. `12.50 USD`).
+ * Compound units such as `$/hr` are unaffected.
+ */
+export enum CurrencyResultDisplay {
+	/** Prefix the currency symbol: `$12.50` (default) */
+	Symbol = "symbol",
+	/** Suffix the ISO currency code: `12.50 USD` (pre-existing behavior) */
+	CurrencyCode = "code",
 }
 
 interface CurrencySymbolMapping {
@@ -60,6 +73,7 @@ export interface NumeralsSettings {
 	provideSuggestions: boolean;
 	suggestionsIncludeMathjsSymbols: boolean;
 	numberFormat: NumeralsNumberFormat;
+	currencyResultDisplay: CurrencyResultDisplay;
 	forceProcessAllFrontmatter: boolean;
 	customCurrencySymbol: CurrencyType | null;
 	enableGreekAutoComplete: boolean;
@@ -88,6 +102,7 @@ export const DEFAULT_SETTINGS: NumeralsSettings = {
 	provideSuggestions: 				true,
 	suggestionsIncludeMathjsSymbols: 	false,
 	numberFormat: 						NumeralsNumberFormat.System,
+	currencyResultDisplay: 				CurrencyResultDisplay.Symbol,
 	forceProcessAllFrontmatter: 		false,
 	customCurrencySymbol: 				null,
 	enableGreekAutoComplete: 			true,
@@ -113,6 +128,28 @@ export interface CurrencyType {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type mathjsFormat = number | math.FormatOptions | ((item: any) => string) | undefined;
+
+/**
+ * Everything the result→string formatter needs to render a value.
+ *
+ * Replaces the ad-hoc threading of `numberFormat` alongside currency data.
+ * Built once per render (see `NumeralsPlugin.getDisplayContext`) and passed
+ * through the block, inline, TeX, and result-insertion surfaces.
+ */
+export interface NumeralsDisplayContext {
+	/** Resolved number format (global setting; a block `@format` directive may override it) */
+	numberFormat: mathjsFormat;
+	/**
+	 * True when a block `@format` directive set the format explicitly.
+	 * Suppresses currency-convention decimals so the directive wins.
+	 * (Reserved for the `@format` directive feature; unset in the base feature.)
+	 */
+	hasExplicitFormat?: boolean;
+	/** Active currency map (symbol ↔ ISO code), from plugin settings */
+	currencies: ReadonlyArray<CurrencyType>;
+	/** How pure currency results render (symbol vs. ISO code) */
+	currencyDisplay: CurrencyResultDisplay;
+}
 
 export class NumeralsScope extends Map<string, unknown>{}
 
@@ -198,8 +235,8 @@ export interface RenderContext {
 	renderStyle: NumeralsRenderStyle;
 	/** User settings affecting display and formatting */
 	settings: NumeralsSettings;
-	/** Number formatting configuration for displaying results */
-	numberFormat: mathjsFormat;
+	/** Number formatting and currency-display configuration for results */
+	displayContext: NumeralsDisplayContext;
 	/** String replacements to apply (e.g., currency symbols) */
 	preProcessors: StringReplaceMap[];
 }

--- a/src/numeralsUtilities.ts
+++ b/src/numeralsUtilities.ts
@@ -46,4 +46,8 @@ export {
 	mathjaxLoop,
 	getLocaleFormatter,
 	defaultCurrencyMap,
+	formatNumeralsResult,
+	formatPureCurrencyTeX,
+	getPureCurrencyInfo,
+	getCurrencyMinorUnits,
 } from './rendering/displayUtils';

--- a/src/renderers/BaseLineRenderer.ts
+++ b/src/renderers/BaseLineRenderer.ts
@@ -1,6 +1,6 @@
-import * as math from 'mathjs';
 import { LineRenderData, RenderContext } from '../numerals.types';
 import { renderComment } from '../rendering/linePreparation';
+import { formatNumeralsResult } from '../rendering/displayUtils';
 import { ILineRenderer } from './ILineRenderer';
 
 /**
@@ -90,7 +90,7 @@ export abstract class BaseLineRenderer implements ILineRenderer {
 	): void {
 		const formattedResult =
 			context.settings.resultSeparator +
-			math.format(lineData.result, context.numberFormat);
+			formatNumeralsResult(lineData.result, context.displayContext);
 		resultElement.setText(formattedResult);
 	}
 }

--- a/src/renderers/TeXRenderer.ts
+++ b/src/renderers/TeXRenderer.ts
@@ -94,7 +94,7 @@ export class TeXRenderer extends BaseLineRenderer {
 		lineData: LineRenderData,
 		context: RenderContext
 	): void {
-		const texResult = resultToTeX(lineData.result, context.preProcessors);
+		const texResult = resultToTeX(lineData.result, context.preProcessors, context.displayContext);
 
 		// Render with MathJax
 		const resultTexElement = resultElement.createEl('span', { cls: 'numerals-tex' });

--- a/src/rendering/displayUtils.ts
+++ b/src/rendering/displayUtils.ts
@@ -1,6 +1,6 @@
 import { finishRenderMath, renderMath, sanitizeHTMLToDom } from 'obsidian';
 import * as math from 'mathjs';
-import { CurrencyType } from '../numerals.types';
+import { CurrencyType, CurrencyResultDisplay, NumeralsDisplayContext, mathjsFormat } from '../numerals.types';
 
 const MAX_FIXED_FORMAT_LEADING_DECIMAL_ZEROES = 5;
 
@@ -166,4 +166,273 @@ function countLeadingDecimalZeroes(value: number): number {
 		return 0;
 	}
 	return Math.max(0, -Math.floor(Math.log10(absValue)) - 1);
+}
+
+/****************************************************
+ * Currency-aware result formatting
+ ****************************************************/
+
+/**
+ * A mathjs Unit narrowed to the fields Numerals inspects for currency
+ * detection: its component list and its numeric value.
+ */
+interface MathjsUnitWithComponents {
+	units: math.Unit['units'];
+	value: number | null;
+}
+
+/** Fallback minor-unit count for currencies Intl cannot resolve. */
+const DEFAULT_CURRENCY_MINOR_UNITS = 2;
+
+/** Cache of ISO code → conventional minor-unit (decimal) count. */
+const currencyMinorUnitsCache = new Map<string, number>();
+
+/**
+ * Resolve the number of conventional minor units (decimal places) for an ISO
+ * currency code via `Intl.NumberFormat`, cached per code.
+ *
+ * Examples: USD/GBP/EUR/INR → 2, JPY → 0. Codes that Intl cannot resolve
+ * (e.g. custom non-ISO codes) fall back to {@link DEFAULT_CURRENCY_MINOR_UNITS}.
+ *
+ * @param code - The ISO 4217 currency code (e.g. `"USD"`).
+ * @returns The conventional decimal-place count for the currency.
+ */
+export function getCurrencyMinorUnits(code: string): number {
+	const cached = currencyMinorUnitsCache.get(code);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	let minorUnits = DEFAULT_CURRENCY_MINOR_UNITS;
+	try {
+		const resolved = new Intl.NumberFormat('en-US', {
+			style: 'currency',
+			currency: code,
+		}).resolvedOptions();
+		minorUnits = resolved.maximumFractionDigits ?? DEFAULT_CURRENCY_MINOR_UNITS;
+	} catch {
+		minorUnits = DEFAULT_CURRENCY_MINOR_UNITS;
+	}
+
+	currencyMinorUnitsCache.set(code, minorUnits);
+	return minorUnits;
+}
+
+/**
+ * Determine whether a value is a "pure" currency result and, if so, resolve
+ * its ISO code and display symbol.
+ *
+ * A value is pure currency when it is a mathjs Unit with exactly one unit
+ * component at power 1, a finite numeric value, and a component unit name that
+ * matches an active currency code. Compound units (e.g. `$/hr`) and units with
+ * a null value return `null`.
+ *
+ * @param value - The evaluated result to inspect.
+ * @param currencies - The active currency map (symbol ↔ ISO code).
+ * @returns `{ code, symbol }` for a pure currency value, otherwise `null`.
+ */
+export function getPureCurrencyInfo(
+	value: unknown,
+	currencies: ReadonlyArray<CurrencyType>
+): { code: string; symbol: string } | null {
+	if (!math.isUnit(value)) {
+		return null;
+	}
+
+	const unit = value as unknown as MathjsUnitWithComponents;
+	if (unit.units.length !== 1) {
+		return null;
+	}
+
+	const [component] = unit.units;
+	if (component.power !== 1) {
+		return null;
+	}
+
+	if (typeof unit.value !== 'number' || !Number.isFinite(unit.value)) {
+		return null;
+	}
+
+	const code = component.unit.name;
+	const match = currencies.find(currency => currency.currency === code);
+	if (!match) {
+		return null;
+	}
+
+	return { code, symbol: match.symbol };
+}
+
+/**
+ * Format an evaluated result for display, restoring currency conventions.
+ *
+ * Non-currency values format exactly as before via `math.format`. Pure
+ * currency values are formatted with their conventional decimal places (unless
+ * `ctx.hasExplicitFormat` is set) and rendered either with the currency symbol
+ * (`$12.50`) or the ISO code (`12.50 USD`) per `ctx.currencyDisplay`.
+ *
+ * @param value - The evaluated result (number, Unit, matrix, etc.).
+ * @param ctx - Display context (number format + currency configuration).
+ * @returns The formatted display string.
+ */
+export function formatNumeralsResult(value: unknown, ctx: NumeralsDisplayContext): string {
+	const info = getPureCurrencyInfo(value, ctx.currencies);
+	if (!info) {
+		return ctx.numberFormat !== undefined
+			? math.format(value, ctx.numberFormat)
+			: math.format(value);
+	}
+
+	const numeric = formatPureCurrencyNumeric(value, info.code, ctx);
+	if (ctx.currencyDisplay === CurrencyResultDisplay.CurrencyCode) {
+		return `${numeric} ${info.code}`;
+	}
+	return applyCurrencySymbol(numeric, info.symbol);
+}
+
+/**
+ * Build the TeX string for a pure currency result, bypassing the
+ * `math.parse(...).toTex()` reconstruction path.
+ *
+ * The numeric part always uses an en-US, no-grouping formatter (a constraint of
+ * the TeX rendering path) with conventional decimals. Symbol mode emits e.g.
+ * `\pound 12.50` (sign outside: `-\pound 12.50`); code mode emits
+ * `12.50~\mathrm{GBP}`.
+ *
+ * @param value - The evaluated result to inspect.
+ * @param ctx - Display context (currency configuration).
+ * @returns The TeX string, or `null` when the value is not pure currency.
+ */
+export function formatPureCurrencyTeX(value: unknown, ctx: NumeralsDisplayContext): string | null {
+	const info = getPureCurrencyInfo(value, ctx.currencies);
+	if (!info) {
+		return null;
+	}
+
+	// The TeX path cannot carry grouping separators through parsing, so the
+	// numeric part is always formatted en-US without grouping.
+	const texCtx: NumeralsDisplayContext = {
+		...ctx,
+		numberFormat: getLocaleFormatter('en-US', { useGrouping: false }),
+	};
+	const numeric = formatPureCurrencyNumeric(value, info.code, texCtx);
+
+	if (ctx.currencyDisplay === CurrencyResultDisplay.CurrencyCode) {
+		return `${numeric}~\\mathrm{${info.code}}`;
+	}
+	return texCurrencyReplacement(applyCurrencySymbol(numeric, info.symbol));
+}
+
+/**
+ * Format the numeric portion of a pure currency value (no symbol, no code),
+ * applying conventional decimals unless an explicit format is in effect.
+ */
+function formatPureCurrencyNumeric(
+	value: unknown,
+	code: string,
+	ctx: NumeralsDisplayContext
+): string {
+	const minorUnits = getCurrencyMinorUnits(code);
+	const resolvedFormat = ctx.hasExplicitFormat
+		? ctx.numberFormat
+		: getCurrencyNumberFormat(ctx.numberFormat, minorUnits);
+	// `math.format(value, undefined)` matches `math.format(value)`, so an
+	// explicit-but-undefined format still formats with mathjs defaults.
+	const formatted = math.format(value, resolvedFormat);
+	return stripTrailingCurrencyCode(formatted, code);
+}
+
+/**
+ * Prefix a formatted numeric string with a currency symbol, keeping any
+ * negative sign outside the symbol (e.g. `-12.50` → `-£12.50`).
+ */
+function applyCurrencySymbol(numeric: string, symbol: string): string {
+	if (numeric.startsWith('-')) {
+		return `-${symbol}${numeric.slice(1)}`;
+	}
+	return `${symbol}${numeric}`;
+}
+
+/**
+ * Strip a trailing ` CODE` suffix produced by `math.format` on a Unit.
+ * Matches the exact unit code (custom codes may not be three letters).
+ */
+function stripTrailingCurrencyCode(formatted: string, code: string): string {
+	const suffix = ` ${code}`;
+	return formatted.endsWith(suffix)
+		? formatted.slice(0, -suffix.length)
+		: formatted;
+}
+
+/**
+ * Derive the mathjs format used for a pure currency's numeric part.
+ *
+ * Object/undefined base formats become `{ notation: 'fixed', precision: N }`.
+ * Callback (locale) formats are wrapped so the fraction is rounded and padded
+ * or truncated to exactly N digits, respecting the locale decimal separator.
+ */
+function getCurrencyNumberFormat(numberFormat: mathjsFormat, minorUnits: number): mathjsFormat {
+	if (typeof numberFormat === 'function') {
+		const baseFormatter = numberFormat;
+		return (value: unknown): string => {
+			if (typeof value === 'number') {
+				return formatNumberWithFixedDecimals(value, baseFormatter, minorUnits);
+			}
+			return math.format(value);
+		};
+	}
+
+	return { notation: 'fixed', precision: minorUnits };
+}
+
+/**
+ * Format a number through a locale formatter, then round and pad/truncate its
+ * fraction to exactly `decimals` digits (0 → no decimal separator at all).
+ */
+function formatNumberWithFixedDecimals(
+	value: number,
+	baseFormatter: (value: number) => string,
+	decimals: number
+): string {
+	if (!Number.isFinite(value)) {
+		return baseFormatter(value);
+	}
+
+	const roundedValue = roundToDecimalPlaces(value, decimals);
+	const formattedValue = baseFormatter(roundedValue);
+	// Locale formatters can fall back to exponential for extreme values; the
+	// fixed-decimal padding below does not apply to that notation.
+	if (/[eE][+-]?\d+$/.test(formattedValue)) {
+		return roundedValue.toFixed(decimals);
+	}
+
+	const decimalSeparator = getDecimalSeparator(baseFormatter);
+	const decimalIndex = formattedValue.lastIndexOf(decimalSeparator);
+
+	if (decimals === 0) {
+		// No fractional part wanted — drop any separator and digits after it.
+		return decimalIndex === -1 ? formattedValue : formattedValue.slice(0, decimalIndex);
+	}
+
+	if (decimalIndex === -1) {
+		return `${formattedValue}${decimalSeparator}${'0'.repeat(decimals)}`;
+	}
+
+	const fractionDigits = formattedValue.length - decimalIndex - decimalSeparator.length;
+	if (fractionDigits < decimals) {
+		return `${formattedValue}${'0'.repeat(decimals - fractionDigits)}`;
+	}
+	return formattedValue;
+}
+
+/** Round to N decimal places, nudging by EPSILON to avoid float artifacts. */
+function roundToDecimalPlaces(value: number, decimals: number): number {
+	const factor = 10 ** decimals;
+	return Math.round((value + Math.sign(value) * Number.EPSILON) * factor) / factor;
+}
+
+/** Detect the decimal separator a locale formatter uses (e.g. `.` or `,`). */
+function getDecimalSeparator(formatter: (value: number) => string): string {
+	const formatted = formatter(1.1);
+	const match = formatted.match(/1(\D+)1/u);
+	return match?.[1] ?? '.';
 }

--- a/src/rendering/displayUtils.ts
+++ b/src/rendering/displayUtils.ts
@@ -224,17 +224,21 @@ export function getCurrencyMinorUnits(code: string): number {
  *
  * A value is pure currency when it is a mathjs Unit with exactly one unit
  * component at power 1, a finite numeric value, and a component unit name that
- * matches an active currency code. Compound units (e.g. `$/hr`) and units with
- * a null value return `null`.
+ * matches an active currency code (case-insensitively, since Numerals registers
+ * lowercase and symbol aliases — `100 usd` reports `usd` as the unit name) or
+ * an active currency symbol. Compound units (e.g. `$/hr`) and units with a
+ * null value return `null`.
  *
  * @param value - The evaluated result to inspect.
  * @param currencies - The active currency map (symbol ↔ ISO code).
- * @returns `{ code, symbol }` for a pure currency value, otherwise `null`.
+ * @returns `{ code, symbol, unitName }` for a pure currency value — `code` is
+ * the canonical ISO code from the currency map, and `unitName` is the mathjs
+ * component name exactly as `math.format` will emit it — otherwise `null`.
  */
 export function getPureCurrencyInfo(
 	value: unknown,
 	currencies: ReadonlyArray<CurrencyType>
-): { code: string; symbol: string } | null {
+): { code: string; symbol: string; unitName: string } | null {
 	if (!math.isUnit(value)) {
 		return null;
 	}
@@ -253,13 +257,16 @@ export function getPureCurrencyInfo(
 		return null;
 	}
 
-	const code = component.unit.name;
-	const match = currencies.find(currency => currency.currency === code);
+	const unitName = component.unit.name;
+	const match = currencies.find(currency =>
+		currency.currency !== '' &&
+		(currency.currency.toUpperCase() === unitName.toUpperCase() || currency.symbol === unitName)
+	);
 	if (!match) {
 		return null;
 	}
 
-	return { code, symbol: match.symbol };
+	return { code: match.currency, symbol: match.symbol, unitName };
 }
 
 /**
@@ -282,7 +289,7 @@ export function formatNumeralsResult(value: unknown, ctx: NumeralsDisplayContext
 			: math.format(value);
 	}
 
-	const numeric = formatPureCurrencyNumeric(value, info.code, ctx);
+	const numeric = formatPureCurrencyNumeric(value, info, ctx);
 	if (ctx.currencyDisplay === CurrencyResultDisplay.CurrencyCode) {
 		return `${numeric} ${info.code}`;
 	}
@@ -314,7 +321,7 @@ export function formatPureCurrencyTeX(value: unknown, ctx: NumeralsDisplayContex
 		...ctx,
 		numberFormat: getLocaleFormatter('en-US', { useGrouping: false }),
 	};
-	const numeric = formatPureCurrencyNumeric(value, info.code, texCtx);
+	const numeric = formatPureCurrencyNumeric(value, info, texCtx);
 
 	if (ctx.currencyDisplay === CurrencyResultDisplay.CurrencyCode) {
 		return `${numeric}~\\mathrm{${info.code}}`;
@@ -325,20 +332,31 @@ export function formatPureCurrencyTeX(value: unknown, ctx: NumeralsDisplayContex
 /**
  * Format the numeric portion of a pure currency value (no symbol, no code),
  * applying conventional decimals unless an explicit format is in effect.
+ *
+ * Minor units resolve from the canonical ISO code, but the trailing unit
+ * suffix is stripped using the mathjs component name (`info.unitName`) since
+ * that is what `math.format` actually emits (e.g. `100.00 usd` for a
+ * lowercase-alias unit).
  */
 function formatPureCurrencyNumeric(
 	value: unknown,
-	code: string,
+	info: { code: string; unitName: string },
 	ctx: NumeralsDisplayContext
 ): string {
-	const minorUnits = getCurrencyMinorUnits(code);
+	const minorUnits = getCurrencyMinorUnits(info.code);
 	const resolvedFormat = ctx.hasExplicitFormat
 		? ctx.numberFormat
 		: getCurrencyNumberFormat(ctx.numberFormat, minorUnits);
 	// `math.format(value, undefined)` matches `math.format(value)`, so an
 	// explicit-but-undefined format still formats with mathjs defaults.
 	const formatted = math.format(value, resolvedFormat);
-	return stripTrailingCurrencyCode(formatted, code);
+	let numeric = stripTrailingCurrencyCode(formatted, info.unitName);
+	// A value that rounds to zero must not display a stray minus (mathjs fixed
+	// notation emits `-0.00` for negative values that round to zero).
+	if (numeric.startsWith('-') && !/[1-9]/.test(numeric)) {
+		numeric = numeric.slice(1);
+	}
+	return numeric;
 }
 
 /**
@@ -353,11 +371,13 @@ function applyCurrencySymbol(numeric: string, symbol: string): string {
 }
 
 /**
- * Strip a trailing ` CODE` suffix produced by `math.format` on a Unit.
- * Matches the exact unit code (custom codes may not be three letters).
+ * Strip a trailing ` unitName` suffix produced by `math.format` on a Unit.
+ * Matches the exact emitted unit name — the component name mathjs reports,
+ * which may be a lowercase or symbol alias rather than the canonical code
+ * (and custom codes may not be three letters), so no generic regex is used.
  */
-function stripTrailingCurrencyCode(formatted: string, code: string): string {
-	const suffix = ` ${code}`;
+function stripTrailingCurrencyCode(formatted: string, unitName: string): string {
+	const suffix = ` ${unitName}`;
 	return formatted.endsWith(suffix)
 		? formatted.slice(0, -suffix.length)
 		: formatted;
@@ -424,10 +444,16 @@ function formatNumberWithFixedDecimals(
 	return formattedValue;
 }
 
-/** Round to N decimal places, nudging by EPSILON to avoid float artifacts. */
+/**
+ * Round to N decimal places with half-away-from-zero tie-breaking, matching
+ * Intl's `halfExpand` and mathjs fixed notation. (Plain `Math.round` breaks
+ * ties toward +∞, which mis-rounds negative half-boundary values like -2.675.)
+ * Negative zero is normalized to positive zero so no stray minus is shown.
+ */
 function roundToDecimalPlaces(value: number, decimals: number): number {
 	const factor = 10 ** decimals;
-	return Math.round((value + Math.sign(value) * Number.EPSILON) * factor) / factor;
+	const rounded = Math.sign(value) * Math.round(Math.abs(value) * factor) / factor;
+	return rounded === 0 ? 0 : rounded;
 }
 
 /** Detect the decimal separator a locale formatter uses (e.g. `.` or `,`). */

--- a/src/rendering/orchestrator.ts
+++ b/src/rendering/orchestrator.ts
@@ -1,6 +1,5 @@
-import * as math from 'mathjs';
 import { App, MarkdownPostProcessorContext } from 'obsidian';
-import { NumeralsLayout, NumeralsRenderStyle, NumeralsSettings, NumeralsError, NumeralsBlockResult, mathjsFormat, NumeralsScope, StringReplaceMap, ProcessedBlock, EvaluationResult, RenderContext } from '../numerals.types';
+import { NumeralsLayout, NumeralsRenderStyle, NumeralsSettings, NumeralsError, NumeralsBlockResult, NumeralsDisplayContext, CurrencyResultDisplay, NumeralsScope, StringReplaceMap, ProcessedBlock, EvaluationResult, RenderContext } from '../numerals.types';
 import { RendererFactory } from '../renderers';
 import { getScopeFromFrontmatter } from '../processing/scope';
 import { preProcessBlockForNumeralsDirectives } from '../processing/preprocessor';
@@ -8,6 +7,7 @@ import { evaluateMathFromSourceStrings } from '../processing/evaluator';
 import { resolveCrossNoteReferences } from '../processing/crossNoteResolver';
 import { prepareLineData } from './linePreparation';
 import { findEditorForPath } from './editorNavigation';
+import { formatNumeralsResult } from './displayUtils';
 
 /**
  * Renders error information into the container element.
@@ -92,9 +92,15 @@ export function renderNumeralsBlock(
  * The insertion uses the format: @[variableName::calculatedValue]
  * where calculatedValue is the formatted result from evaluation.
  *
+ * Inserted values always use the ISO currency-code form (e.g. `12.50 USD`),
+ * regardless of the currency display setting: the inserted text is a data
+ * surface (round-tripped by Numerals and read by tools like Dataview), and
+ * keeping the code form avoids `$` replacement-pattern hazards in the write-back
+ * `String.replace`. Conventional decimals still apply.
+ *
  * @param results - Array of evaluated results
  * @param insertionLines - Array of line indices that have insertion directives
- * @param numberFormat - Format specification for displaying numbers
+ * @param displayContext - Number-format + currency-display configuration
  * @param ctx - Markdown post processor context (provides section info)
  * @param app - Obsidian App instance (provides editor access)
  * @param el - The HTML element being rendered (used to get section info)
@@ -108,7 +114,7 @@ export function renderNumeralsBlock(
  * handleResultInsertions(
  *   [100],
  *   [0],
- *   numberFormat,
+ *   displayContext,
  *   ctx,
  *   app,
  *   el
@@ -124,11 +130,16 @@ export function renderNumeralsBlock(
 export function handleResultInsertions(
 	results: unknown[],
 	insertionLines: number[],
-	numberFormat: mathjsFormat,
+	displayContext: NumeralsDisplayContext,
 	ctx: MarkdownPostProcessorContext,
 	app: App,
 	el: HTMLElement
 ): void {
+	// Inserted values are a data surface — always emit the ISO-code form.
+	const insertionContext: NumeralsDisplayContext = {
+		...displayContext,
+		currencyDisplay: CurrencyResultDisplay.CurrencyCode,
+	};
 	for (const i of insertionLines) {
 		const sectionInfo = ctx.getSectionInfo(el);
 		const lineStart = sectionInfo?.lineStart;
@@ -151,7 +162,7 @@ export function handleResultInsertions(
 
 		const curLine = lineStart + i + 1;
 		const sourceLine = editor.getLine(curLine);
-		const insertionValue = math.format(results[i], numberFormat);
+		const insertionValue = formatNumeralsResult(results[i], insertionContext);
 
 		// Replace @[variable] or @[variable::oldValue] with @[variable::newValue]
 		const modifiedSource = sourceLine.replace(
@@ -186,14 +197,14 @@ export function handleResultInsertions(
  * @param settings - A NumeralsSettings object that provides settings for the rendering process. These   
  * settings can control aspects such as the layout style, whether to alternate row colors, and whether   
  * to hide lines without markup when emitting.  
- * @param numberFormat - A mathjsFormat function that is used to format numbers in the Numerals block.  
- * @param preProcessors - An array of StringReplaceMap objects that specify text replacements to be   
- * made in the source string before it is processed.  
+ * @param displayContext - Number-format + currency-display configuration for results.
+ * @param preProcessors - An array of StringReplaceMap objects that specify text replacements to be
+ * made in the source string before it is processed.
  * @param app - The Obsidian App instance.
- *  
- * @returns void  
  *
- */  
+ * @returns void
+ *
+ */
 export function processAndRenderNumeralsBlockFromSource(
 	el: HTMLElement,
 	source: string,
@@ -201,7 +212,7 @@ export function processAndRenderNumeralsBlockFromSource(
 	metadata: {[key: string]: unknown} | undefined,
 	type: NumeralsRenderStyle | undefined,
 	settings: NumeralsSettings,
-	numberFormat: mathjsFormat,
+	displayContext: NumeralsDisplayContext,
 	preProcessors: StringReplaceMap[],
 	app: App
 ): NumeralsBlockResult {
@@ -259,7 +270,7 @@ export function processAndRenderNumeralsBlockFromSource(
 	handleResultInsertions(
 		evaluationResult.results,
 		processedBlock.blockInfo.insertion_lines,
-		numberFormat,
+		displayContext,
 		ctx,
 		app,
 		el
@@ -269,7 +280,7 @@ export function processAndRenderNumeralsBlockFromSource(
 	const renderContext: RenderContext = {
 		renderStyle: blockRenderStyle,
 		settings,
-		numberFormat,
+		displayContext,
 		preProcessors,
 	};
 

--- a/src/rendering/texRendering.ts
+++ b/src/rendering/texRendering.ts
@@ -1,10 +1,11 @@
 import * as math from 'mathjs';
-import { StringReplaceMap } from '../numerals.types';
+import { NumeralsDisplayContext, StringReplaceMap } from '../numerals.types';
 import {
 	texCurrencyReplacement,
 	unescapeSubscripts,
 	replaceSumMagicVariableInProcessedWithSumDirectiveFromRaw,
 	getLocaleFormatter,
+	formatPureCurrencyTeX,
 } from './displayUtils';
 
 /**
@@ -32,11 +33,21 @@ export function expressionToTeX(
 /**
  * Convert an evaluated mathjs result into TeX using the same no-grouping,
  * period-decimal formatting that block TeX rendering uses.
+ *
+ * Pure currency results bypass the `math.parse(...).toTex()` reconstruction and
+ * are built directly (symbol or ISO-code form) so their conventional decimals
+ * and symbol/sign placement survive rendering.
  */
 export function resultToTeX(
 	result: unknown,
-	preProcessors: StringReplaceMap[]
+	preProcessors: StringReplaceMap[],
+	displayContext: NumeralsDisplayContext
 ): string {
+	const currencyTex = formatPureCurrencyTeX(result, displayContext);
+	if (currencyTex !== null) {
+		return currencyTex;
+	}
+
 	let processedResult = math.format(
 		result,
 		getLocaleFormatter('en-US', { useGrouping: false })

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,7 +5,7 @@
 import NumeralsPlugin from "./main";
 import { NumeralsSuggestor } from "./NumeralsSuggestor";
 import { htmlToElements } from "./rendering/displayUtils";
-import { NumeralsRenderStyle, NumeralsNumberFormat, NumeralsLayout } from "./numerals.types";
+import { NumeralsRenderStyle, NumeralsNumberFormat, NumeralsLayout, CurrencyResultDisplay } from "./numerals.types";
 
 import {
     PluginSettingTab,
@@ -255,6 +255,19 @@ export class NumeralsSettingTab extends PluginSettingTab {
 					this.plugin.updateLocale();
 				});
 			})
+
+		new Setting(containerEl)
+			.setName('Currency result display')
+			.setDesc('Choose how pure currency results are displayed. Compound units (e.g. `$/hr`) are unaffected.')
+			.addDropdown(dropDown => {
+				dropDown.addOption(CurrencyResultDisplay.Symbol, 'Currency symbol ($12.50)');
+				dropDown.addOption(CurrencyResultDisplay.CurrencyCode, 'Currency code (12.50 USD)'); // eslint-disable-line obsidianmd/ui/sentence-case
+				dropDown.setValue(this.plugin.settings.currencyResultDisplay);
+				dropDown.onChange(async (value) => {
+					this.plugin.settings.currencyResultDisplay = value as CurrencyResultDisplay;
+					await this.plugin.saveSettings();
+				});
+			});
 
 		new Setting(containerEl)
 			.setName('`$` symbol currency mapping')

--- a/tests/__snapshots__/numeralsUtilities.test.ts.snap
+++ b/tests/__snapshots__/numeralsUtilities.test.ts.snap
@@ -114,7 +114,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 10 USD
+       → $10.00
     </span>
   </div>
   <div
@@ -129,7 +129,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20 USD
+       → $20.00
     </span>
   </div>
   <div
@@ -144,7 +144,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 30 USD
+       → $30.00
     </span>
   </div>
   <div
@@ -167,7 +167,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 60 USD
+       → $60.00
     </span>
   </div>
   <div
@@ -425,7 +425,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 100,000 USD
+       → $100,000.00
     </span>
   </div>
   <div
@@ -455,7 +455,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20,000 USD
+       → $20,000.00
     </span>
   </div>
   <div
@@ -680,7 +680,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 89.99 USD
+       → $89.99
     </span>
   </div>
   <div
@@ -875,7 +875,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 1,100 USD
+       → $1,100.00
     </span>
   </div>
   <div
@@ -1055,7 +1055,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 10 USD
+       → $10.00
     </span>
   </div>
   <div
@@ -1070,7 +1070,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20 USD
+       → $20.00
     </span>
   </div>
   <div
@@ -1085,7 +1085,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 30 USD
+       → $30.00
     </span>
   </div>
   <div
@@ -1108,7 +1108,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 60 USD
+       → $60.00
     </span>
   </div>
   <div
@@ -1366,7 +1366,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 100,000 USD
+       → $100,000.00
     </span>
   </div>
   <div
@@ -1396,7 +1396,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20,000 USD
+       → $20,000.00
     </span>
   </div>
   <div
@@ -1621,7 +1621,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 89.99 USD
+       → $89.99
     </span>
   </div>
   <div
@@ -1816,7 +1816,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 1,100 USD
+       → $1,100.00
     </span>
   </div>
   <div
@@ -1996,7 +1996,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 10 USD
+       → $10.00
     </span>
   </div>
   <div
@@ -2011,7 +2011,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20 USD
+       → $20.00
     </span>
   </div>
   <div
@@ -2026,7 +2026,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 30 USD
+       → $30.00
     </span>
   </div>
   <div
@@ -2049,7 +2049,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 60 USD
+       → $60.00
     </span>
   </div>
   <div
@@ -2307,7 +2307,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 100,000 USD
+       → $100,000.00
     </span>
   </div>
   <div
@@ -2337,7 +2337,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20,000 USD
+       → $20,000.00
     </span>
   </div>
   <div
@@ -2562,7 +2562,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 89.99 USD
+       → $89.99
     </span>
   </div>
   <div
@@ -2757,7 +2757,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 1,100 USD
+       → $1,100.00
     </span>
   </div>
   <div
@@ -2937,7 +2937,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 10 USD
+       → $10.00
     </span>
   </div>
   <div
@@ -2952,7 +2952,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20 USD
+       → $20.00
     </span>
   </div>
   <div
@@ -2967,7 +2967,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 30 USD
+       → $30.00
     </span>
   </div>
   <div
@@ -2990,7 +2990,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 60 USD
+       → $60.00
     </span>
   </div>
   <div
@@ -3248,7 +3248,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 100,000 USD
+       → $100,000.00
     </span>
   </div>
   <div
@@ -3278,7 +3278,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20,000 USD
+       → $20,000.00
     </span>
   </div>
   <div
@@ -3503,7 +3503,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 89.99 USD
+       → $89.99
     </span>
   </div>
   <div
@@ -3698,7 +3698,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 1,100 USD
+       → $1,100.00
     </span>
   </div>
   <div
@@ -3878,7 +3878,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 10 USD
+       → $10.00
     </span>
   </div>
   <div
@@ -3893,7 +3893,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20 USD
+       → $20.00
     </span>
   </div>
   <div
@@ -3908,7 +3908,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 30 USD
+       → $30.00
     </span>
   </div>
   <div
@@ -3931,7 +3931,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 60 USD
+       → $60.00
     </span>
   </div>
   <div
@@ -4189,7 +4189,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 100,000 USD
+       → $100,000.00
     </span>
   </div>
   <div
@@ -4219,7 +4219,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 20,000 USD
+       → $20,000.00
     </span>
   </div>
   <div
@@ -4444,7 +4444,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 89.99 USD
+       → $89.99
     </span>
   </div>
   <div
@@ -4639,7 +4639,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 1,100 USD
+       → $1,100.00
     </span>
   </div>
   <div
@@ -4900,7 +4900,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 1,100 USD
+       → $1,100.00
     </span>
   </div>
   <div
@@ -4915,7 +4915,7 @@ exports[`numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end t
     <span
       class="numerals-result"
     >
-       → 110 USD
+       → $110.00
     </span>
   </div>
 </div>

--- a/tests/currencyDisplay.test.ts
+++ b/tests/currencyDisplay.test.ts
@@ -71,7 +71,13 @@ describe('getCurrencyMinorUnits', () => {
 // ---------------------------------------------------------------------------
 describe('getPureCurrencyInfo', () => {
 	it('detects a pure currency unit', () => {
-		expect(getPureCurrencyInfo(value('100 USD'), defaultCurrencyMap)).toEqual({ code: 'USD', symbol: '$' });
+		expect(getPureCurrencyInfo(value('100 USD'), defaultCurrencyMap))
+			.toEqual({ code: 'USD', symbol: '$', unitName: 'USD' });
+	});
+
+	it('detects a lowercase-alias unit and returns the canonical code', () => {
+		expect(getPureCurrencyInfo(value('100 usd'), defaultCurrencyMap))
+			.toEqual({ code: 'USD', symbol: '$', unitName: 'usd' });
 	});
 
 	it('returns null for compound currency units', () => {
@@ -134,6 +140,33 @@ describe('formatNumeralsResult (symbol mode)', () => {
 	it('formats tiny values to $0.00', () => {
 		expect(formatNumeralsResult(value('0.0001 USD'), symbolContext())).toBe('$0.00');
 	});
+
+	it('rounds negative half-boundary values away from zero (locale format)', () => {
+		// Regression: Math.round breaks ties toward +∞, which under-rounded
+		// negative currency values at the half-minor-unit boundary.
+		const ctx = symbolContext(getLocaleFormatter('en-US'));
+		expect(formatNumeralsResult(value('-5.35 USD / 2'), ctx)).toBe('-$2.68');
+		expect(formatNumeralsResult(value('-5.005 USD'), ctx)).toBe('-$5.01');
+		expect(formatNumeralsResult(value('-120.345 USD'), ctx)).toBe('-$120.35');
+		expect(formatNumeralsResult(value('-10.01 USD / 2'), ctx)).toBe('-$5.01');
+	});
+
+	it('rounds negative half-boundary values away from zero (fixed format)', () => {
+		expect(formatNumeralsResult(value('-5.35 USD / 2'), symbolContext())).toBe('-$2.68');
+		expect(formatNumeralsResult(value('-120.345 USD'), symbolContext())).toBe('-$120.35');
+	});
+
+	it('shows no stray minus when a negative value rounds to zero', () => {
+		expect(formatNumeralsResult(value('-0.0001 USD'), symbolContext())).toBe('$0.00');
+		const ctx = symbolContext(getLocaleFormatter('en-US'));
+		expect(formatNumeralsResult(value('-0.0001 USD'), ctx)).toBe('$0.00');
+		expect(formatNumeralsResult(value('-0 USD'), ctx)).toBe('$0.00');
+	});
+
+	it('formats lowercase-alias units with the symbol: 100 usd → $100.00', () => {
+		expect(formatNumeralsResult(value('100 usd'), symbolContext())).toBe('$100.00');
+		expect(formatNumeralsResult(value('100 USD to usd'), symbolContext())).toBe('$100.00');
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -152,6 +185,11 @@ describe('formatNumeralsResult (code mode)', () => {
 	it('groups large values in code mode: 1,000,000.00 USD', () => {
 		const ctx = codeContext(getLocaleFormatter('en-US'));
 		expect(formatNumeralsResult(value('1000000 USD'), ctx)).toBe('1,000,000.00 USD');
+	});
+
+	it('renders lowercase-alias units with the canonical code: 100 usd → 100.00 USD', () => {
+		expect(formatNumeralsResult(value('100 usd'), codeContext())).toBe('100.00 USD');
+		expect(formatNumeralsResult(value('100 USD to usd'), codeContext())).toBe('100.00 USD');
 	});
 });
 
@@ -218,6 +256,11 @@ describe('formatPureCurrencyTeX', () => {
 	it('uses no grouping in the numeric part (TeX path constraint)', () => {
 		const ctx = symbolContext(getLocaleFormatter('en-US'));
 		expect(formatPureCurrencyTeX(value('1000000 USD'), ctx)).toBe('\\dollar 1000000.00');
+	});
+
+	it('renders lowercase-alias units with the canonical code in TeX', () => {
+		const ctx = codeContext();
+		expect(formatPureCurrencyTeX(value('100 usd'), ctx)).toBe('100.00~\\mathrm{USD}');
 	});
 
 	it('returns null for non-currency values', () => {

--- a/tests/currencyDisplay.test.ts
+++ b/tests/currencyDisplay.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for currency-aware display formatting (displayUtils).
+ *
+ * Covers pure-currency detection, Intl minor-unit resolution, symbol and
+ * code display modes, negatives, locale decimal separators, grouping,
+ * compound-unit passthrough, tiny values, and the hasExplicitFormat override.
+ */
+
+jest.mock('obsidian', () => ({
+	finishRenderMath: jest.fn(),
+	renderMath: jest.fn(),
+	sanitizeHTMLToDom: jest.fn(),
+}), { virtual: true });
+
+import * as math from 'mathjs';
+import {
+	formatNumeralsResult,
+	formatPureCurrencyTeX,
+	getPureCurrencyInfo,
+	getCurrencyMinorUnits,
+	getLocaleFormatter,
+	defaultCurrencyMap,
+} from '../src/rendering/displayUtils';
+import { CurrencyResultDisplay, NumeralsDisplayContext, mathjsFormat } from '../src/numerals.types';
+import { makeDisplayContext } from './testHelpers';
+
+// ---------------------------------------------------------------------------
+// Currency unit setup (mirrors the plugin's onload createUnit loop)
+// ---------------------------------------------------------------------------
+for (const moneyType of defaultCurrencyMap) {
+	if (moneyType.currency !== '') {
+		try {
+			math.createUnit(moneyType.currency, {
+				aliases: [moneyType.currency.toLowerCase(), moneyType.symbol],
+			});
+		} catch {
+			/* unit already exists */
+		}
+	}
+}
+
+const symbolContext = (numberFormat?: mathjsFormat): NumeralsDisplayContext =>
+	makeDisplayContext({ numberFormat, currencyDisplay: CurrencyResultDisplay.Symbol });
+const codeContext = (numberFormat?: mathjsFormat): NumeralsDisplayContext =>
+	makeDisplayContext({ numberFormat, currencyDisplay: CurrencyResultDisplay.CurrencyCode });
+
+const value = (expr: string): unknown => math.evaluate(expr);
+
+// ---------------------------------------------------------------------------
+// getCurrencyMinorUnits
+// ---------------------------------------------------------------------------
+describe('getCurrencyMinorUnits', () => {
+	it('resolves standard currencies to 2 minor units', () => {
+		expect(getCurrencyMinorUnits('USD')).toBe(2);
+		expect(getCurrencyMinorUnits('GBP')).toBe(2);
+		expect(getCurrencyMinorUnits('EUR')).toBe(2);
+		expect(getCurrencyMinorUnits('INR')).toBe(2);
+	});
+
+	it('resolves JPY to 0 minor units', () => {
+		expect(getCurrencyMinorUnits('JPY')).toBe(0);
+	});
+
+	it('falls back to 2 for unknown/custom codes', () => {
+		expect(getCurrencyMinorUnits('XYZ')).toBe(2);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getPureCurrencyInfo
+// ---------------------------------------------------------------------------
+describe('getPureCurrencyInfo', () => {
+	it('detects a pure currency unit', () => {
+		expect(getPureCurrencyInfo(value('100 USD'), defaultCurrencyMap)).toEqual({ code: 'USD', symbol: '$' });
+	});
+
+	it('returns null for compound currency units', () => {
+		expect(getPureCurrencyInfo(value('100 USD / hr'), defaultCurrencyMap)).toBeNull();
+	});
+
+	it('returns null for non-currency units', () => {
+		expect(getPureCurrencyInfo(value('3 ft'), defaultCurrencyMap)).toBeNull();
+	});
+
+	it('returns null for plain numbers', () => {
+		expect(getPureCurrencyInfo(120, defaultCurrencyMap)).toBeNull();
+	});
+
+	it('returns null for a currency unit with a null value', () => {
+		// `USD` on its own is a valueless unit
+		expect(getPureCurrencyInfo(value('USD'), defaultCurrencyMap)).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatNumeralsResult — symbol mode
+// ---------------------------------------------------------------------------
+describe('formatNumeralsResult (symbol mode)', () => {
+	it('pads whole values to conventional decimals: $120 → $120.00', () => {
+		expect(formatNumeralsResult(value('120 USD'), symbolContext())).toBe('$120.00');
+	});
+
+	it('pads single-decimal values: $120.1 → $120.10', () => {
+		expect(formatNumeralsResult(value('120.1 USD'), symbolContext())).toBe('$120.10');
+	});
+
+	it('rounds to conventional decimals: $120.3499 → $120.35', () => {
+		expect(formatNumeralsResult(value('120.3499 USD'), symbolContext())).toBe('$120.35');
+	});
+
+	it('formats GBP division: 100 GBP / 3 → £33.33', () => {
+		expect(formatNumeralsResult(value('100 GBP / 3'), symbolContext())).toBe('£33.33');
+	});
+
+	it('keeps the sign outside the symbol for negatives: -£33.33', () => {
+		expect(formatNumeralsResult(value('-100 GBP / 3'), symbolContext())).toBe('-£33.33');
+	});
+
+	it('uses 0 minor units for JPY with grouping: ¥1234 → ¥1,234', () => {
+		const ctx = symbolContext(getLocaleFormatter('en-US'));
+		expect(formatNumeralsResult(value('1234 JPY'), ctx)).toBe('¥1,234');
+	});
+
+	it('groups large values: 1000000 USD → $1,000,000.00', () => {
+		const ctx = symbolContext(getLocaleFormatter('en-US'));
+		expect(formatNumeralsResult(value('1000000 USD'), ctx)).toBe('$1,000,000.00');
+	});
+
+	it('respects a locale decimal separator: de-DE €120 → €120,00', () => {
+		const ctx = symbolContext(getLocaleFormatter('de-DE'));
+		expect(formatNumeralsResult(value('120 EUR'), ctx)).toBe('€120,00');
+	});
+
+	it('formats tiny values to $0.00', () => {
+		expect(formatNumeralsResult(value('0.0001 USD'), symbolContext())).toBe('$0.00');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatNumeralsResult — code mode
+// ---------------------------------------------------------------------------
+describe('formatNumeralsResult (code mode)', () => {
+	it('renders the ISO code with conventional decimals: 120 USD', () => {
+		expect(formatNumeralsResult(value('120 USD'), codeContext())).toBe('120.00 USD');
+	});
+
+	it('uses 0 minor units for JPY in code mode: 1234 JPY', () => {
+		const ctx = codeContext(getLocaleFormatter('en-US'));
+		expect(formatNumeralsResult(value('1234 JPY'), ctx)).toBe('1,234 JPY');
+	});
+
+	it('groups large values in code mode: 1,000,000.00 USD', () => {
+		const ctx = codeContext(getLocaleFormatter('en-US'));
+		expect(formatNumeralsResult(value('1000000 USD'), ctx)).toBe('1,000,000.00 USD');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Passthrough / non-currency
+// ---------------------------------------------------------------------------
+describe('formatNumeralsResult (non-currency passthrough)', () => {
+	it('leaves compound currency rates on existing formatting: $100/hr', () => {
+		expect(formatNumeralsResult(value('100 USD / hr'), symbolContext())).toBe('100 USD / hr');
+	});
+
+	it('leaves plain numbers unchanged', () => {
+		expect(formatNumeralsResult(120, symbolContext())).toBe('120');
+	});
+
+	it('leaves non-currency units unchanged', () => {
+		expect(formatNumeralsResult(value('3 ft'), symbolContext())).toBe('3 ft');
+	});
+
+	it('formats a valueless currency unit with mathjs defaults', () => {
+		expect(formatNumeralsResult(value('USD'), symbolContext())).toBe('USD');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// hasExplicitFormat override (PR B compatibility)
+// ---------------------------------------------------------------------------
+describe('formatNumeralsResult (hasExplicitFormat)', () => {
+	it('suppresses convention decimals but keeps symbol display', () => {
+		const ctx = makeDisplayContext({
+			numberFormat: { notation: 'fixed', precision: 4 },
+			hasExplicitFormat: true,
+			currencyDisplay: CurrencyResultDisplay.Symbol,
+		});
+		expect(formatNumeralsResult(value('100 USD / 3'), ctx)).toBe('$33.3333');
+	});
+
+	it('suppresses convention decimals in code mode too', () => {
+		const ctx = makeDisplayContext({
+			numberFormat: { notation: 'fixed', precision: 4 },
+			hasExplicitFormat: true,
+			currencyDisplay: CurrencyResultDisplay.CurrencyCode,
+		});
+		expect(formatNumeralsResult(value('100 USD / 3'), ctx)).toBe('33.3333 USD');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatPureCurrencyTeX
+// ---------------------------------------------------------------------------
+describe('formatPureCurrencyTeX', () => {
+	it('builds symbol-mode TeX: \\pound 12.50', () => {
+		expect(formatPureCurrencyTeX(value('12.5 GBP'), symbolContext())).toBe('\\pound 12.50');
+	});
+
+	it('keeps the sign outside the symbol: -\\pound 12.50', () => {
+		expect(formatPureCurrencyTeX(value('-12.5 GBP'), symbolContext())).toBe('-\\pound 12.50');
+	});
+
+	it('builds code-mode TeX: 12.50~\\mathrm{GBP}', () => {
+		expect(formatPureCurrencyTeX(value('12.5 GBP'), codeContext())).toBe('12.50~\\mathrm{GBP}');
+	});
+
+	it('uses no grouping in the numeric part (TeX path constraint)', () => {
+		const ctx = symbolContext(getLocaleFormatter('en-US'));
+		expect(formatPureCurrencyTeX(value('1000000 USD'), ctx)).toBe('\\dollar 1000000.00');
+	});
+
+	it('returns null for non-currency values', () => {
+		expect(formatPureCurrencyTeX(value('3 ft'), symbolContext())).toBeNull();
+	});
+});

--- a/tests/inline.test.ts
+++ b/tests/inline.test.ts
@@ -26,6 +26,8 @@ import {
 } from '../src/numerals.types';
 import { parseInlineExpression } from '../src/inline/inlineParser';
 import { evaluateInlineExpression } from '../src/inline/inlineEvaluator';
+import { CurrencyResultDisplay } from '../src/numerals.types';
+import { makeDisplayContext } from './testHelpers';
 
 // ---------------------------------------------------------------------------
 // Currency setup (mirrors numeralsUtilities.test.ts)
@@ -275,7 +277,7 @@ describe('parseInlineExpression', () => {
 // ---------------------------------------------------------------------------
 describe('evaluateInlineExpression', () => {
 	const emptyScope = new NumeralsScope();
-	const defaultFormat: mathjsFormat = undefined;
+	const defaultFormat = makeDisplayContext();
 	const noPreProcessors: StringReplaceMap[] = [];
 	const crossNoteSettings = {
 		enableCrossNoteReferences: true,
@@ -291,7 +293,7 @@ describe('evaluateInlineExpression', () => {
 
 		it('should evaluate "10 / 3" with fixed format containing "3.333"', () => {
 			const fixedFormat: mathjsFormat = { notation: 'fixed', precision: 4 };
-			const result = evaluateInlineExpression('10 / 3', emptyScope, fixedFormat, noPreProcessors);
+			const result = evaluateInlineExpression('10 / 3', emptyScope, makeDisplayContext({ numberFormat: fixedFormat }), noPreProcessors);
 			expect(result.formatted).toContain('3.333');
 		});
 
@@ -362,16 +364,20 @@ describe('evaluateInlineExpression', () => {
 
 	// --- Currency ------------------------------------------------------------
 	describe('currency', () => {
-		it('should evaluate "$100 * 2" and produce result with "200" and "USD"', () => {
+		it('should evaluate "$100 * 2" to symbol form "$200.00" by default', () => {
 			const result = evaluateInlineExpression('$100 * 2', emptyScope, defaultFormat, preProcessors);
-			expect(result.formatted).toContain('200');
-			expect(result.formatted).toContain('USD');
+			expect(result.formatted).toBe('$200.00');
 		});
 
-		it('should evaluate "€50 + €25" with EUR currency', () => {
+		it('should evaluate "€50 + €25" to symbol form "€75.00"', () => {
 			const result = evaluateInlineExpression('€50 + €25', emptyScope, defaultFormat, preProcessors);
-			expect(result.formatted).toContain('75');
-			expect(result.formatted).toContain('EUR');
+			expect(result.formatted).toBe('€75.00');
+		});
+
+		it('should evaluate "$100 * 2" to code form "200.00 USD" when configured', () => {
+			const codeContext = makeDisplayContext({ currencyDisplay: CurrencyResultDisplay.CurrencyCode });
+			const result = evaluateInlineExpression('$100 * 2', emptyScope, codeContext, preProcessors);
+			expect(result.formatted).toBe('200.00 USD');
 		});
 	});
 
@@ -414,8 +420,7 @@ describe('evaluateInlineExpression', () => {
 				defaultFormat,
 				preProcessors
 			);
-			expect(result.formatted).toContain('20');
-			expect(result.formatted).toContain('USD');
+			expect(result.formatted).toBe('$20.00');
 		});
 	});
 
@@ -447,10 +452,9 @@ describe('evaluateInlineExpression', () => {
 
 	// --- Preprocessing -------------------------------------------------------
 	describe('preprocessing', () => {
-		it('should handle thousands separators: "$1,000 * 2" → contains "2000" and "USD"', () => {
+		it('should handle thousands separators: "$1,000 * 2" → "$2000.00"', () => {
 			const result = evaluateInlineExpression('$1,000 * 2', emptyScope, defaultFormat, preProcessors);
-			expect(result.formatted).toContain('2000');
-			expect(result.formatted).toContain('USD');
+			expect(result.formatted).toBe('$2000.00');
 		});
 
 		it('should return the processed expression used for mathjs evaluation', () => {
@@ -477,18 +481,18 @@ describe('evaluateInlineExpression', () => {
 	describe('number formatting', () => {
 		it('should respect exponential notation format', () => {
 			const expFormat: mathjsFormat = { notation: 'exponential', precision: 3 };
-			const result = evaluateInlineExpression('1234567', emptyScope, expFormat, noPreProcessors);
+			const result = evaluateInlineExpression('1234567', emptyScope, makeDisplayContext({ numberFormat: expFormat }), noPreProcessors);
 			expect(result.formatted).toMatch(/1\.23.*e\+6/);
 		});
 
 		it('should respect engineering notation format', () => {
 			const engFormat: mathjsFormat = { notation: 'engineering', precision: 3 };
-			const result = evaluateInlineExpression('1234567', emptyScope, engFormat, noPreProcessors);
+			const result = evaluateInlineExpression('1234567', emptyScope, makeDisplayContext({ numberFormat: engFormat }), noPreProcessors);
 			expect(result.formatted).toMatch(/1\.23.*e\+6/);
 		});
 
 		it('should use default format when format is undefined', () => {
-			const result = evaluateInlineExpression('2 + 2', emptyScope, undefined, noPreProcessors);
+			const result = evaluateInlineExpression('2 + 2', emptyScope, makeDisplayContext(), noPreProcessors);
 			expect(result.formatted).toBe('4');
 		});
 	});
@@ -499,7 +503,7 @@ describe('evaluateInlineExpression', () => {
 // ---------------------------------------------------------------------------
 describe('evaluateInlineExpression — @prev directive', () => {
 	const emptyScope = new NumeralsScope();
-	const defaultFormat: mathjsFormat = undefined;
+	const defaultFormat = makeDisplayContext();
 	const noPreProcessors: StringReplaceMap[] = [];
 
 	describe('basic @prev usage', () => {
@@ -543,8 +547,7 @@ describe('evaluateInlineExpression — @prev directive', () => {
 			const prevValue = math.evaluate('100 USD');
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 			const result = evaluateInlineExpression('@prev * 1.08', emptyScope, defaultFormat, preProcessors, prevValue);
-			expect(result.formatted).toContain('108');
-			expect(result.formatted).toContain('USD');
+			expect(result.formatted).toBe('$108.00');
 		});
 	});
 
@@ -575,8 +578,7 @@ describe('evaluateInlineExpression — @prev directive', () => {
 
 		it('should work with preprocessors (currency)', () => {
 			const result = evaluateInlineExpression('$50 + @prev', emptyScope, defaultFormat, preProcessors, math.evaluate('50 USD'));
-			expect(result.formatted).toContain('100');
-			expect(result.formatted).toContain('USD');
+			expect(result.formatted).toBe('$100.00');
 		});
 	});
 
@@ -599,7 +601,7 @@ describe('evaluateInlineExpression — @prev directive', () => {
 // ---------------------------------------------------------------------------
 describe('evaluateInlineExpression — note-global extraction', () => {
 	const emptyScope = new NumeralsScope();
-	const defaultFormat: mathjsFormat = undefined;
+	const defaultFormat = makeDisplayContext();
 	const noPreProcessors: StringReplaceMap[] = [];
 
 	describe('$-prefixed assignments are extracted', () => {

--- a/tests/inlinePostProcessor.test.ts
+++ b/tests/inlinePostProcessor.test.ts
@@ -35,6 +35,7 @@ import {
 import { parseInlineExpression } from '../src/inline/inlineParser';
 import { evaluateInlineExpression } from '../src/inline/inlineEvaluator';
 import { createInlineNumeralsPostProcessor } from '../src/inline/inlinePostProcessor';
+import { makeDisplayContext } from './testHelpers';
 
 const mockRegisteredEvents: unknown[] = [];
 
@@ -111,7 +112,7 @@ function simulateInlinePipeline(
 	const { formatted } = evaluateInlineExpression(
 		parsed.expression,
 		scope,
-		undefined,
+		makeDisplayContext(),
 		preProcessors
 	);
 
@@ -171,7 +172,7 @@ describe('inline numerals integration', () => {
 			return createInlineNumeralsPostProcessor(
 				app as any,
 				() => DEFAULT_SETTINGS,
-				() => undefined,
+				() => makeDisplayContext(),
 				() => preProcessors,
 				new Map(),
 			);
@@ -271,7 +272,7 @@ describe('inline numerals integration', () => {
 			});
 			expect(parsed).not.toBeNull();
 			expect(() => {
-				evaluateInlineExpression(parsed!.expression, new NumeralsScope(), undefined, []);
+				evaluateInlineExpression(parsed!.expression, new NumeralsScope(), makeDisplayContext(), []);
 			}).toThrow();
 		});
 	});
@@ -315,7 +316,7 @@ describe('inline post-processor cross-note references', () => {
 		const postProcessor = createInlineNumeralsPostProcessor(
 			app as any,
 			() => DEFAULT_SETTINGS,
-			() => undefined,
+			() => makeDisplayContext(),
 			() => [],
 			new Map(),
 		);
@@ -340,13 +341,13 @@ describe('inline note-global ($) variable chaining', () => {
 
 	describe('globals extracted from inline evaluation', () => {
 		it('should return $x in globals when assigning $x = 10', () => {
-			const result = evaluateInlineExpression('$x = 10', new NumeralsScope(), undefined, []);
+			const result = evaluateInlineExpression('$x = 10', new NumeralsScope(), makeDisplayContext(), []);
 			expect(result.globals.size).toBe(1);
 			expect(result.globals.get('$x')).toBe(10);
 		});
 
 		it('should return no globals for non-$ assignment', () => {
-			const result = evaluateInlineExpression('y = 10', new NumeralsScope(), undefined, []);
+			const result = evaluateInlineExpression('y = 10', new NumeralsScope(), makeDisplayContext(), []);
 			expect(result.globals.size).toBe(0);
 		});
 	});
@@ -357,25 +358,25 @@ describe('inline note-global ($) variable chaining', () => {
 			const scope = new NumeralsScope();
 
 			// First expression defines $apples
-			const r1 = evaluateInlineExpression('$apples = 100', scope, undefined, []);
+			const r1 = evaluateInlineExpression('$apples = 100', scope, makeDisplayContext(), []);
 			// Post-processor would inject globals into shared scope
 			for (const [k, v] of r1.globals) { scope.set(k, v); }
 
 			// Second expression uses $apples
-			const r2 = evaluateInlineExpression('$apples * 2', scope, undefined, []);
+			const r2 = evaluateInlineExpression('$apples * 2', scope, makeDisplayContext(), []);
 			expect(r2.formatted).toBe('200');
 		});
 
 		it('should chain three globals sequentially', () => {
 			const scope = new NumeralsScope();
 
-			const r1 = evaluateInlineExpression('$a = 10', scope, undefined, []);
+			const r1 = evaluateInlineExpression('$a = 10', scope, makeDisplayContext(), []);
 			for (const [k, v] of r1.globals) { scope.set(k, v); }
 
-			const r2 = evaluateInlineExpression('$b = $a * 3', scope, undefined, []);
+			const r2 = evaluateInlineExpression('$b = $a * 3', scope, makeDisplayContext(), []);
 			for (const [k, v] of r2.globals) { scope.set(k, v); }
 
-			const r3 = evaluateInlineExpression('$a + $b', scope, undefined, []);
+			const r3 = evaluateInlineExpression('$a + $b', scope, makeDisplayContext(), []);
 			expect(r3.formatted).toBe('40');
 		});
 	});
@@ -385,7 +386,7 @@ describe('inline note-global ($) variable chaining', () => {
 			const scopeCache = new Map<string, NumeralsScope>();
 			const scope = new NumeralsScope();
 
-			const result = evaluateInlineExpression('$price = 42', scope, undefined, []);
+			const result = evaluateInlineExpression('$price = 42', scope, makeDisplayContext(), []);
 			
 			// Simulate what the post-processor does after evaluation
 			if (result.globals.size > 0) {
@@ -409,8 +410,8 @@ describe('inline note-global ($) variable chaining', () => {
 		it('should support $total = @prev pattern', () => {
 			const scope = new NumeralsScope();
 
-			const r1 = evaluateInlineExpression('100 * 1.2', scope, undefined, []);
-			const r2 = evaluateInlineExpression('$total = @prev * 1.08', scope, undefined, [], r1.raw);
+			const r1 = evaluateInlineExpression('100 * 1.2', scope, makeDisplayContext(), []);
+			const r2 = evaluateInlineExpression('$total = @prev * 1.08', scope, makeDisplayContext(), [], r1.raw);
 			
 			expect(r2.globals.has('$total')).toBe(true);
 			// 100 * 1.2 * 1.08 = 129.6

--- a/tests/numeralsUtilities.test.ts
+++ b/tests/numeralsUtilities.test.ts
@@ -37,10 +37,12 @@ import {
 	NumeralsRenderStyle,
 	NumeralsLayout,
 	NumeralsScope,
+	NumeralsDisplayContext,
 	mathjsFormat,
 	StringReplaceMap,
 	DEFAULT_SETTINGS,
 } from "../src/numerals.types";
+import { makeDisplayContext } from "./testHelpers";
 
 // jest.mock('obsidian-dataview');
 
@@ -887,6 +889,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
     let type: NumeralsRenderStyle;
     let settings: NumeralsSettings;
     let numberFormat: mathjsFormat;
+    let displayContext: NumeralsDisplayContext;
 
     beforeEach(() => {
         el = document.createElement("div");
@@ -939,13 +942,14 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
         type = NumeralsRenderStyle.Plain;
         settings = { ...DEFAULT_SETTINGS };
         numberFormat = getLocaleFormatter();
+        displayContext = makeDisplayContext({ numberFormat });
     });
 
 	const resultSeparator = DEFAULT_SETTINGS.resultSeparator;
 
     it("renders a simple math block correctly", () => {
         source = "1 + 1\n2 * 2";
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 
         const lines = el.querySelectorAll(".numerals-line");
         expect(lines.length).toBe(2);
@@ -955,7 +959,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 
     it("renders a block with emitter lines correctly", () => {
         source = "1 + 1 =>\n2 * 2 =>";
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 
         const emitterLines = el.querySelectorAll(".numerals-emitter");
         expect(emitterLines.length).toBe(2);
@@ -966,7 +970,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
     it("renders a block with insertion directives correctly", () => {
 		metadata = { numerals: "all", result1: 1, result2: 2, result3: 3 };
         source = "@[result1]\n@[result2::2]\n@[result3::4]";
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 
         const insertionLines = el.querySelectorAll(".numerals-line");
         // const children = Array.from(el.children);
@@ -978,16 +982,16 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 
     it("applies preProcessors correctly", () => {
         source = "$100 + $1,000";
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 
         const lines = el.querySelectorAll(".numerals-line");
         expect(lines.length).toBe(1);
-        expect(lines[0].textContent).toContain(`$100 + $1,000${resultSeparator}1,100 USD`);
+        expect(lines[0].textContent).toContain(`$100 + $1,000${resultSeparator}$1,100.00`);
     });
 
     it("handles errors in math expressions gracefully", () => {
         source = "1 +\n2 * 2";
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 
         const errorLine = el.querySelector(".numerals-error-line");
         expect(errorLine).not.toBeNull();
@@ -996,7 +1000,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 
     it("calculates with variables correctly", () => {
         source = "lemons = 20\napples = 10\nfruit = lemons + apples";
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 
         const lines = el.querySelectorAll(".numerals-line");
         expect(lines.length).toBe(3);
@@ -1007,11 +1011,11 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 
 	it('simple math block with currency and emitter with snapshot', () => {
 		source = "amount = 100 USD + $1,000\ntax = 10% * amount =>";
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 		const lines = el.querySelectorAll(".numerals-line");
 		expect(lines.length).toBe(2);
-		expect(lines[0].textContent).toContain(`amount = 100 USD + $1,000${resultSeparator}1,100 USD`);
-		expect(lines[1].textContent).toContain(`tax = 10% * amount${resultSeparator}110 USD`);
+		expect(lines[0].textContent).toContain(`amount = 100 USD + $1,000${resultSeparator}$1,100.00`);
+		expect(lines[1].textContent).toContain(`tax = 10% * amount${resultSeparator}$110.00`);
 
 		expect(el).toMatchSnapshot();
 	});
@@ -1027,7 +1031,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 		tuesday = $20
 		wednesday = $30
 		profit = @total`;
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 		const lines = el.querySelectorAll(".numerals-line");
 		expect(lines.length).toBe(10);	
 		expect(lines[0].textContent).toContain(`# Fruit`);
@@ -1036,10 +1040,10 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 		expect(lines[3].textContent).toContain(`grapes = 10${resultSeparator}10`);
 		expect(lines[4].textContent).toContain(`fruit = @sum${resultSeparator}17`);
 		expect(lines[5].textContent).toContain(`# Money`);
-		expect(lines[6].textContent).toContain(`monday = $10${resultSeparator}10 USD`);
-		expect(lines[7].textContent).toContain(`tuesday = $20${resultSeparator}20 USD`);
-		expect(lines[8].textContent).toContain(`wednesday = $30${resultSeparator}30 USD`);
-		expect(lines[9].textContent).toContain(`profit = @total${resultSeparator}60 USD`);
+		expect(lines[6].textContent).toContain(`monday = $10${resultSeparator}$10.00`);
+		expect(lines[7].textContent).toContain(`tuesday = $20${resultSeparator}$20.00`);
+		expect(lines[8].textContent).toContain(`wednesday = $30${resultSeparator}$30.00`);
+		expect(lines[9].textContent).toContain(`profit = @total${resultSeparator}$60.00`);
 	});
 
     it("renders only result-annotated rows when @hideRows is used", () => {
@@ -1049,7 +1053,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
         2 + 3 =>
         @[$result::5]`;
         
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 
         const lines = el.querySelectorAll(".numerals-line");
         // expect(lines.length).toBe(3); // Only 3 lines should be rendered
@@ -1062,7 +1066,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
         2 + 3 =>
         @[$result::5]`;
         
-        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+        processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 
         const lines = el.querySelectorAll(".numerals-line");
         expect(lines.length).toBe(4); // All 4 lines should be rendered
@@ -1078,7 +1082,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 		distance = 100 m
 		time = distance / speed =>
 		@[time]`;
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});	
 	
@@ -1089,7 +1093,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 		lambda=780.246021 nanometer
 		nu=speedOfLight/lambda
 		pi+1`;
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});		
 	
@@ -1157,26 +1161,26 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 	it('Extended Snapshot 1: Default Settings', () => {
 		source = extendedSource;
 		settings = { ...DEFAULT_SETTINGS };
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});
 
 	it('Extended Snapshot 2: Answer Right', () => {
 		source = extendedSource;
 		settings = { ...DEFAULT_SETTINGS, layoutStyle: NumeralsLayout.AnswerRight };
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});	
 	it('Extended Snapshot 3: Answer Below', () => {
 		source = extendedSource;
 		settings = { ...DEFAULT_SETTINGS, layoutStyle: NumeralsLayout.AnswerBelow };
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});		
 	it('Extended Snapshot 4: Answer Inline', () => {
 		source = extendedSource;
 		settings = { ...DEFAULT_SETTINGS, layoutStyle: NumeralsLayout.AnswerInline };
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});			
 	it('Extended Snapshot 5: Mixed Settings', () => {
@@ -1188,7 +1192,7 @@ describe("numeralsUtilities: processAndRenderNumeralsBlockFromSource end-to-end 
 			layoutStyle: NumeralsLayout.AnswerRight,
 			hideEmitterMarkupInInput: false
 		};
-		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, numberFormat, preProcessors, mockApp);
+		processAndRenderNumeralsBlockFromSource(el, source, ctx, metadata, type, settings, displayContext, preProcessors, mockApp);
 		expect(el).toMatchSnapshot();
 	});		
 });

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -1,5 +1,6 @@
 import { renderError, renderNumeralsBlock } from '../src/numeralsUtilities';
 import { EvaluationResult, ProcessedBlock, RenderContext, NumeralsRenderStyle, NumeralsSettings, numeralsBlockInfo } from '../src/numerals.types';
+import { makeDisplayContext } from './testHelpers';
 import * as math from 'mathjs';
 
 // Mock Obsidian functions before importing renderers
@@ -109,7 +110,7 @@ describe('renderNumeralsBlock', () => {
 		context = {
 			renderStyle: NumeralsRenderStyle.Plain,
 			settings,
-			numberFormat: math.format,
+			displayContext: makeDisplayContext({ numberFormat: math.format }),
 			preProcessors: []
 		};
 	});

--- a/tests/renderers.test.ts
+++ b/tests/renderers.test.ts
@@ -31,13 +31,23 @@ import {
 	LineRenderData,
 	RenderContext,
 	NumeralsRenderStyle,
+	CurrencyResultDisplay,
 	DEFAULT_SETTINGS,
 } from '../src/numerals.types';
 import { expressionToTeX, resultToTeX } from '../src/rendering/texRendering';
 import { getLocaleFormatter } from '../src/numeralsUtilities';
+import { makeDisplayContext } from './testHelpers';
 
 // Mock Obsidian DOM methods
 beforeAll(() => {
+	for (const code of ['USD', 'GBP', 'EUR', 'JPY', 'INR']) {
+		try {
+			math.createUnit(code, { aliases: [code.toLowerCase()] });
+		} catch {
+			/* unit already exists */
+		}
+	}
+
 	Object.defineProperty(HTMLElement.prototype, 'createEl', {
 		value: jest.fn(function (this: HTMLElement, tag, options) {
 			const element = document.createElement(tag);
@@ -82,7 +92,7 @@ describe('Renderer Implementations', () => {
 		context = {
 			renderStyle: NumeralsRenderStyle.Plain,
 			settings: DEFAULT_SETTINGS,
-			numberFormat: getLocaleFormatter(),
+			displayContext: makeDisplayContext({ numberFormat: getLocaleFormatter() }),
 			preProcessors: [],
 		};
 	});
@@ -193,6 +203,49 @@ describe('Renderer Implementations', () => {
 			const totalElement = container.querySelector('.numerals-sum');
 			expect(totalElement).not.toBeNull();
 			expect(totalElement?.textContent).toBe('@total');
+		});
+
+		it('renders pure currency results with the symbol by default', () => {
+			const lineData: LineRenderData = {
+				index: 0, rawInput: '$120.1', processedInput: '120.1 USD',
+				result: math.evaluate('120.1 USD'),
+				isEmpty: false, isEmitter: false, isHidden: false, comment: null,
+			};
+
+			renderer.renderLine(container, lineData, context);
+
+			expect(container.querySelector('.numerals-result')?.textContent).toBe(' → $120.10');
+		});
+
+		it('renders pure currency results with the ISO code when configured', () => {
+			context = {
+				...context,
+				displayContext: makeDisplayContext({
+					numberFormat: getLocaleFormatter(),
+					currencyDisplay: CurrencyResultDisplay.CurrencyCode,
+				}),
+			};
+			const lineData: LineRenderData = {
+				index: 0, rawInput: '$120.1', processedInput: '120.1 USD',
+				result: math.evaluate('120.1 USD'),
+				isEmpty: false, isEmitter: false, isHidden: false, comment: null,
+			};
+
+			renderer.renderLine(container, lineData, context);
+
+			expect(container.querySelector('.numerals-result')?.textContent).toBe(' → 120.10 USD');
+		});
+
+		it('leaves compound currency rates on existing precision', () => {
+			const lineData: LineRenderData = {
+				index: 0, rawInput: '$0.042/floz', processedInput: '0.042 USD / floz',
+				result: math.evaluate('0.042 USD / floz'),
+				isEmpty: false, isEmitter: false, isHidden: false, comment: null,
+			};
+
+			renderer.renderLine(container, lineData, context);
+
+			expect(container.querySelector('.numerals-result')?.textContent).toBe(' → 0.042 USD / floz');
 		});
 	});
 
@@ -319,7 +372,17 @@ describe('Renderer Implementations', () => {
 
 		it('should convert expressions and results using shared TeX helpers', () => {
 			expect(expressionToTeX('sqrt(144)')).toBe('\\sqrt{144}');
-			expect(resultToTeX(math.evaluate('3 ft to inches'), [])).toBe('36~\\mathrm{inches}');
+			expect(resultToTeX(math.evaluate('3 ft to inches'), [], makeDisplayContext())).toBe('36~\\mathrm{inches}');
+		});
+
+		it('renders pure currency results as symbol-mode TeX by default', () => {
+			expect(resultToTeX(math.evaluate('12.5 GBP'), [], makeDisplayContext())).toBe('\\pound 12.50');
+			expect(resultToTeX(math.evaluate('-12.5 GBP'), [], makeDisplayContext())).toBe('-\\pound 12.50');
+		});
+
+		it('renders pure currency results as code-mode TeX when configured', () => {
+			const ctx = makeDisplayContext({ currencyDisplay: CurrencyResultDisplay.CurrencyCode });
+			expect(resultToTeX(math.evaluate('12.5 GBP'), [], ctx)).toBe('12.50~\\mathrm{GBP}');
 		});
 
 		it('should restore the @prev directive in expressionToTeX', () => {

--- a/tests/resultInsertion.test.ts
+++ b/tests/resultInsertion.test.ts
@@ -6,6 +6,15 @@
 import { handleResultInsertions } from '../src/numeralsUtilities';
 import { getLocaleFormatter } from '../src/numeralsUtilities';
 import { App, MarkdownPostProcessorContext, MarkdownView } from 'obsidian';
+import { makeDisplayContext } from './testHelpers';
+import { CurrencyResultDisplay } from '../src/numerals.types';
+import * as math from 'mathjs';
+
+try {
+	math.createUnit('USD', { aliases: ['usd'] });
+} catch {
+	/* unit already exists */
+}
 
 // Mock Obsidian types
 type MockEditor = {
@@ -23,7 +32,7 @@ describe('handleResultInsertions', () => {
 	let mockApp: Partial<App>;
 	let mockCtx: MockContext;
 	let mockEl: HTMLElement;
-	let numberFormat: any;
+	let displayContext: any;
 
 	beforeEach(() => {
 		// Mock editor
@@ -56,7 +65,7 @@ describe('handleResultInsertions', () => {
 		mockEl = document.createElement('div');
 
 		// Number format
-		numberFormat = getLocaleFormatter();
+		displayContext = makeDisplayContext({ numberFormat: getLocaleFormatter() });
 
 		// Clear setTimeout mock
 		jest.useFakeTimers();
@@ -76,7 +85,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -101,7 +110,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -127,7 +136,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -150,7 +159,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -171,7 +180,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -193,7 +202,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -213,7 +222,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -233,7 +242,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -255,7 +264,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -275,7 +284,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -296,7 +305,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -320,7 +329,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -344,7 +353,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -376,7 +385,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -403,7 +412,7 @@ describe('handleResultInsertions', () => {
 		handleResultInsertions(
 			results,
 			insertionLines,
-			numberFormat,
+			displayContext,
 			mockCtx as unknown as MarkdownPostProcessorContext,
 			mockApp as App,
 			mockEl
@@ -415,5 +424,31 @@ describe('handleResultInsertions', () => {
 		expect(mockEditor.setLine).toHaveBeenCalledTimes(2);
 		expect(mockEditor.setLine).toHaveBeenNthCalledWith(1, 1, '@[result1::100]');
 		expect(mockEditor.setLine).toHaveBeenNthCalledWith(2, 3, '@[result3::300]');
+	});
+
+	it('inserts pure currency results in ISO-code form even under symbol display', () => {
+		// Symbol display is the default; insertion must still write the code form.
+		displayContext = makeDisplayContext({
+			numberFormat: getLocaleFormatter(),
+			currencyDisplay: CurrencyResultDisplay.Symbol,
+		});
+		const results = [math.evaluate('120.1 USD')];
+		const insertionLines = [0];
+
+		mockCtx.getSectionInfo.mockReturnValue({ lineStart: 0 });
+		mockEditor.getLine.mockReturnValue('@[total]');
+
+		handleResultInsertions(
+			results,
+			insertionLines,
+			displayContext,
+			mockCtx as unknown as MarkdownPostProcessorContext,
+			mockApp as App,
+			mockEl
+		);
+
+		jest.runAllTimers();
+
+		expect(mockEditor.setLine).toHaveBeenCalledWith(1, '@[total::120.10 USD]');
 	});
 });

--- a/tests/testHelpers.ts
+++ b/tests/testHelpers.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared helpers for constructing a NumeralsDisplayContext in tests.
+ *
+ * Not a test file (no `.test.ts` suffix), so jest imports it without running it.
+ */
+
+import {
+	CurrencyResultDisplay,
+	NumeralsDisplayContext,
+	mathjsFormat,
+} from '../src/numerals.types';
+import { defaultCurrencyMap } from '../src/rendering/displayUtils';
+
+/**
+ * Build a NumeralsDisplayContext for tests.
+ *
+ * Defaults mirror the plugin defaults: no explicit number format, the default
+ * currency map, and symbol currency display.
+ *
+ * @param overrides - Partial fields to override (numberFormat, currencyDisplay, etc.)
+ */
+export function makeDisplayContext(
+	overrides: Partial<NumeralsDisplayContext> = {}
+): NumeralsDisplayContext {
+	return {
+		numberFormat: undefined,
+		currencies: defaultCurrencyMap,
+		currencyDisplay: CurrencyResultDisplay.Symbol,
+		...overrides,
+	};
+}
+
+/** Convenience: a display context using the given number format (symbol display). */
+export function displayContextWithFormat(numberFormat: mathjsFormat): NumeralsDisplayContext {
+	return makeDisplayContext({ numberFormat });
+}

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -15,6 +15,7 @@ import {
 	mathjsFormat,
 	numeralsBlockInfo,
 } from '../src/numerals.types';
+import { makeDisplayContext } from './testHelpers';
 
 describe('Rendering Pipeline Types', () => {
 	describe('ProcessedBlock', () => {
@@ -178,7 +179,7 @@ describe('Rendering Pipeline Types', () => {
 			const context: RenderContext = {
 				renderStyle: NumeralsRenderStyle.Plain,
 				settings: DEFAULT_SETTINGS,
-				numberFormat: undefined,
+				displayContext: makeDisplayContext(),
 				preProcessors: [],
 			};
 
@@ -190,12 +191,12 @@ describe('Rendering Pipeline Types', () => {
 			const context: RenderContext = {
 				renderStyle: NumeralsRenderStyle.TeX,
 				settings: DEFAULT_SETTINGS,
-				numberFormat: { notation: 'fixed' },
+				displayContext: makeDisplayContext({ numberFormat: { notation: 'fixed' } }),
 				preProcessors: [],
 			};
 
 			expect(context.renderStyle).toBe(NumeralsRenderStyle.TeX);
-			expect(context.numberFormat).toHaveProperty('notation', 'fixed');
+			expect(context.displayContext.numberFormat).toHaveProperty('notation', 'fixed');
 		});
 
 		it('should accept valid RenderContext with preProcessors', () => {
@@ -207,7 +208,7 @@ describe('Rendering Pipeline Types', () => {
 			const context: RenderContext = {
 				renderStyle: NumeralsRenderStyle.SyntaxHighlight,
 				settings: DEFAULT_SETTINGS,
-				numberFormat: undefined,
+				displayContext: makeDisplayContext(),
 				preProcessors,
 			};
 


### PR DESCRIPTION
Part of #160; foundation for #75 and #140 (closed by the stacked follow-up PR).

## What this does

Currency results now display the way people write them. `$100/4` renders as **`$25.00`** instead of `25 USD` — across every rendering surface: math blocks (Plain and Syntax Highlight), inline Numerals (Reading mode and Live Preview), and TeX.

- **Symbol restoration**: pure currency results render symbol-first (`$12.50`, `£33.33`, `¥1,234`), mirroring Numerals' input syntax. A new **"Currency result display"** setting toggles between symbol (`$12.50`, the new default) and currency code (`12.50 USD`, the previous behavior).
- **Conventional decimals**: pure currency results are displayed with their currency's conventional minor units, derived via `Intl` (USD/GBP/EUR/INR → 2, JPY → 0; unknown/custom codes fall back to 2). `100 GBP / 3` → `£33.33`, not `33.333333333333336 GBP`.
- **Computation is untouched** — this is display-only. Values keep full precision in scope; no mathjs internals are patched.

## Design

All result→string conversion now flows through a single chokepoint, `formatNumeralsResult(value, NumeralsDisplayContext)` in `src/rendering/displayUtils.ts`, replacing the scattered `math.format` calls in the block renderer, inline evaluator, TeX renderer, and result insertion. The context object (resolved number format + active currency map + display mode) is built once in `main.ts` and threaded through the render pipeline.

Deliberate scope decisions:
- **Compound units are untouched**: `$100/hr` keeps the selected number format — rates often need more precision than money display allows.
- **Result insertion (`@[name::value]`) keeps the ISO-code form** (`1,550.00 USD`) with convention decimals. Inserted text is a storage/data surface (Dataview etc.); the code form keeps round-trips unambiguous.
- The context carries a `hasExplicitFormat` flag so a per-block format directive (follow-up PR) can override the currency convention.

Full design notes in `docs/currency-display-formatting.md`.

## Review hardening

An adversarial review pass verified locale-formatter interaction (de-DE/fr-FR/en-IN separators and grouping), TeX macro composition, insertion round-trips, and threading completeness, and caught two bugs fixed in the second commit: negative amounts mis-rounding at the half-cent boundary (`-2.675` → `-$2.67` instead of `-$2.68`) and lowercase currency aliases (`100 usd`) bypassing currency formatting.

## Testing

- 460 tests passing (31-case `tests/currencyDisplay.test.ts` added, plus renderer/inline/insertion coverage); lint and build clean.
- Snapshot changes were individually verified to be the intended symbol-default change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
