### PR TITLE
fix: standardize inline TeX equation trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 ### Added
-- Per-expression TeX rendering for Inline Numerals via the new `#$:` (result only) and `#=$:` (equation) trigger prefixes, which render with MathJax in both Live Preview and Reading mode. Both prefixes are configurable in settings. (Closes #161)
+- Per-expression TeX rendering for Inline Numerals via the new `#$:` (result only) and `#$=:` (equation) trigger prefixes, which render with MathJax in both Live Preview and Reading mode. Both prefixes are configurable in settings. (Closes #161)
 - Block-level `@format` and `@decimalPlaces` directives for overriding result presentation without changing calculated values. (Closes #75, #140)
 - Currency-standard decimal places by default and optional configured-symbol display for pure currency results, including derived currency values. Currency-code display remains the default. (Closes #160)
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Inline Numerals expressions are ordinary inline code with a trigger prefix:
 | `` `#: 3ft * 4ft` `` | `12 ft^2` | Showing just the answer |
 | `` `#=: 3ft * 4ft` `` | `3 ft * 4 ft = 12 ft^2` | Showing the expression and answer |
 | `` `#$: 3ft * 4ft` `` | 12 ft² typeset with MathJax | A TeX-rendered answer |
-| `` `#=$: 3ft * 4ft` `` | 3 ft · 4 ft = 12 ft² typeset with MathJax | A TeX-rendered equation |
+| `` `#$=: 3ft * 4ft` `` | 3 ft · 4 ft = 12 ft² typeset with MathJax | A TeX-rendered equation |
 
 Inline calculations work in Live Preview and Reading mode. They support the same math engine, number formatting, units, currency symbols, variables, frontmatter, and Dataview values as math blocks.
 
-The `#$:` and `#=$:` triggers render the result (and, in equation mode, the expression) as TeX-style MathJax — the same typesetting used by math blocks — chosen per expression rather than through a global setting. All four trigger prefixes are configurable in the Numerals settings.
+The `#$:` and `#$=:` triggers render the result (and, in equation mode, the expression) as TeX-style MathJax — the same typesetting used by math blocks — chosen per expression rather than through a global setting. All four trigger prefixes are configurable in the Numerals settings.
 
 ### Math Blocks
 

--- a/src/inline/inlineParser.ts
+++ b/src/inline/inlineParser.ts
@@ -47,8 +47,8 @@ export function getActiveInlineTriggers(settings: NumeralsSettings): string[] {
  * Checks whether the text starts with a recognized trigger prefix. Each
  * trigger maps to a rendering mode (result-only or equation) and a render
  * style (plain text or TeX). Triggers are checked longest-first so that a
- * longer trigger that has a shorter trigger as a prefix wins (e.g. "#=$:"
- * before "#=:", "#$:", and "#:").
+ * longer trigger that has a shorter trigger as a prefix wins (e.g. "#=:"
+ * before "#:").
  *
  * Empty triggers are silently ignored to prevent matching all code spans.
  *
@@ -67,7 +67,7 @@ export function parseInlineExpression(
 	if (triggers.texResultTrigger) candidates.push([triggers.texResultTrigger, InlineNumeralsMode.ResultOnly, NumeralsRenderStyle.TeX]);
 	if (triggers.texEquationTrigger) candidates.push([triggers.texEquationTrigger, InlineNumeralsMode.Equation, NumeralsRenderStyle.TeX]);
 
-	// Sort longest-first to avoid prefix conflicts ("#=$:" before "#=:")
+	// Sort longest-first to avoid prefix conflicts ("#=:" before "#:")
 	candidates.sort((a, b) => b[0].length - a[0].length);
 
 	for (const [trigger, mode, renderStyle] of candidates) {

--- a/src/inline/inlineParser.ts
+++ b/src/inline/inlineParser.ts
@@ -47,8 +47,8 @@ export function getActiveInlineTriggers(settings: NumeralsSettings): string[] {
  * Checks whether the text starts with a recognized trigger prefix. Each
  * trigger maps to a rendering mode (result-only or equation) and a render
  * style (plain text or TeX). Triggers are checked longest-first so that a
- * longer trigger that has a shorter trigger as a prefix wins (e.g. "#=:"
- * before "#:").
+ * longer trigger that has a shorter trigger as a prefix wins (e.g. "##"
+ * before "#" for custom triggers).
  *
  * Empty triggers are silently ignored to prevent matching all code spans.
  *
@@ -67,7 +67,7 @@ export function parseInlineExpression(
 	if (triggers.texResultTrigger) candidates.push([triggers.texResultTrigger, InlineNumeralsMode.ResultOnly, NumeralsRenderStyle.TeX]);
 	if (triggers.texEquationTrigger) candidates.push([triggers.texEquationTrigger, InlineNumeralsMode.Equation, NumeralsRenderStyle.TeX]);
 
-	// Sort longest-first to avoid prefix conflicts ("#=:" before "#:")
+	// Sort longest-first to avoid configurable prefix conflicts ("##" before "#")
 	candidates.sort((a, b) => b[0].length - a[0].length);
 
 	for (const [trigger, mode, renderStyle] of candidates) {

--- a/src/inlineSuggestorUtils.ts
+++ b/src/inlineSuggestorUtils.ts
@@ -63,7 +63,7 @@ export function findInlineNumeralsContext(
 	const segments = findInlineCodeSegments(line);
 
 	// Build trigger candidates, filtering out empty triggers.
-	// Sort longest-first to handle prefix conflicts (e.g. '#=:' before '#:').
+	// Sort longest-first to handle configurable prefix conflicts (e.g. '##' before '#').
 	const triggers = listInlineTriggers(triggerSettings).filter(t => t.length > 0);
 	triggers.sort((a, b) => b.length - a.length);
 

--- a/src/inlineSuggestorUtils.ts
+++ b/src/inlineSuggestorUtils.ts
@@ -63,7 +63,7 @@ export function findInlineNumeralsContext(
 	const segments = findInlineCodeSegments(line);
 
 	// Build trigger candidates, filtering out empty triggers.
-	// Sort longest-first to handle prefix conflicts (e.g. '#=$:' before '#=:').
+	// Sort longest-first to handle prefix conflicts (e.g. '#=:' before '#:').
 	const triggers = listInlineTriggers(triggerSettings).filter(t => t.length > 0);
 	triggers.sort((a, b) => b.length - a.length);
 

--- a/src/numerals.types.ts
+++ b/src/numerals.types.ts
@@ -122,7 +122,7 @@ export const DEFAULT_SETTINGS: NumeralsSettings = {
 	inlineResultTrigger:				"#:",
 	inlineEquationTrigger:				"#=:",
 	inlineTexResultTrigger:				"#$:",
-	inlineTexEquationTrigger:			"#=$:",
+	inlineTexEquationTrigger:			"#$=:",
 	inlineEquationSeparator:				" = ",
 	provideInlineSuggestions:			true,
 	// Cross-note reference settings

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -563,11 +563,11 @@ export class NumeralsSettingTab extends PluginSettingTab {
 			.setName('TeX equation trigger') // eslint-disable-line obsidianmd/ui/sentence-case
 			.setDesc(htmlToElements(
 				`Prefix for inline code that renders the expression and result with TeX (MathJax).<br>`
-				+ `Example: <code>#=$: sqrt(2)/2</code> renders as typeset math like <b>√2⁄2 = 0.7071</b><br>`
+				+ `Example: <code>#$=: sqrt(2)/2</code> renders as typeset math like <b>√2⁄2 = 0.7071</b><br>`
 				+ `Must differ from the other trigger prefixes.`
 			))
 			.addText(text => text
-				.setPlaceholder('#=$:')
+				.setPlaceholder('#$=:')
 				.setValue(this.plugin.settings.inlineTexEquationTrigger)
 				.onChange(async (value) => {
 					this.plugin.settings.inlineTexEquationTrigger = value;

--- a/tests/inline.test.ts
+++ b/tests/inline.test.ts
@@ -156,7 +156,7 @@ describe('parseInlineExpression', () => {
 
 	// --- Trigger precedence (critical!) ------------------------------------
 	describe('trigger precedence', () => {
-		it('should check "#=:" before "#:" so "#=: 5*3" is Equation mode', () => {
+		it('should parse "#=: 5*3" as Equation mode', () => {
 			const result = parse('#=: 5*3');
 			expect(result).not.toBeNull();
 			expect(result!.mode).toBe(InlineNumeralsMode.Equation);

--- a/tests/inline.test.ts
+++ b/tests/inline.test.ts
@@ -64,7 +64,7 @@ const DEFAULT_TRIGGERS: InlineTriggerSettings = {
 	resultTrigger: '#:',
 	equationTrigger: '#=:',
 	texResultTrigger: '#$:',
-	texEquationTrigger: '#=$:',
+	texEquationTrigger: '#$=:',
 };
 
 function parse(text: string, triggers: Partial<InlineTriggerSettings> = {}) {
@@ -121,12 +121,16 @@ describe('parseInlineExpression', () => {
 			expect(result!.expression).toBe('3+2');
 		});
 
-		it('should parse TeX equation trigger "#=$: 3+2"', () => {
-			const result = parse('#=$: 3+2');
+		it('should parse TeX equation trigger "#$=: 3+2"', () => {
+			const result = parse('#$=: 3+2');
 			expect(result).not.toBeNull();
 			expect(result!.mode).toBe(InlineNumeralsMode.Equation);
 			expect(result!.renderStyle).toBe(NumeralsRenderStyle.TeX);
 			expect(result!.expression).toBe('3+2');
+		});
+
+		it('should not treat the previous "#=$:" syntax as a default trigger', () => {
+			expect(parse('#=$: 3+2')).toBeNull();
 		});
 
 		it('should return null for unrecognized text', () => {
@@ -171,8 +175,8 @@ describe('parseInlineExpression', () => {
 			expect(result!.expression).toBe('5*3');
 		});
 
-		it('should check "#=$:" before "#=:", "#$:", and "#:" among the four defaults', () => {
-			const result = parse('#=$: 5*3');
+		it('should distinguish "#$=:" as the TeX equation default', () => {
+			const result = parse('#$=: 5*3');
 			expect(result).not.toBeNull();
 			expect(result!.mode).toBe(InlineNumeralsMode.Equation);
 			expect(result!.renderStyle).toBe(NumeralsRenderStyle.TeX);
@@ -258,6 +262,17 @@ describe('parseInlineExpression', () => {
 			expect(texResult!.renderStyle).toBe(NumeralsRenderStyle.TeX);
 			expect(texResult!.expression).toBe('3+2');
 		});
+
+		it('should preserve the previous syntax when explicitly configured', () => {
+			const result = parse('#=$: 3+2', {
+				...allEmpty,
+				texEquationTrigger: '#=$:',
+			});
+			expect(result).not.toBeNull();
+			expect(result!.mode).toBe(InlineNumeralsMode.Equation);
+			expect(result!.renderStyle).toBe(NumeralsRenderStyle.TeX);
+			expect(result!.expression).toBe('3+2');
+		});
 	});
 
 	// --- Empty trigger safety -----------------------------------------------
@@ -289,7 +304,7 @@ describe('parseInlineExpression', () => {
 			expect(parse('#: 3+2', noTex)!.renderStyle).toBe(NumeralsRenderStyle.Plain);
 			// TeX trigger text no longer matches a trigger
 			expect(parse('#$: 3+2', noTex)).toBeNull();
-			expect(parse('#=$: 3+2', noTex)).toBeNull();
+			expect(parse('#$=: 3+2', noTex)).toBeNull();
 		});
 	});
 });

--- a/tests/inlinePostProcessor.test.ts
+++ b/tests/inlinePostProcessor.test.ts
@@ -177,7 +177,7 @@ describe('inline numerals integration', () => {
 	});
 
 	describe('TeX rendering mode', () => {
-		// TeX rendering is chosen per-expression via the `#$:` / `#=$:` triggers,
+		// TeX rendering is chosen per-expression via the `#$:` / `#$=:` triggers,
 		// not a global setting. Uses DEFAULT_SETTINGS trigger prefixes unchanged.
 		function createPostProcessor(preProcessors: StringReplaceMap[] = []) {
 			const app = {
@@ -217,8 +217,8 @@ describe('inline numerals integration', () => {
 			expect(renderMath).toHaveBeenCalledWith('36~\\mathrm{inches}', false);
 		});
 
-		it('renders "#=$:" equation input and result with MathJax in Reading mode', async () => {
-			const code = renderInline('#=$: sqrt(144)');
+		it('renders "#$=:" equation input and result with MathJax in Reading mode', async () => {
+			const code = renderInline('#$=: sqrt(144)');
 			await Promise.resolve();
 
 			expect(code.classList.contains('numerals-inline-tex')).toBe(true);
@@ -254,7 +254,7 @@ describe('inline numerals integration', () => {
 		});
 
 		it('quick-reject still matches when only TeX triggers appear in the document', async () => {
-			const code = renderInline('#=$: 2+3');
+			const code = renderInline('#$=: 2+3');
 			await Promise.resolve();
 
 			expect(code.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:5');
@@ -290,7 +290,7 @@ describe('inline numerals integration', () => {
 				resultTrigger: '#:',
 				equationTrigger: '#=:',
 				texResultTrigger: '#$:',
-				texEquationTrigger: '#=$:',
+				texEquationTrigger: '#$=:',
 			});
 			expect(parsed).not.toBeNull();
 			expect(() => {

--- a/tests/inlinePostProcessor.test.ts
+++ b/tests/inlinePostProcessor.test.ts
@@ -179,7 +179,10 @@ describe('inline numerals integration', () => {
 	describe('TeX rendering mode', () => {
 		// TeX rendering is chosen per-expression via the `#$:` / `#$=:` triggers,
 		// not a global setting. Uses DEFAULT_SETTINGS trigger prefixes unchanged.
-		function createPostProcessor(preProcessors: StringReplaceMap[] = []) {
+		function createPostProcessor(
+			preProcessors: StringReplaceMap[] = [],
+			settings: NumeralsSettings = DEFAULT_SETTINGS,
+		) {
 			const app = {
 				vault: {
 					getAbstractFileByPath: jest.fn(() => null),
@@ -190,19 +193,23 @@ describe('inline numerals integration', () => {
 			};
 			return createInlineNumeralsPostProcessor(
 				app as any,
-				() => DEFAULT_SETTINGS,
+				() => settings,
 				() => testFormatter(preProcessors),
 				() => preProcessors,
 				new Map(),
 			);
 		}
 
-		function renderInline(inlineText: string, preProcessors: StringReplaceMap[] = []): HTMLElement {
+		function renderInline(
+			inlineText: string,
+			preProcessors: StringReplaceMap[] = [],
+			settings: NumeralsSettings = DEFAULT_SETTINGS,
+		): HTMLElement {
 			const container = document.createElement('p');
 			const code = document.createElement('code');
 			code.innerText = inlineText;
 			container.appendChild(code);
-			createPostProcessor(preProcessors)(container, { sourcePath: 'source.md', addChild: jest.fn() } as any);
+			createPostProcessor(preProcessors, settings)(container, { sourcePath: 'source.md', addChild: jest.fn() } as any);
 			return code;
 		}
 
@@ -224,6 +231,21 @@ describe('inline numerals integration', () => {
 			expect(code.classList.contains('numerals-inline-tex')).toBe(true);
 			expect(code.querySelector('.numerals-inline-input .numerals-tex')?.textContent).toBe('TeX:\\sqrt{144}');
 			expect(code.querySelector('.numerals-inline-separator')?.textContent).toBe(' = ');
+			expect(code.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:12');
+			expect(renderMath).toHaveBeenNthCalledWith(1, '\\sqrt{144}', false);
+			expect(renderMath).toHaveBeenNthCalledWith(2, '12', false);
+		});
+
+		it('honors the previous TeX equation syntax when persisted in settings', async () => {
+			const settings = {
+				...DEFAULT_SETTINGS,
+				inlineTexEquationTrigger: '#=$:',
+			};
+			const code = renderInline('#=$: sqrt(144)', [], settings);
+			await Promise.resolve();
+
+			expect(code.classList.contains('numerals-inline-tex')).toBe(true);
+			expect(code.querySelector('.numerals-inline-input .numerals-tex')?.textContent).toBe('TeX:\\sqrt{144}');
 			expect(code.querySelector('.numerals-inline-value .numerals-tex')?.textContent).toBe('TeX:12');
 			expect(renderMath).toHaveBeenNthCalledWith(1, '\\sqrt{144}', false);
 			expect(renderMath).toHaveBeenNthCalledWith(2, '12', false);

--- a/tests/inlineSuggestor.test.ts
+++ b/tests/inlineSuggestor.test.ts
@@ -233,10 +233,15 @@ describe('findInlineNumeralsContext', () => {
 	// --- Trigger precedence ---
 	describe('trigger precedence', () => {
 		it('should match longer trigger first when one is prefix of another', () => {
-			const line = '`#=: 5*3`';
-			const result = find(line, 7);
+			const line = '`## 5*3`';
+			const result = find(line, 6, {
+				resultTrigger: '##',
+				equationTrigger: '',
+				texResultTrigger: '#',
+				texEquationTrigger: '',
+			});
 			expect(result).not.toBeNull();
-			expect(result!.triggerPrefix).toBe('#=:');
+			expect(result!.triggerPrefix).toBe('##');
 		});
 
 		it('should detect "#$=:" among the four defaults', () => {

--- a/tests/inlineSuggestor.test.ts
+++ b/tests/inlineSuggestor.test.ts
@@ -16,7 +16,7 @@ const DEFAULT_TRIGGERS: InlineTriggerSettings = {
 	resultTrigger: '#:',
 	equationTrigger: '#=:',
 	texResultTrigger: '#$:',
-	texEquationTrigger: '#=$:',
+	texEquationTrigger: '#$=:',
 };
 
 function find(line: string, cursorCh: number, triggers: Partial<InlineTriggerSettings> = {}) {
@@ -184,11 +184,11 @@ describe('findInlineNumeralsContext', () => {
 		});
 
 		it('should detect cursor inside a TeX equation span', () => {
-			// `(0)#(1)=(2)$(3):(4) (5)x(6)`(7)
-			const line = '`#=$: x`';
+			// `(0)#(1)$(2)=(3):(4) (5)x(6)`(7)
+			const line = '`#$=: x`';
 			const result = find(line, 6); // cursor at 'x'
 			expect(result).not.toBeNull();
-			expect(result!.triggerPrefix).toBe('#=$:');
+			expect(result!.triggerPrefix).toBe('#$=:');
 			expect(result!.expressionStartCh).toBe(5);
 		});
 	});
@@ -220,6 +220,14 @@ describe('findInlineNumeralsContext', () => {
 			const line = '`anything`';
 			expect(find(line, 5, allEmpty)).toBeNull();
 		});
+
+		it('should preserve the previous syntax when explicitly configured', () => {
+			const line = '`#=$: x`';
+			const result = find(line, 6, { ...allEmpty, texEquationTrigger: '#=$:' });
+			expect(result).not.toBeNull();
+			expect(result!.triggerPrefix).toBe('#=$:');
+			expect(result!.expressionStartCh).toBe(5);
+		});
 	});
 
 	// --- Trigger precedence ---
@@ -231,11 +239,11 @@ describe('findInlineNumeralsContext', () => {
 			expect(result!.triggerPrefix).toBe('#=:');
 		});
 
-		it('should match "#=$:" over "#=:", "#$:", and "#:" among the four defaults', () => {
-			const line = '`#=$: 5*3`';
+		it('should detect "#$=:" among the four defaults', () => {
+			const line = '`#$=: 5*3`';
 			const result = find(line, 7);
 			expect(result).not.toBeNull();
-			expect(result!.triggerPrefix).toBe('#=$:');
+			expect(result!.triggerPrefix).toBe('#$=:');
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- change the default inline TeX equation trigger from `#=$:` to `#$=:` so the TeX marker consistently precedes the equation marker
- update the Numerals settings example and placeholder, README, and Unreleased changelog entry
- update parser, Reading mode, quick-rejection, and autocomplete coverage for the new default
- retain end-to-end coverage showing that `#=$:` still works when a user explicitly configures it

## Compatibility

This corrects an unreleased default introduced by #164. Numerals continues to merge persisted settings over defaults, so existing custom or saved trigger values are not rewritten. New installations, and installations without a persisted TeX equation trigger, receive `#$=:`.

No hidden alias or migration is added: trigger prefixes remain fully user-configurable through the existing parser, Reading mode, Live Preview, and autocomplete pipeline.

## Adversarial review hardening

- persisted `#=$:` configuration is exercised through the Reading-mode MathJax renderer, in addition to parser and autocomplete coverage
- longest-first precedence coverage now uses a real configurable prefix collision
- this branch includes the reviewed #165 and #166 heads

## Validation

- `npm test -- --runInBand`: 20 suites, 536 tests, 8 snapshots
- `npm run lint`
- `npm run build`
- `npx tsc --noEmit`
- `git diff --check`

## Stack

This PR is intentionally based on #166. Merge order is #165, then #166, then this PR; retarget each stacked PR to `master` after its base merges.
